### PR TITLE
Apply latest changes on the PHP API Client since alpha4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,9 @@
             },
             "drupal/key": {
                 "Fix implementation of NoneKeyInput": "https://www.drupal.org/files/issues/2018-06-27/key-fix-implementation-of-nonekeyinput-2982124-2.patch"
+            },
+            "apigee/apigee-client-php": {
+                "Ensure compatibility with latest changes since alpha4": "https://github.com/apigee/apigee-client-php/compare/2.0.0-alpha4...2.x.diff"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "webflo/drupal-core-require-dev": "^8.6"
     },
     "conflict": {
-        "apigee/apigee-client-php": "< 2.0.0-alpha4"
+        "apigee/apigee-client-php": "< 2.0.0-alpha4",
+        "php-http/client-common": ">1.7"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
Also block php-http/client-common:1.8.0.

https://github.com/apigee/apigee-client-php/pull/20

https://travis-ci.org/mxr576/apigee-devportal-drupal/builds/436629756