### PR TITLE
Bump minimum required API client version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "webflo/drupal-core-require-dev": "^8.5"
     },
     "conflict": {
-        "apigee/apigee-client-php": "<= 2.0.0-alpha1"
+        "apigee/apigee-client-php": "< 2.0.0-alpha3"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -40,10 +40,6 @@
             },
             "drupal/key": {
                 "Fix implementation of NoneKeyInput": "https://www.drupal.org/files/issues/2018-06-27/key-fix-implementation-of-nonekeyinput-2982124-2.patch"
-            },
-            "apigee/apigee-client-php": {
-                "OAuth re-authentication fix with expired refresh token and minor changes": "https://github.com/apigee/apigee-client-php/pull/9.diff",
-                "Pagination related changes": "https://github.com/apigee/apigee-client-php/pull/10.diff"
             }
         }
     }


### PR DESCRIPTION
Alpha 3 is out: https://github.com/apigee/apigee-client-php/blob/2.x/CHANGELOG.md#200-alpha3---2018-07-26