### PR TITLE
Store active authentication key in a config object again

### DIFF
--- a/apigee_edge.install
+++ b/apigee_edge.install
@@ -87,17 +87,6 @@ function apigee_edge_install() {
     ];
     user_role_grant_permissions(RoleInterface::AUTHENTICATED_ID, $authenticated_user_permissions);
   }
-
-  // Set default client configuration.
-  \Drupal::state()->set('apigee_edge.auth', [
-    'active_key' => '',
-    'active_key_oauth_token' => '',
-  ]);
-  \Drupal::state()->set('apigee_edge.client', [
-    'http_client_connect_timeout' => 30,
-    'http_client_timeout' => 30,
-    'http_client_proxy' => '',
-  ]);
 }
 
 /**

--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -1155,12 +1155,12 @@ function apigee_edge_field_ui_field_storage_add_form_submit(array &$form, FormSt
 function apigee_edge_key_delete(EntityInterface $entity) {
   /** @var \Drupal\key\KeyInterface $entity */
   $active_key = \Drupal::configFactory()
-    ->get('apigee_edge.client')
+    ->get('apigee_edge.auth')
     ->get('active_key');
 
   if ($active_key === $entity->id()) {
     \Drupal::configFactory()
-      ->getEditable('apigee_edge.client')
+      ->getEditable('apigee_edge.auth')
       ->set('active_key', '')
       ->set('active_key_oauth_token', '')
       ->save();

--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -1153,13 +1153,17 @@ function apigee_edge_field_ui_field_storage_add_form_submit(array &$form, FormSt
  * Implements hook_key_delete().
  */
 function apigee_edge_key_delete(EntityInterface $entity) {
-  $state = \Drupal::state();
-  if ($state->get('apigee_edge.auth')['active_key'] === $entity->id()) {
-    $state->set('apigee_edge.auth', [
-      'active_key' => '',
-      'active_key_oauth_token' => '',
-    ]);
-    $state->resetCache();
+  /** @var \Drupal\key\KeyInterface $entity */
+  $active_key = \Drupal::configFactory()
+    ->get('apigee_edge.client')
+    ->get('active_key');
+
+  if ($active_key === $entity->id()) {
+    \Drupal::configFactory()
+      ->getEditable('apigee_edge.client')
+      ->set('active_key', '')
+      ->set('active_key_oauth_token', '')
+      ->save();
   }
 }
 

--- a/apigee_edge.services.yml
+++ b/apigee_edge.services.yml
@@ -18,7 +18,7 @@ services:
 
   apigee_edge.sdk_connector:
     class: Drupal\apigee_edge\SDKConnector
-    arguments: ['@http_client_factory', '@key.repository', '@entity_type.manager', '@state', '@module_handler', '@info_parser']
+    arguments: ['@http_client_factory', '@key.repository', '@entity_type.manager', '@config.factory', '@module_handler', '@info_parser']
 
   apigee_edge.job_executor:
     class: Drupal\apigee_edge\JobExecutor

--- a/config/install/apigee_edge.auth.yml
+++ b/config/install/apigee_edge.auth.yml
@@ -1,0 +1,2 @@
+active_key: ''
+active_key_oauth_token: ''

--- a/config/install/apigee_edge.client.yml
+++ b/config/install/apigee_edge.client.yml
@@ -1,0 +1,5 @@
+active_key: ''
+active_key_oauth_token: ''
+http_client_connect_timeout: 30
+http_client_timeout: 30
+http_client_proxy: ''

--- a/config/install/apigee_edge.client.yml
+++ b/config/install/apigee_edge.client.yml
@@ -1,5 +1,3 @@
-active_key: ''
-active_key_oauth_token: ''
 http_client_connect_timeout: 30
 http_client_timeout: 30
 http_client_proxy: ''

--- a/config/schema/apigee_edge.schema.yml
+++ b/config/schema/apigee_edge.schema.yml
@@ -14,13 +14,17 @@ apigee_edge.error_page:
           type: text
           label: 'Error page content'
 
-apigee_edge.client:
+apigee_edge.auth:
   type: config_object
   mapping:
     active_key:
       type: string
     active_key_oauth_token:
       type: string
+
+apigee_edge.client:
+  type: config_object
+  mapping:
     http_client_connect_timeout:
       type: float
     http_client_timeout:

--- a/config/schema/apigee_edge.schema.yml
+++ b/config/schema/apigee_edge.schema.yml
@@ -14,6 +14,20 @@ apigee_edge.error_page:
           type: text
           label: 'Error page content'
 
+apigee_edge.client:
+  type: config_object
+  mapping:
+    active_key:
+      type: string
+    active_key_oauth_token:
+      type: string
+    http_client_connect_timeout:
+      type: float
+    http_client_timeout:
+      type: float
+    http_client_proxy:
+      type: string
+
 apigee_edge.common_app_settings:
   type: config_object
   label: 'Common app settings'

--- a/modules/apigee_edge_debug/apigee_edge_debug.services.yml
+++ b/modules/apigee_edge_debug/apigee_edge_debug.services.yml
@@ -8,7 +8,7 @@ services:
     decorates: apigee_edge.sdk_connector
     decoration_priority: -10
     public: false
-    arguments: ['@apigee_edge_debug.sdk_connector.inner', '@http_client_factory', '@key.repository', '@entity_type.manager', '@state', '@module_handler', '@info_parser']
+    arguments: ['@apigee_edge_debug.sdk_connector.inner', '@http_client_factory', '@key.repository', '@entity_type.manager', '@module_handler', '@info_parser']
 
   plugin.manager.apigee_edge_debug.debug_message_formatter:
     class: Drupal\apigee_edge_debug\DebugMessageFormatterPluginManager

--- a/modules/apigee_edge_debug/apigee_edge_debug.services.yml
+++ b/modules/apigee_edge_debug/apigee_edge_debug.services.yml
@@ -8,7 +8,7 @@ services:
     decorates: apigee_edge.sdk_connector
     decoration_priority: -10
     public: false
-    arguments: ['@apigee_edge_debug.sdk_connector.inner', '@http_client_factory', '@key.repository', '@entity_type.manager', '@module_handler', '@info_parser']
+    arguments: ['@apigee_edge_debug.sdk_connector.inner', '@http_client_factory', '@key.repository', '@entity_type.manager',  '@config.factory', '@module_handler', '@info_parser']
 
   plugin.manager.apigee_edge_debug.debug_message_formatter:
     class: Drupal\apigee_edge_debug\DebugMessageFormatterPluginManager

--- a/modules/apigee_edge_debug/src/SDKConnector.php
+++ b/modules/apigee_edge_debug/src/SDKConnector.php
@@ -22,6 +22,7 @@ namespace Drupal\apigee_edge_debug;
 
 use Drupal\apigee_edge\SDKConnector as OriginalSDKConnector;
 use Drupal\apigee_edge\SDKConnectorInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\InfoParserInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
@@ -61,16 +62,16 @@ class SDKConnector extends OriginalSDKConnector implements SDKConnectorInterface
    *   The key repository.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   Entity type manager service.
-   * @param \Drupal\Core\State\StateInterface $state
-   *   The state key/value store.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   Module handler service.
    * @param \Drupal\Core\Extension\InfoParserInterface $info_parser
    *   Info file parser service.
    */
-  public function __construct(SDKConnectorInterface $inner_service, ClientFactory $client_factory, KeyRepositoryInterface $key_repository, EntityTypeManagerInterface $entity_type_manager, ModuleHandlerInterface $module_handler, InfoParserInterface $info_parser) {
+  public function __construct(SDKConnectorInterface $inner_service, ClientFactory $client_factory, KeyRepositoryInterface $key_repository, EntityTypeManagerInterface $entity_type_manager, ConfigFactoryInterface $config_factory, ModuleHandlerInterface $module_handler, InfoParserInterface $info_parser) {
     $this->innerService = $inner_service;
-    parent::__construct($client_factory, $key_repository, $entity_type_manager, $state, $module_handler, $info_parser);
+    parent::__construct($client_factory, $key_repository, $entity_type_manager, $config_factory, $module_handler, $info_parser);
   }
 
   /**

--- a/modules/apigee_edge_debug/src/SDKConnector.php
+++ b/modules/apigee_edge_debug/src/SDKConnector.php
@@ -26,7 +26,6 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\InfoParserInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Http\ClientFactory;
-use Drupal\Core\State\StateInterface;
 use Drupal\key\KeyRepositoryInterface;
 
 /**
@@ -69,7 +68,7 @@ class SDKConnector extends OriginalSDKConnector implements SDKConnectorInterface
    * @param \Drupal\Core\Extension\InfoParserInterface $info_parser
    *   Info file parser service.
    */
-  public function __construct(SDKConnectorInterface $inner_service, ClientFactory $client_factory, KeyRepositoryInterface $key_repository, EntityTypeManagerInterface $entity_type_manager, StateInterface $state, ModuleHandlerInterface $module_handler, InfoParserInterface $info_parser) {
+  public function __construct(SDKConnectorInterface $inner_service, ClientFactory $client_factory, KeyRepositoryInterface $key_repository, EntityTypeManagerInterface $entity_type_manager, ModuleHandlerInterface $module_handler, InfoParserInterface $info_parser) {
     $this->innerService = $inner_service;
     parent::__construct($client_factory, $key_repository, $entity_type_manager, $state, $module_handler, $info_parser);
   }

--- a/src/Form/AuthenticationForm.php
+++ b/src/Form/AuthenticationForm.php
@@ -107,7 +107,7 @@ class AuthenticationForm extends ConfigFormBase {
    */
   protected function getEditableConfigNames() {
     return [
-      'apigee_edge.client',
+      'apigee_edge.auth',
     ];
   }
 
@@ -115,7 +115,7 @@ class AuthenticationForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $config = $this->config('apigee_edge.client');
+    $config = $this->config('apigee_edge.auth');
     $form = parent::buildForm($form, $form_state);
     $form['#prefix'] = '<div id="apigee-edge-auth-form">';
     $form['#suffix'] = '</div>';
@@ -568,13 +568,13 @@ class AuthenticationForm extends ConfigFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     if ($form_state->getValue('key_type') === 'apigee_edge_basic_auth') {
-      $this->config('apigee_edge.client')
+      $this->config('apigee_edge.auth')
         ->set('active_key', $form_state->getValue('key_basic_auth'))
         ->set('active_key_oauth_token', '')
         ->save();
     }
     elseif ($form_state->getValue('key_type') === 'apigee_edge_oauth') {
-      $this->config('apigee_edge.client')
+      $this->config('apigee_edge.auth')
         ->set('active_key', $form_state->getValue('key_oauth'))
         ->set('active_key_oauth_token', $form_state->getValue('key_oauth_token'))
         ->save();

--- a/src/Form/AuthenticationForm.php
+++ b/src/Form/AuthenticationForm.php
@@ -31,7 +31,6 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\State\StateInterface;
 use Drupal\Core\Url;
 use Drupal\key\KeyInterface;
 use Drupal\key\KeyRepositoryInterface;
@@ -43,13 +42,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Provides a form for saving the Apigee Edge API authentication key.
  */
 class AuthenticationForm extends ConfigFormBase {
-
-  /**
-   * The state key/value store.
-   *
-   * @var \Drupal\Core\State\StateInterface
-   */
-  protected $state;
 
   /**
    * The key repository.
@@ -77,8 +69,6 @@ class AuthenticationForm extends ConfigFormBase {
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The factory for configuration objects.
-   * @param \Drupal\Core\State\StateInterface $state
-   *   The state key/value store.
    * @param \Drupal\key\KeyRepositoryInterface $key_repository
    *   The key repository.
    * @param \Drupal\apigee_edge\SDKConnectorInterface $sdk_connector
@@ -86,9 +76,8 @@ class AuthenticationForm extends ConfigFormBase {
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   Module handler service.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, StateInterface $state, KeyRepositoryInterface $key_repository, SDKConnectorInterface $sdk_connector, ModuleHandlerInterface $module_handler) {
+  public function __construct(ConfigFactoryInterface $config_factory, KeyRepositoryInterface $key_repository, SDKConnectorInterface $sdk_connector, ModuleHandlerInterface $module_handler) {
     parent::__construct($config_factory);
-    $this->state = $state;
     $this->keyRepository = $key_repository;
     $this->sdkConnector = $sdk_connector;
     $this->moduleHandler = $module_handler;
@@ -100,7 +89,6 @@ class AuthenticationForm extends ConfigFormBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('config.factory'),
-      $container->get('state'),
       $container->get('key.repository'),
       $container->get('apigee_edge.sdk_connector'),
       $container->get('module_handler')
@@ -118,14 +106,16 @@ class AuthenticationForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   protected function getEditableConfigNames() {
-    return [];
+    return [
+      'apigee_edge.client',
+    ];
   }
 
   /**
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $keys = $this->state->get('apigee_edge.auth');
+    $config = $this->config('apigee_edge.client');
     $form = parent::buildForm($form, $form_state);
     $form['#prefix'] = '<div id="apigee-edge-auth-form">';
     $form['#suffix'] = '</div>';
@@ -158,7 +148,7 @@ class AuthenticationForm extends ConfigFormBase {
         ':url' => Url::fromRoute('entity.key.edit_form', ['key' => $key_id, 'destination' => 'admin/config/apigee-edge/settings'])->toString(),
       ]);
     }
-    $basic_auth_default_value = array_key_exists($keys['active_key'], $basic_auth_keys) ? $keys['active_key'] : NULL;
+    $basic_auth_default_value = array_key_exists($config->get('active_key'), $basic_auth_keys) ? $config->get('active_key') : NULL;
 
     // Loading OAuth keys.
     $oauth_keys = $this->keyRepository->getKeyNamesAsOptions(['type' => 'apigee_edge_oauth']);
@@ -168,7 +158,7 @@ class AuthenticationForm extends ConfigFormBase {
         ':url' => Url::fromRoute('entity.key.edit_form', ['key' => $key_id, 'destination' => 'admin/config/apigee-edge/settings'])->toString(),
       ]);
     }
-    $oauth_default_value = array_key_exists($keys['active_key'], $oauth_keys) ? $keys['active_key'] : NULL;
+    $oauth_default_value = array_key_exists($config->get('active_key'), $oauth_keys) ? $config->get('active_key') : NULL;
 
     // Loading OAuth token keys.
     $oauth_token_keys = $this->keyRepository->getKeyNamesAsOptions(['type' => 'apigee_edge_oauth_token']);
@@ -178,7 +168,7 @@ class AuthenticationForm extends ConfigFormBase {
         ':url' => Url::fromRoute('entity.key.edit_form', ['key' => $key_id, 'destination' => 'admin/config/apigee-edge/settings'])->toString(),
       ]);
     }
-    $oauth_token_default_value = array_key_exists($keys['active_key_oauth_token'], $oauth_token_keys) ? $keys['active_key_oauth_token'] : NULL;
+    $oauth_token_default_value = array_key_exists($config->get('active_key_oauth_token'), $oauth_token_keys) ? $config->get('active_key_oauth_token') : NULL;
 
     $form['authentication']['key_type'] = [
       '#type' => 'select',
@@ -577,20 +567,18 @@ class AuthenticationForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    $keys = $this->state->get('apigee_edge.auth');
     if ($form_state->getValue('key_type') === 'apigee_edge_basic_auth') {
-      $keys['active_key'] = $form_state->getValue('key_basic_auth');
-      $keys['active_key_oauth_token'] = '';
-      $this->state->set('apigee_edge.auth', $keys);
+      $this->config('apigee_edge.client')
+        ->set('active_key', $form_state->getValue('key_basic_auth'))
+        ->set('active_key_oauth_token', '')
+        ->save();
     }
     elseif ($form_state->getValue('key_type') === 'apigee_edge_oauth') {
-      $keys['active_key'] = $form_state->getValue('key_oauth');
-      $keys['active_key_oauth_token'] = $form_state->getValue('key_oauth_token');
-      $this->state->set('apigee_edge.auth', $keys);
+      $this->config('apigee_edge.client')
+        ->set('active_key', $form_state->getValue('key_oauth'))
+        ->set('active_key_oauth_token', $form_state->getValue('key_oauth_token'))
+        ->save();
     }
-    // Reset state's static cache to correctly display the active key in the
-    // form's key list.
-    $this->state->resetCache();
     parent::submitForm($form, $form_state);
   }
 

--- a/src/Form/AuthenticationForm.php
+++ b/src/Form/AuthenticationForm.php
@@ -439,8 +439,8 @@ class AuthenticationForm extends ConfigFormBase {
           if ($curl_exception->getHandlerContext()['errno'] === CURLE_OPERATION_TIMEDOUT) {
             $suggestion = $this->t('@fail_text The connection timeout threshold (%connect_timeout) or the request timeout (%timeout) is too low or something is wrong with the connection.', [
               '@fail_text' => $fail_text,
-              '%connect_timeout' => $this->state->get('apigee_edge.client')['http_client_connect_timeout'],
-              '%timeout' => $this->state->get('apigee_edge.client')['http_client_timeout'],
+              '%connect_timeout' => $this->configFactory()->get('apigee_edge.client')->get('http_client_connect_timeout'),
+              '%timeout' => $this->configFactory()->get('apigee_edge.client')->get('http_client_timeout'),
             ]);
           }
           // The remote host was not resolved (authorization server).
@@ -484,8 +484,8 @@ class AuthenticationForm extends ConfigFormBase {
           if ($curl_exception->getHandlerContext()['errno'] === CURLE_OPERATION_TIMEDOUT) {
             $suggestion = $this->t('@fail_text The connection timeout threshold (%connect_timeout) or the request timeout (%timeout) is too low or something is wrong with the connection.', [
               '@fail_text' => $fail_text,
-              '%connect_timeout' => $this->state->get('apigee_edge.client')['http_client_connect_timeout'],
-              '%timeout' => $this->state->get('apigee_edge.client')['http_client_timeout'],
+              '%connect_timeout' => $this->configFactory()->get('apigee_edge.client')->get('http_client_connect_timeout'),
+              '%timeout' => $this->configFactory()->get('apigee_edge.client')->get('http_client_timeout'),
             ]);
           }
           // The remote host was not resolved (endpoint).
@@ -556,7 +556,7 @@ class AuthenticationForm extends ConfigFormBase {
       PHP_EOL .
       json_encode($keys, JSON_PRETTY_PRINT) .
       PHP_EOL .
-      json_encode($this->state->get('apigee_edge.client'), JSON_PRETTY_PRINT) .
+      json_encode($this->configFactory()->get('apigee_edge.client')->get(), JSON_PRETTY_PRINT) .
       PHP_EOL .
       $exception_text;
 

--- a/src/Form/AuthenticationForm.php
+++ b/src/Form/AuthenticationForm.php
@@ -439,8 +439,8 @@ class AuthenticationForm extends ConfigFormBase {
           if ($curl_exception->getHandlerContext()['errno'] === CURLE_OPERATION_TIMEDOUT) {
             $suggestion = $this->t('@fail_text The connection timeout threshold (%connect_timeout) or the request timeout (%timeout) is too low or something is wrong with the connection.', [
               '@fail_text' => $fail_text,
-              '%connect_timeout' => $this->configFactory()->get('apigee_edge.client')->get('http_client_connect_timeout'),
-              '%timeout' => $this->configFactory()->get('apigee_edge.client')->get('http_client_timeout'),
+              '%connect_timeout' => $this->config('apigee_edge.client')->get('http_client_connect_timeout'),
+              '%timeout' => $this->config('apigee_edge.client')->get('http_client_timeout'),
             ]);
           }
           // The remote host was not resolved (authorization server).
@@ -484,8 +484,8 @@ class AuthenticationForm extends ConfigFormBase {
           if ($curl_exception->getHandlerContext()['errno'] === CURLE_OPERATION_TIMEDOUT) {
             $suggestion = $this->t('@fail_text The connection timeout threshold (%connect_timeout) or the request timeout (%timeout) is too low or something is wrong with the connection.', [
               '@fail_text' => $fail_text,
-              '%connect_timeout' => $this->configFactory()->get('apigee_edge.client')->get('http_client_connect_timeout'),
-              '%timeout' => $this->configFactory()->get('apigee_edge.client')->get('http_client_timeout'),
+              '%connect_timeout' => $this->config('apigee_edge.client')->get('http_client_connect_timeout'),
+              '%timeout' => $this->config('apigee_edge.client')->get('http_client_timeout'),
             ]);
           }
           // The remote host was not resolved (endpoint).
@@ -556,7 +556,7 @@ class AuthenticationForm extends ConfigFormBase {
       PHP_EOL .
       json_encode($keys, JSON_PRETTY_PRINT) .
       PHP_EOL .
-      json_encode($this->configFactory()->get('apigee_edge.client')->get(), JSON_PRETTY_PRINT) .
+      json_encode($this->config('apigee_edge.client')->get(), JSON_PRETTY_PRINT) .
       PHP_EOL .
       $exception_text;
 

--- a/src/SDKConnector.php
+++ b/src/SDKConnector.php
@@ -135,19 +135,16 @@ class SDKConnector implements SDKConnectorInterface {
    * Allows to override some configuration of the http client built by the
    * factory for the API client.
    *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   Config factory object.
-   *
    * @return array
    *   Associative array of configuration settings.
    *
    * @see http://docs.guzzlephp.org/en/stable/request-options.html
    */
-  protected function getHttpClientConfiguration(ConfigFactoryInterface $config_factory): array {
+  protected function httpClientConfiguration(): array {
     return [
-      'connect_timeout' => $config_factory->get('apigee_edge.client')->get('http_client_connect_timeout'),
-      'timeout' => $config_factory->get('apigee_edge.client')->get('http_client_timeout'),
-      'proxy' => $config_factory->get('apigee_edge.client')->get('http_client_proxy'),
+      'connect_timeout' => $this->configFactory->get('apigee_edge.client')->get('http_client_connect_timeout') ?? 30,
+      'timeout' => $this->configFactory->get('apigee_edge.client')->get('http_client_timeout') ?? 30,
+      'proxy' => $this->configFactory->get('apigee_edge.client')->get('http_client_proxy') ?? '',
     ];
   }
 

--- a/src/SDKConnector.php
+++ b/src/SDKConnector.php
@@ -26,11 +26,11 @@ use Apigee\Edge\HttpClient\Utility\Builder;
 use Drupal\apigee_edge\Exception\KeyNotFoundException;
 use Drupal\apigee_edge\Plugin\EdgeKeyTypeInterface;
 use Drupal\apigee_edge\Plugin\EdgeOauthKeyTypeInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\InfoParserInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Http\ClientFactory;
-use Drupal\Core\State\StateInterface;
 use Drupal\key\KeyInterface;
 use Drupal\key\KeyRepositoryInterface;
 use Http\Adapter\Guzzle6\Client as GuzzleClientAdapter;
@@ -63,11 +63,11 @@ class SDKConnector implements SDKConnectorInterface {
   private static $userAgentPrefix = NULL;
 
   /**
-   * The state key/value store.
+   * The config factory.
    *
-   * @var \Drupal\Core\State\StateInterface
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
    */
-  protected $state;
+  protected $configFactory;
 
   /**
    * The key repository.
@@ -113,18 +113,18 @@ class SDKConnector implements SDKConnectorInterface {
    *   The key repository.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   Entity type manager service.
-   * @param \Drupal\Core\State\StateInterface $state
-   *   The state key/value store.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler
    *   Module handler service.
    * @param \Drupal\Core\Extension\InfoParserInterface $infoParser
    *   Info file parser service.
    */
-  public function __construct(ClientFactory $clientFactory, KeyRepositoryInterface $key_repository, EntityTypeManagerInterface $entity_type_manager, StateInterface $state, ModuleHandlerInterface $moduleHandler, InfoParserInterface $infoParser) {
+  public function __construct(ClientFactory $clientFactory, KeyRepositoryInterface $key_repository, EntityTypeManagerInterface $entity_type_manager, ConfigFactoryInterface $config_factory, ModuleHandlerInterface $moduleHandler, InfoParserInterface $infoParser) {
     $this->clientFactory = $clientFactory;
     $this->entityTypeManager = $entity_type_manager;
     $this->keyRepository = $key_repository;
-    $this->state = $state;
+    $this->configFactory = $config_factory;
     $this->moduleHandler = $moduleHandler;
     $this->infoParser = $infoParser;
   }
@@ -135,17 +135,19 @@ class SDKConnector implements SDKConnectorInterface {
    * Allows to override some configuration of the http client built by the
    * factory for the API client.
    *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   Config factory object.
+   *
    * @return array
    *   Associative array of configuration settings.
    *
    * @see http://docs.guzzlephp.org/en/stable/request-options.html
    */
-  protected function httpClientConfiguration(): array {
-    $config = $this->state->get('apigee_edge.client');
+  protected function getHttpClientConfiguration(ConfigFactoryInterface $config_factory): array {
     return [
-      'connect_timeout' => $config['http_client_connect_timeout'] ?? 30,
-      'timeout' => $config['http_client_timeout'] ?? 30,
-      'proxy' => $config['http_client_proxy'] ?? '',
+      'connect_timeout' => $config_factory->get('apigee_edge.client')->get('http_client_connect_timeout'),
+      'timeout' => $config_factory->get('apigee_edge.client')->get('http_client_timeout'),
+      'proxy' => $config_factory->get('apigee_edge.client')->get('http_client_proxy'),
     ];
   }
 
@@ -197,12 +199,11 @@ class SDKConnector implements SDKConnectorInterface {
    */
   private function getCredentials(): CredentialsInterface {
     if (self::$credentials === NULL) {
-      $keys = $this->state->get('apigee_edge.auth');
-      $key = $this->keyRepository->getKey($keys['active_key']);
+      $key = $this->keyRepository->getKey($this->configFactory->get('apigee_edge.client')->get('active_key'));
       if ($key === NULL) {
         throw new KeyNotFoundException('Apigee Edge API authentication key not found.');
       }
-      $key_token = $this->keyRepository->getKey($keys['active_key_oauth_token']);
+      $key_token = $this->keyRepository->getKey($this->configFactory->get('apigee_edge.client')->get('active_key_oauth_token'));
       self::$credentials = $this->buildCredentials($key, $key_token);
     }
 

--- a/src/SDKConnector.php
+++ b/src/SDKConnector.php
@@ -196,11 +196,11 @@ class SDKConnector implements SDKConnectorInterface {
    */
   private function getCredentials(): CredentialsInterface {
     if (self::$credentials === NULL) {
-      $key = $this->keyRepository->getKey($this->configFactory->get('apigee_edge.client')->get('active_key'));
+      $key = $this->keyRepository->getKey($this->configFactory->get('apigee_edge.auth')->get('active_key'));
       if ($key === NULL) {
         throw new KeyNotFoundException('Apigee Edge API authentication key not found.');
       }
-      $key_token = $this->keyRepository->getKey($this->configFactory->get('apigee_edge.client')->get('active_key_oauth_token'));
+      $key_token = $this->keyRepository->getKey($this->configFactory->get('apigee_edge.auth')->get('active_key_oauth_token'));
       self::$credentials = $this->buildCredentials($key, $key_token);
     }
 

--- a/tests/modules/apigee_edge_test/apigee_edge_test.install
+++ b/tests/modules/apigee_edge_test/apigee_edge_test.install
@@ -33,7 +33,7 @@ function apigee_edge_test_install() {
     ->save();
 
   // Increase timeout of the API client to ensure tests do not fail.
-  $client_config = \Drupal::state()->get('apigee_edge.client');
-  $client_config['http_client_timeout'] = 120;
-  \Drupal::state()->set('apigee_edge.client', $client_config);
+  \Drupal::configFactory()->getEditable('apigee_edge.client')
+    ->set('http_client_timeout', 120)
+    ->save();
 }

--- a/tests/modules/apigee_edge_test/apigee_edge_test.services.yml
+++ b/tests/modules/apigee_edge_test/apigee_edge_test.services.yml
@@ -22,4 +22,4 @@ services:
     decorates: apigee_edge_debug.sdk_connector
     decoration_priority: 0
     public: false
-    arguments: ['@apigee_edge_test.sdk_connector.inner', '@logger.channel.apigee_edge_test', '@http_client_factory', '@key.repository', '@entity_type.manager', '@state', '@module_handler', '@info_parser']
+    arguments: ['@apigee_edge_test.sdk_connector.inner', '@logger.channel.apigee_edge_test', '@http_client_factory', '@key.repository', '@entity_type.manager', '@config.factory', '@module_handler', '@info_parser']

--- a/tests/modules/apigee_edge_test/src/SDKConnector.php
+++ b/tests/modules/apigee_edge_test/src/SDKConnector.php
@@ -25,11 +25,11 @@ use Apigee\Edge\ClientInterface;
 use Apigee\Edge\Exception\ApiResponseException;
 use Drupal\apigee_edge\SDKConnector as OriginalSDKConnector;
 use Drupal\apigee_edge\SDKConnectorInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\InfoParserInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Http\ClientFactory;
-use Drupal\Core\State\StateInterface;
 use Drupal\key\KeyRepositoryInterface;
 use Http\Client\Exception;
 use Http\Message\Authentication;
@@ -68,17 +68,17 @@ class SDKConnector extends OriginalSDKConnector implements SDKConnectorInterface
    *   The key repository.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   Entity type manager service.
-   * @param \Drupal\Core\State\StateInterface $state
-   *   The state key/value store.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler
    *   Module handler service.
    * @param \Drupal\Core\Extension\InfoParserInterface $infoParser
    *   Info file parser service.
    */
-  public function __construct(SDKConnectorInterface $inner_service, LoggerInterface $logger, ClientFactory $clientFactory, KeyRepositoryInterface $key_repository, EntityTypeManagerInterface $entity_type_manager, StateInterface $state, ModuleHandlerInterface $moduleHandler, InfoParserInterface $infoParser) {
+  public function __construct(SDKConnectorInterface $inner_service, LoggerInterface $logger, ClientFactory $clientFactory, KeyRepositoryInterface $key_repository, EntityTypeManagerInterface $entity_type_manager, ConfigFactoryInterface $config_factory, ModuleHandlerInterface $moduleHandler, InfoParserInterface $infoParser) {
     $this->innerService = $inner_service;
     $this->logger = $logger;
-    parent::__construct($clientFactory, $key_repository, $entity_type_manager, $state, $moduleHandler, $infoParser);
+    parent::__construct($clientFactory, $key_repository, $entity_type_manager, $config_factory, $moduleHandler, $infoParser);
   }
 
   /**

--- a/tests/src/Functional/ApigeeEdgeTestTrait.php
+++ b/tests/src/Functional/ApigeeEdgeTestTrait.php
@@ -55,64 +55,21 @@ trait ApigeeEdgeTestTrait {
     catch (EntityStorageException $exception) {
       self::fail('Could not create key for testing.');
     }
-
-    $this->container->get('state')->set('apigee_edge.auth', [
-      'active_key' => 'test',
-      'active_key_oauth_token' => '',
-    ]);
-    $this->container->get('state')->resetCache();
+    $this->config('apigee_edge.client')->set('active_key', 'test')->save();
   }
 
   /**
    * Restores the active key.
    */
   protected function restoreKey() {
-    $this->container->get('state')->set('apigee_edge.auth', [
-      'active_key' => 'test',
-      'active_key_oauth_token' => '',
-    ]);
-    $this->container->get('state')->resetCache();
+    $this->config('apigee_edge.client')->set('active_key', 'test')->save();
   }
 
   /**
    * Removes the active key for testing with unset API credentials.
    */
   protected function invalidateKey() {
-    $this->container->get('state')->set('apigee_edge.auth', [
-      'active_key' => '',
-      'active_key_oauth_token' => '',
-    ]);
-    $this->container->get('state')->resetCache();
-  }
-
-  /**
-   * Set active authentication keys in states.
-   *
-   * @param string $active_key
-   *   The active authentication key.
-   * @param string $active_key_oauth_token
-   *   The active OAuth token key.
-   */
-  protected function setKey(string $active_key, string $active_key_oauth_token) {
-    $this->container->get('state')->set('apigee_edge.auth', [
-      'active_key' => $active_key,
-      'active_key_oauth_token' => $active_key_oauth_token,
-    ]);
-    $this->container->get('state')->resetCache();
-  }
-
-  /**
-   * The corresponding developer will be created if a Drupal user is saved.
-   */
-  protected function enableUserPresave() {
-    _apigee_edge_set_sync_in_progress(FALSE);
-  }
-
-  /**
-   * The corresponding developer will not be created if a Drupal user is saved.
-   */
-  protected function disableUserPresave() {
-    _apigee_edge_set_sync_in_progress(TRUE);
+    $this->config('apigee_edge.client')->set('active_key', '')->save();
   }
 
   /**

--- a/tests/src/Functional/ApigeeEdgeTestTrait.php
+++ b/tests/src/Functional/ApigeeEdgeTestTrait.php
@@ -55,21 +55,56 @@ trait ApigeeEdgeTestTrait {
     catch (EntityStorageException $exception) {
       self::fail('Could not create key for testing.');
     }
-    $this->config('apigee_edge.client')->set('active_key', 'test')->save();
+    $this->restoreKey();
   }
 
   /**
    * Restores the active key.
    */
   protected function restoreKey() {
-    $this->config('apigee_edge.client')->set('active_key', 'test')->save();
+    $this->config('apigee_edge.client')
+      ->set('active_key', 'test')
+      ->set('active_key_oauth_token', '')
+      ->save();
   }
 
   /**
    * Removes the active key for testing with unset API credentials.
    */
   protected function invalidateKey() {
-    $this->config('apigee_edge.client')->set('active_key', '')->save();
+    $this->config('apigee_edge.client')
+      ->set('active_key', '')
+      ->set('active_key_oauth_token', '')
+      ->save();
+  }
+
+  /**
+   * Set active authentication keys in states.
+   *
+   * @param string $active_key
+   *   The active authentication key.
+   * @param string $active_key_oauth_token
+   *   The active OAuth token key.
+   */
+  protected function setKey(string $active_key, string $active_key_oauth_token) {
+    $this->config('apigee_edge.client')
+      ->set('active_key', $active_key)
+      ->set('active_key_oauth_token', $active_key_oauth_token)
+      ->save();
+  }
+
+  /**
+   * The corresponding developer will be created if a Drupal user is saved.
+   */
+  protected function enableUserPresave() {
+    _apigee_edge_set_sync_in_progress(FALSE);
+  }
+
+  /**
+   * The corresponding developer will not be created if a Drupal user is saved.
+   */
+  protected function disableUserPresave() {
+    _apigee_edge_set_sync_in_progress(TRUE);
   }
 
   /**

--- a/tests/src/Functional/ApigeeEdgeTestTrait.php
+++ b/tests/src/Functional/ApigeeEdgeTestTrait.php
@@ -62,7 +62,7 @@ trait ApigeeEdgeTestTrait {
    * Restores the active key.
    */
   protected function restoreKey() {
-    $this->config('apigee_edge.client')
+    $this->config('apigee_edge.auth')
       ->set('active_key', 'test')
       ->set('active_key_oauth_token', '')
       ->save();
@@ -72,14 +72,14 @@ trait ApigeeEdgeTestTrait {
    * Removes the active key for testing with unset API credentials.
    */
   protected function invalidateKey() {
-    $this->config('apigee_edge.client')
+    $this->config('apigee_edge.auth')
       ->set('active_key', '')
       ->set('active_key_oauth_token', '')
       ->save();
   }
 
   /**
-   * Set active authentication keys in states.
+   * Set active authentication keys in config.
    *
    * @param string $active_key
    *   The active authentication key.
@@ -87,7 +87,7 @@ trait ApigeeEdgeTestTrait {
    *   The active OAuth token key.
    */
   protected function setKey(string $active_key, string $active_key_oauth_token) {
-    $this->config('apigee_edge.client')
+    $this->config('apigee_edge.auth')
       ->set('active_key', $active_key)
       ->set('active_key_oauth_token', $active_key_oauth_token)
       ->save();

--- a/tests/src/FunctionalJavascript/ApigeeEdgeFunctionalJavascriptTestBase.php
+++ b/tests/src/FunctionalJavascript/ApigeeEdgeFunctionalJavascriptTestBase.php
@@ -19,7 +19,6 @@
 
 namespace Drupal\Tests\apigee_edge\FunctionalJavascript;
 
-use Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver;
 use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
 use Drupal\Tests\apigee_edge\Functional\ApigeeEdgeTestTrait;
 

--- a/tests/src/FunctionalJavascript/AuthenticationTest.php
+++ b/tests/src/FunctionalJavascript/AuthenticationTest.php
@@ -94,8 +94,8 @@ class AuthenticationTest extends ApigeeEdgeFunctionalJavascriptTestBase {
   public function testAuthentication() {
     // Delete pre-defined test key.
     Key::load('test')->delete();
-    $this->assertEmpty($this->container->get('state')->get('apigee_edge.auth')['active_key']);
-    $this->assertEmpty($this->container->get('state')->get('apigee_edge.auth')['active_key_oauth_token']);
+    $this->assertEmpty($this->config('apigee_edge.auth')->get('active_key'));
+    $this->assertEmpty($this->config('apigee_edge.auth')->get('active_key_oauth_token'));
 
     // Create a key entity using key's default type and provider, then visit
     // authentication form and ensure that there are no available Apigee Edge
@@ -226,8 +226,8 @@ class AuthenticationTest extends ApigeeEdgeFunctionalJavascriptTestBase {
       Key::load($key_id)->delete();
     }
     $this->drupalGet(Url::fromRoute('apigee_edge.settings'));
-    $this->assertEmpty($this->container->get('state')->get('apigee_edge.auth')['active_key']);
-    $this->assertEmpty($this->container->get('state')->get('apigee_edge.auth')['active_key_oauth_token']);
+    $this->assertEmpty($this->config('apigee_edge.auth')->get('active_key'));
+    $this->assertEmpty($this->config('apigee_edge.auth')->get('active_key_oauth_token'));
     $this->assertSession()->pageTextContains(self::NO_AVAILABLE_BASIC_AUTH_KEY);
     $this->getSession()->getPage()->selectFieldOption('edit-key-type', 'apigee_edge_oauth');
     $this->assertSession()->pageTextContains(self::NO_AVAILABLE_OAUTH_KEY);
@@ -350,15 +350,15 @@ class AuthenticationTest extends ApigeeEdgeFunctionalJavascriptTestBase {
     if (empty($message)) {
       $this->assertSession()->pageTextContains('The configuration options have been saved');
       $this->assertSession()->pageTextNotContains(self::DEBUG_INFORMATION_TITLE);
-      $this->assertEquals($this->container->get('state')->get('apigee_edge.auth')['active_key'], $key_id);
-      $this->assertEquals($this->container->get('state')->get('apigee_edge.auth')['active_key_oauth_token'], $key_token_id);
+      $this->assertEquals($this->config('apigee_edge.auth')->get('active_key'), $key_id);
+      $this->assertEquals($this->config('apigee_edge.auth')->get('active_key_oauth_token'), $key_token_id);
       $this->container->get('apigee_edge.sdk_connector')->testConnection();
     }
     else {
       $this->assertSession()->pageTextContains($message);
       $this->assertSession()->pageTextContains(self::DEBUG_INFORMATION_TITLE);
       $this->assertDebugText($key_id);
-      $this->assertNotEquals($this->container->get('state')->get('apigee_edge.auth')['active_key'], $key_id);
+      $this->assertNotEquals($this->config('apigee_edge.auth')->get('active_key'), $key_id);
     }
   }
 


### PR DESCRIPTION
To support active key overrides from settings.php and provide better support to Config split based workflows, ex.: https://github.com/mxr576/apigee_devportal_composer_kickstart/tree/8.6.x-cmi

Related test: https://travis-ci.org/mxr576/apigee-devportal-drupal (skipped "highest" tests because of php-http/client common issue).
