### PR TITLE
Improves error handling.

### DIFF
--- a/apigee_edge.routing.yml
+++ b/apigee_edge.routing.yml
@@ -4,8 +4,7 @@ apigee_edge.error_page:
     _controller: '\Drupal\apigee_edge\Controller\ErrorPageController::render'
     _title_callback: '\Drupal\apigee_edge\Controller\ErrorPageController::getPageTitle'
   requirements:
-    _permission: 'access content'
-    _user_is_logged_in: 'TRUE'
+    _access: 'TRUE'
 
 apigee_edge.admin_config_edge:
   path: '/admin/config/apigee-edge'
@@ -86,6 +85,7 @@ apigee_edge.settings.product.caching:
     _title: 'API Product caching'
   requirements:
     _permission: 'administer apigee edge'
+
 apigee_edge.settings.product.access_control:
   path: '/admin/config/apigee-edge/product-settings/access-control'
   defaults:

--- a/apigee_edge.services.yml
+++ b/apigee_edge.services.yml
@@ -26,7 +26,11 @@ services:
 
   apigee_edge.exception_subscriber:
     class: Drupal\apigee_edge\EventSubscriber\EdgeExceptionSubscriber
-    arguments: ['@url_generator']
+    arguments:
+      - '@http_kernel'
+      - '@logger.channel.php'
+      - '@redirect.destination'
+      - '@router.no_access_checks'
     tags:
       - { name: event_subscriber }
 

--- a/src/Controller/DeveloperAppListBuilderForDeveloper.php
+++ b/src/Controller/DeveloperAppListBuilderForDeveloper.php
@@ -19,6 +19,7 @@
 
 namespace Drupal\apigee_edge\Controller;
 
+use Drupal\apigee_edge\Exception\DeveloperDoesNotExistException;
 use Drupal\apigee_edge\Entity\DeveloperAppInterface;
 use Drupal\apigee_edge\Entity\DeveloperStatusCheckTrait;
 use Drupal\apigee_edge\Entity\ListBuilder\DeveloperAppListBuilder;
@@ -95,7 +96,7 @@ class DeveloperAppListBuilderForDeveloper extends DeveloperAppListBuilder {
     // either there is connection error or the site is out of sync with
     // Apigee Edge.
     if ($developerId === NULL) {
-      return [];
+      throw new DeveloperDoesNotExistException($user->getEmail());
     }
 
     $query = $this->storage->getQuery()

--- a/src/Entity/DeveloperStatusCheckTrait.php
+++ b/src/Entity/DeveloperStatusCheckTrait.php
@@ -19,6 +19,7 @@
 
 namespace Drupal\apigee_edge\Entity;
 
+use Drupal\apigee_edge\Exception\DeveloperDoesNotExistException;
 use Drupal\Core\Url;
 use Drupal\user\Entity\User;
 
@@ -43,8 +44,11 @@ trait DeveloperStatusCheckTrait {
 
     $user = User::load($uid);
     /** @var \Drupal\apigee_edge\Entity\DeveloperInterface $developer */
-    $developer = Developer::load($user->getEmail());
-    if (!isset($developer) || $developer->getStatus() === Developer::STATUS_INACTIVE) {
+    if (!($developer = Developer::load($user->getEmail()))) {
+      throw new DeveloperDoesNotExistException($user->getEmail());
+    }
+
+    if ($developer->getStatus() === Developer::STATUS_INACTIVE) {
       // Displays different warning message for admin users.
       $message = $user->id() === \Drupal::currentUser()->id()
         ? t('Your developer account has inactive status so you will not be able to use your credentials until your account is enabled. Please contact the Developer Portal support for further assistance.')

--- a/src/EventSubscriber/EdgeExceptionSubscriber.php
+++ b/src/EventSubscriber/EdgeExceptionSubscriber.php
@@ -20,11 +20,9 @@
 namespace Drupal\apigee_edge\EventSubscriber;
 
 use Apigee\Edge\Exception\ApiException;
-use Drupal\Core\Routing\UrlGeneratorInterface;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
+use Drupal\Core\EventSubscriber\DefaultExceptionHtmlSubscriber;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
-use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
  * Handles uncaught ApiExceptions.
@@ -32,46 +30,24 @@ use Symfony\Component\HttpKernel\KernelEvents;
  * Redirects the user to the Edge error page if an uncaught
  * SDK-level ApiException event appears in the HttpKernel component.
  */
-class EdgeExceptionSubscriber implements EventSubscriberInterface {
-
-  /**
-   * The URL generator.
-   *
-   * @var \Drupal\Core\Routing\UrlGeneratorInterface
-   */
-  protected $urlGenerator;
-
-  /**
-   * Constructs EdgeExceptionSubscriber.
-   *
-   * @param \Drupal\Core\Routing\UrlGeneratorInterface $url_generator
-   *   The URL generator service.
-   */
-  public function __construct(UrlGeneratorInterface $url_generator) {
-    $this->urlGenerator = $url_generator;
-  }
+class EdgeExceptionSubscriber extends DefaultExceptionHtmlSubscriber {
 
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
-    $events[KernelEvents::EXCEPTION][] = 'onException';
-    return $events;
+  protected static function getPriority() {
+    return 1024;
   }
 
   /**
-   * Redirects user to the Edge error page.
-   *
-   * Redirects user to the Edge error page if the
-   * uncaught exception is an instance of ApiException.
+   * Displays the Edge connection error page.
    *
    * @param \Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent $event
    *   The exception event.
    */
   public function onException(GetResponseForExceptionEvent $event) {
     if ($event->getException() instanceof ApiException || $event->getException()->getPrevious() instanceof ApiException) {
-      $url = $this->urlGenerator->generateFromRoute('apigee_edge.error_page');
-      $event->setResponse(new RedirectResponse($url));
+      $this->makeSubrequest($event, '/api-communication-error', Response::HTTP_SERVICE_UNAVAILABLE);
     }
   }
 

--- a/src/Exception/DeveloperDoesNotExistException.php
+++ b/src/Exception/DeveloperDoesNotExistException.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_edge\Exception;
+
+use Apigee\Edge\Exception\ApiException;
+use Throwable;
+
+/**
+ * This exception is thrown when the developer for a user cannot be loaded.
+ */
+class DeveloperDoesNotExistException extends ApiException {
+
+  /**
+   * Email address of the developer that is supposed to exist.
+   *
+   * @var string
+   */
+  protected $email;
+
+  /**
+   * DeveloperDoesNotExistException constructor.
+   *
+   * @param string $email
+   *   Developer email.
+   * @param string $message
+   *   Exception message.
+   * @param int $code
+   *   Error code.
+   * @param \Throwable|null $previous
+   *   Previous exception.
+   */
+  public function __construct(string $email, string $message = 'Developer with @email address not found.', int $code = 0, Throwable $previous = NULL) {
+    $this->email = $email;
+    $message = strtr($message, ['@email' => $email]);
+    parent::__construct($message, $code, $previous);
+  }
+
+}

--- a/src/ParamConverter/DeveloperAppNameConverter.php
+++ b/src/ParamConverter/DeveloperAppNameConverter.php
@@ -20,6 +20,7 @@
 
 namespace Drupal\apigee_edge\ParamConverter;
 
+use Drupal\apigee_edge\Exception\DeveloperDoesNotExistException;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\ParamConverter\ParamConverterInterface;
@@ -103,6 +104,7 @@ class DeveloperAppNameConverter implements ParamConverterInterface {
         // it has existed before because someone knows the URL of the view
         // app page of one of its app.
         $this->logger->critical('%class: Unable to find developer id for %user user.', ['%class' => get_called_class(), '%user' => $user->getDisplayName()]);
+        throw new DeveloperDoesNotExistException($user->getEmail());
       }
     }
 

--- a/tests/src/Functional/ErrorHandlerTest.php
+++ b/tests/src/Functional/ErrorHandlerTest.php
@@ -19,6 +19,9 @@
 
 namespace Drupal\Tests\apigee_edge\Functional;
 
+use Drupal\Core\Url;
+use Symfony\Component\HttpFoundation\Response;
+
 /**
  * Apigee Edge API connection error page tests.
  *
@@ -27,11 +30,36 @@ namespace Drupal\Tests\apigee_edge\Functional;
 class ErrorHandlerTest extends ApigeeEdgeFunctionalTestBase {
 
   /**
-   * Tests connection error page configuration.
+   * User prefix.
    *
-   * @throws \Behat\Mink\Exception\ResponseTextException
+   * @var string
    */
-  public function testErrorPage() {
+  protected $prefix;
+
+  /**
+   * Drupal user.
+   *
+   * @var \Drupal\user\Entity\User
+   */
+  protected $drupalUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->prefix = $this->randomMachineName();
+    _apigee_edge_set_sync_in_progress(TRUE);
+    $this->drupalUser = $this->createAccount([], TRUE, $this->prefix);
+    $this->drupalUser->save();
+    _apigee_edge_set_sync_in_progress(FALSE);
+  }
+
+  /**
+   * Tests connection error page configuration and developer failures.
+   */
+  public function testErrorPages() {
     $this->drupalLogin($this->rootUser);
     $errorPageTitle = $this->getRandomGenerator()->word(16);
     $this->drupalPostForm('/admin/config/apigee-edge/error-page-settings', [
@@ -39,13 +67,26 @@ class ErrorHandlerTest extends ApigeeEdgeFunctionalTestBase {
     ], 'Save configuration');
     $this->assertSession()->pageTextContains('The configuration options have been saved.');
 
-    $paths = [
-      '/exception/entity-storage',
-      '/exception/api',
+    $this->drupalLogin($this->drupalUser);
+    $parameters = [
+      'user' => $this->drupalUser->id(),
+      'app' => 'x',
+    ];
+    $routes = [
+      'apigee_edge_test.entity_storage_exception',
+      'apigee_edge_test.api_exception',
+      'entity.developer_app.collection_by_developer',
+      'entity.developer_app.add_form_for_developer',
+      'entity.developer_app.canonical_by_developer',
+      'entity.developer_app.edit_form_for_developer',
+      'entity.developer_app.delete_form_for_developer',
+      'entity.developer_app.analytics_for_developer',
     ];
 
-    foreach ($paths as $path) {
-      $this->drupalGet($path);
+    foreach ($routes as $route) {
+      $route = Url::fromRoute($route, $parameters);
+      $this->drupalGet($route);
+      $this->assertEquals(Response::HTTP_SERVICE_UNAVAILABLE, $this->getSession()->getStatusCode());
       $this->assertSession()->pageTextContains($errorPageTitle);
     }
   }


### PR DESCRIPTION
* In case of an Edge error, Drupal will not redirect, just shows
  the error page. This gives the same experience as 404 or 403
  errors.
* When the developer cannot be loaded for a given user, an
  exception will be thrown instead of trying to show the page with
  empty data. The thrown exception will be caught by the error
  page handler.