### PR TITLE
Alpha2 release preparations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
         "phpunit/phpunit": "^6.5",
         "webflo/drupal-core-require-dev": "^8.5.0"
     },
+    "conflict": {
+        "apigee/apigee-client-php": "<= 2.0.0-alpha1"
+    },
     "repositories": [
         {
             "type": "composer",
@@ -46,9 +49,6 @@
             "drupal/core": {
                 "(For testing) Drupal core tests actually requires PHPUnit >= 6.5": "https://www.drupal.org/files/issues/2018-04-11/require_phpunit_65-2947888-5.patch",
                 "(For testing) Time Ago summary does not render on Manage Display for Datetime": "https://www.drupal.org/files/issues/2686409-45.patch"
-            },
-            "apigee/apigee-client-php": {
-                "Fix for an OAuth bug": "https://patch-diff.githubusercontent.com/raw/apigee/apigee-client-php/pull/2.patch"
             }
         },
         "installer-paths": {


### PR DESCRIPTION
Tests failed because of some API communication errors but I think what I tried to solve in this PR have been confirmed by them. Always alpha2 installed from the API client lib.

https://travis-ci.org/mxr576/apigee-devportal-drupal/builds/383124237