### PR TITLE
Copy Changes: General settings

### DIFF
--- a/.travis/prepare-test-env.sh
+++ b/.travis/prepare-test-env.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [[ -z "${APIGEE_EDGE_ENDPOINT}" ]] || [[ -z "${APIGEE_EDGE_USERNAME}" ]] || [[ -z "${APIGEE_EDGE_PASSWORD}" ]] || [[ -z "${APIGEE_EDGE_ORGANIZATION}" ]]; then
-  echo "Incomplete configuration. Please make sure the following environment variables exist and not empty: APIGEE_EDGE_ENDPOINT, APIGEE_EDGE_USERNAME, APIGEE_EDGE_PASSWORD, APIGEE_EDGE_ORGANIZATION."
+  echo "Incomplete configuration. Make sure the following environment variables exist and not empty: APIGEE_EDGE_ENDPOINT, APIGEE_EDGE_USERNAME, APIGEE_EDGE_PASSWORD, APIGEE_EDGE_ORGANIZATION."
   exit 1
 fi
 

--- a/.travis/push-logs.sh
+++ b/.travis/push-logs.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [[ -z "${LOGS_REPO_USER}" ]] || [[ -z "${LOGS_REPO_PASSWORD}" ]] || [[ -z "${LOGS_REPO_HOST}" ]] || [[ -z "${LOGS_REPO_NAME}" ]]; then
-  echo "There is at least one missing information about the destination repo. Please make sure the following environment variables exist and not empty: LOGS_REPO_USER, LOGS_REPO_PASSWORD, LOGS_REPO_HOST, LOGS_REPO_NAME."
+  echo "There is at least one missing information about the destination repo. Make sure the following environment variables exist and not empty: LOGS_REPO_USER, LOGS_REPO_PASSWORD, LOGS_REPO_HOST, LOGS_REPO_NAME."
   exit 0
 fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,9 @@ This project follows [Google's Open Source Community Guidelines](https://opensou
 
 # Suggested contributing workflow
 
-## For a start
+## To start
 * Fork this project on Github.
-* If you do not have an Apigee Edge trial organization please create a new one
+* If you do not have an Apigee Edge trial organization, create a new one
 [here](https://login.apigee.com/login).
 * Register on https://travis-ci.org.
 * Open https://travis-ci.org/[YOUR-GITHUB-USERNAME]/apigee-edge-drupal and click
@@ -42,10 +42,12 @@ required environment variables in the [Testing](#testing) section.)
 
 ## For daily work
 * Create a new branch in your fork repository, ex.: patch-1.
-* Add changes to the code. If you implement new features please always add new
-tests to cover the implemented functionality. If you modify existing features please always update related tests if needed.
+* Add changes to the code. If you implement new features, add new
+tests to cover the implemented functionality. If you modify existing features, update related tests.
 * Push your changes to your repo's patch-1 branch.
-* Wait until all Travis CI test jobs finish and _pass_.
+* Wait until all Travis CI test jobs finish and _pass_. (If any of them fails
+restart them once or twice. They may have failed due to an API communication error. You can 
+identify these type of issues from logs.)
 * Create [new pull request](https://github.com/apigee/apigee-edge-drupal/pull/new/8.x-1.x)
 and do not forget to add a link to Travis CI build that can confirm your code is working.
 
@@ -148,7 +150,7 @@ repository URL:
 `https://${LOGS_REPO_USER}:${LOGS_REPO_PASSWORD}@${LOGS_REPO_HOST}/${LOGS_REPO_USER}/${LOGS_REPO_NAME}.git`
 
 ### If your pull request relies on changes that are not yet available in Apigee Edge Client Library for PHP's latest stable release
-Please *temporary* add required changes as patches to module's composer.json.
+You should *temporarily* add required changes as patches to module's composer.json.
 This way this module's tests could pass on Travis CI.
 
 #### Example:

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ module.**
 ### Requirements
 
 * Drupal 8's minimum requirement is phpdocumentor/reflection-docblock:2.0.4 but at least 3.0 is required by this module. If you get the error  "Your requirements could not be resolved to an installable set of packages" it may be because you are running reflection-docblock version 2. You can update `phpdocumentor/reflection-docblock` with the following command: `composer update phpdocumentor/reflection-docblock --with-dependencies`.
-* **Please check [composer.json](https://github.com/apigee/apigee-edge-drupal/blob/8.x-1.x/composer.json) for required patches.** Patches prefixed with "(For testing)" are only required for running tests. Those are not necessary for using this module. Patches can be applied with the [cweagans/composer-patches](https://packagist.org/packages/cweagans/composer-patches) the plugin automatically or manually.
-* (For developers) The locked commit from `behat/mink` library is required otherwise tests may fail. This caused by a Drupal core [bug](https://www.drupal.org/project/drupal/issues/2956279). Please see the related pull request for behat/mink [here](https://github.com/minkphp/Mink/pull/760).
+* **Check [composer.json](https://github.com/apigee/apigee-edge-drupal/blob/8.x-1.x/composer.json) for required patches.** Patches prefixed with "(For testing)" are only required for running tests. Those are not necessary for using this module. Patches can be applied with the [cweagans/composer-patches](https://packagist.org/packages/cweagans/composer-patches) the plugin automatically or manually.
+* (For developers) The locked commit from `behat/mink` library is required otherwise tests may fail. This caused by a Drupal core [bug](https://www.drupal.org/project/drupal/issues/2956279). See the related pull request for behat/mink [here](https://github.com/minkphp/Mink/pull/760).
 
 ### Troubleshooting
 

--- a/apigee_edge.install
+++ b/apigee_edge.install
@@ -57,7 +57,7 @@ function apigee_edge_requirements($phase) {
       $requirements['apigee_edge_connection_error'] = [
         'title' => t('Apigee Edge'),
         'value' => $exception->getMessage(),
-        'description' => t('Cannot connect to Apigee Edge server. You have either given wrong credential details or the Apigee Edge server is unreachable. Visit the <a href=":url">Apigee Edge Configuration</a> page to get more information.', [
+        'description' => t('Cannot connect to Apigee Edge server. You have either given wrong credential details or the Apigee Edge server is unreachable. Visit the <a href=":url">Apigee Edge general settings</a> page to get more information.', [
           ':url' => Url::fromRoute('apigee_edge.settings', ['destination' => 'admin/reports/status'])->toString(),
         ]),
         'severity' => REQUIREMENT_WARNING,

--- a/apigee_edge.links.menu.yml
+++ b/apigee_edge.links.menu.yml
@@ -25,8 +25,8 @@ apigee_edge.app:
   weight: -8
 
 apigee_edge.product:
-  title: 'API Products'
-  description: 'API Product settings.'
+  title: 'API products'
+  description: 'API product settings.'
   parent: system.admin_config_edge
   route_name: apigee_edge.settings.product.alias
   weight: -2

--- a/apigee_edge.links.task.yml
+++ b/apigee_edge.links.task.yml
@@ -5,7 +5,7 @@ apigee_edge.settings:
 
 apigee_edge.settings.connection_config:
   route_name: apigee_edge.settings.connection_config
-  title: 'Connection config'
+  title: 'Connection settings'
   base_route: apigee_edge.settings
 
 apigee_edge.settings.error_page:
@@ -15,7 +15,7 @@ apigee_edge.settings.error_page:
 
 apigee_edge.settings.app:
   route_name: apigee_edge.settings.app
-  title: 'API Product associations'
+  title: 'API product associations'
   base_route: apigee_edge.settings.app
   weight: -10
 

--- a/apigee_edge.routing.yml
+++ b/apigee_edge.routing.yml
@@ -18,7 +18,7 @@ apigee_edge.settings:
   path: '/admin/config/apigee-edge/settings'
   defaults:
     _form: '\Drupal\apigee_edge\Form\AuthenticationForm'
-    _title: 'Apigee Edge Configuration'
+    _title: 'Apigee Edge general settings'
   requirements:
     _permission: 'administer apigee edge'
 
@@ -26,7 +26,7 @@ apigee_edge.settings.connection_config:
   path: '/admin/config/apigee-edge/connection-config'
   defaults:
     _form: '\Drupal\apigee_edge\Form\ConnectionConfigForm'
-    _title: 'Connection Config'
+    _title: 'Connection settings'
   requirements:
     _permission: 'administer apigee edge'
 
@@ -34,7 +34,7 @@ apigee_edge.settings.error_page:
   path: '/admin/config/apigee-edge/error-page-settings'
   defaults:
     _form: '\Drupal\apigee_edge\Form\ErrorPageSettingsForm'
-    _title: 'Error Page Settings'
+    _title: 'Error page settings'
   requirements:
     _permission: 'administer apigee edge'
 
@@ -42,7 +42,7 @@ apigee_edge.settings.developer:
   path: '/admin/config/apigee-edge/developer-settings'
   defaults:
     _form: '\Drupal\apigee_edge\Form\DeveloperSettingsForm'
-    _title: 'Developer Settings'
+    _title: 'Developer settings'
   requirements:
     _permission: 'administer apigee edge'
 
@@ -50,7 +50,7 @@ apigee_edge.settings.developer.attributes:
   path: '/admin/config/apigee-edge/developer-settings/attributes'
   defaults:
     _form: '\Drupal\apigee_edge\Form\DeveloperAttributesSettingsForm'
-    _title: 'Custom Attributes'
+    _title: 'Custom attributes'
   requirements:
     _permission: 'administer apigee edge'
 
@@ -74,7 +74,7 @@ apigee_edge.settings.product.alias:
   path: '/admin/config/apigee-edge/product-settings/alias'
   defaults:
     _form: '\Drupal\apigee_edge\Form\ProductAliasForm'
-    _title: 'API Product Settings'
+    _title: 'API product settings'
   requirements:
     _permission: 'administer apigee edge'
 
@@ -82,7 +82,7 @@ apigee_edge.settings.product.caching:
   path: '/admin/config/apigee-edge/product-settings/caching'
   defaults:
     _form: '\Drupal\apigee_edge\Form\ProductCachingForm'
-    _title: 'API Product caching'
+    _title: 'API product caching'
   requirements:
     _permission: 'administer apigee edge'
 
@@ -90,7 +90,7 @@ apigee_edge.settings.product.access_control:
   path: '/admin/config/apigee-edge/product-settings/access-control'
   defaults:
     _form: '\Drupal\apigee_edge\Form\ProductAccessControlForm'
-    _title: 'API Product access control'
+    _title: 'API product access control'
   requirements:
     _permission: 'administer apigee edge'
 
@@ -98,7 +98,7 @@ apigee_edge.settings.app:
   path: '/admin/config/apigee-edge/app-settings'
   defaults:
     _form: '\Drupal\apigee_edge\Form\AppSettingsForm'
-    _title: 'App Settings'
+    _title: 'App settings'
   requirements:
     _permission: 'administer apigee edge'
 

--- a/config/install/apigee_edge.developer_app_settings.yml
+++ b/config/install/apigee_edge.developer_app_settings.yml
@@ -1,6 +1,6 @@
 langcode: en
-entity_label_singular: ''
-entity_label_plural: ''
+entity_label_singular: 'App'
+entity_label_plural: 'Apps'
 cache_expiration: 900
 credential_lifetime: 0
 locked_base_fields:

--- a/config/install/apigee_edge.error_page.yml
+++ b/config/install/apigee_edge.error_page.yml
@@ -1,5 +1,5 @@
 langcode: en
-error_page_title: 'Connection Error'
+error_page_title: 'Connection error'
 error_page_content:
- value: 'There is a problem with the connection to the API server. Please contact the Developer Portal support for further assistance.'
+ value: 'Cannot reach management server. An administrator should check the configuration of this site.'
  format: 'plain_text'

--- a/css/apigee_edge.admin.css
+++ b/css/apigee_edge.admin.css
@@ -23,15 +23,6 @@
   margin-top: 10px;
 }
 
-.info-circle {
-  border-radius: 50%;
-  color: white;
-  width: 16px;
-  height: 16px;
-  background: #5c5c5b;
-  display: inline-block;
-  text-align: center;
-}
 
 .table--developer-attributes {
   margin-top: 20px;

--- a/modules/apigee_edge_apiproduct_rbac/apigee_edge_apiproduct_rbac.info.yml
+++ b/modules/apigee_edge_apiproduct_rbac/apigee_edge_apiproduct_rbac.info.yml
@@ -1,5 +1,5 @@
-name: "Apigee Edge: API Product RBAC"
-description: Role based access control over view operation on API Products.
+name: "Apigee Edge: API product RBAC"
+description: Role based access control over view operation on API products.
 package: Apigee
 
 type: module

--- a/modules/apigee_edge_apiproduct_rbac/apigee_edge_apiproduct_rbac.module
+++ b/modules/apigee_edge_apiproduct_rbac/apigee_edge_apiproduct_rbac.module
@@ -160,7 +160,7 @@ function apigee_edge_apiproduct_rbac_form_apigee_edge_api_product_access_control
 
   $form['rbac']['api_products'] = [
     '#type' => 'table',
-    '#header' => [t('API Products')],
+    '#header' => [t('API products')],
     '#id' => 'rbac-settings',
     '#attributes' => ['class' => ['rbac-settings', 'js-rbac-settings']],
     '#sticky' => TRUE,
@@ -269,7 +269,7 @@ function apigee_edge_apiproduct_rbac_form_apigee_edge_api_product_access_control
  * Returns a batch for updating RBAC settings on API products.
  *
  * @param array $product_name_display_name_map
- *   Associative array where keys are the names (ids) of API Products and values
+ *   Associative array where keys are the names (ids) of API products and values
  *   are their display names.
  * @param array $product_name_rids_map
  *   Associative array where keys are the API product names (ids) and values
@@ -298,7 +298,7 @@ function _apigee_edge_apiproduct_rbac_batch(array $product_name_display_name_map
       ],
     ],
     'finished' => '\Drupal\apigee_edge_apiproduct_rbac\RoleBasedAccessSettingsBatch::batchFinishedCallback',
-    'title' => t('Updating @attribute attribute on API Products...', ['@attribute' => $attr_name]),
+    'title' => t('Updating @attribute attribute on API products...', ['@attribute' => $attr_name]),
     // We use a single multi-pass operation, so the default
     // 'Remaining x of y operations' message will be confusing here.
     'progress_message' => '',

--- a/modules/apigee_edge_apiproduct_rbac/src/RoleBasedAccessSettingsBatch.php
+++ b/modules/apigee_edge_apiproduct_rbac/src/RoleBasedAccessSettingsBatch.php
@@ -34,7 +34,7 @@ final class RoleBasedAccessSettingsBatch {
    * Batch operation callback.
    *
    * @param array $product_name_display_name_map
-   *   Associative array where keys are the names (ids) of API Products and
+   *   Associative array where keys are the names (ids) of API products and
    *   values are their display names.
    * @param array $product_name_rids_map
    *   Associative array where keys are the API product names (ids) and values
@@ -56,7 +56,7 @@ final class RoleBasedAccessSettingsBatch {
       $context['sandbox']['max'] = count($product_name_display_name_map);
     }
 
-    // Process API Products by groups of 5.
+    // Process API products by groups of 5.
     /** @var \Drupal\apigee_edge\Entity\Storage\ApiProductStorageInterface $storage */
     $storage = \Drupal::entityTypeManager()->getStorage('api_product');
     /** @var \Apigee\Edge\Api\Management\Controller\ApiProductControllerInterface $controller */
@@ -118,7 +118,7 @@ final class RoleBasedAccessSettingsBatch {
     $failed = $results['failed'] ?? [];
 
     if ($success && !empty($updated) && empty($failed)) {
-      \Drupal::messenger()->addStatus(t('All API product attributes have been updated successfully'));
+      \Drupal::messenger()->addStatus(t('All API product attributes have been updated successfully.'));
     }
     elseif (!empty($updated) || !empty($failed)) {
       if (!empty($updated)) {
@@ -126,7 +126,7 @@ final class RoleBasedAccessSettingsBatch {
           '#theme' => 'item_list',
           '#items' => $updated,
         ];
-        $message = \Drupal::translation()->formatPlural(count($updated), '@product API product successfully updated.', '@count API Products successfully updated: @products',
+        $message = \Drupal::translation()->formatPlural(count($updated), '@product API product successfully updated.', '@count API products successfully updated: @products.',
           [
             '@product' => reset($updated),
             '@products' => \Drupal::service('renderer')->render($items),
@@ -140,7 +140,7 @@ final class RoleBasedAccessSettingsBatch {
           '#theme' => 'item_list',
           '#items' => $failed,
         ];
-        $message = \Drupal::translation()->formatPlural(count($failed), 'An API product failed failed: @product.', '@count API Products could not be updated: @products',
+        $message = \Drupal::translation()->formatPlural(count($failed), 'An API product failed failed: @product.', '@count API products could not be updated: @products.',
           [
             '@product' => reset($failed),
             '@products' => \Drupal::service('renderer')->render($items),

--- a/src/Entity/DeveloperStatusCheckTrait.php
+++ b/src/Entity/DeveloperStatusCheckTrait.php
@@ -51,7 +51,7 @@ trait DeveloperStatusCheckTrait {
     if ($developer->getStatus() === Developer::STATUS_INACTIVE) {
       // Displays different warning message for admin users.
       $message = $user->id() === \Drupal::currentUser()->id()
-        ? t('Your developer account has inactive status so you will not be able to use your credentials until your account is enabled. Please contact the Developer Portal support for further assistance.')
+        ? t('Your developer account has inactive status so you will not be able to use your credentials until your account is enabled. Please contact support for further assistance.')
         : t('The developer account of <a href=":url">@username</a> has inactive status so this user has invalid credentials until the account is enabled.', [
           ':url' => Url::fromRoute('entity.user.edit_form', ['user' => $uid])->toString(),
           '@username' => $user->getAccountName(),

--- a/src/Form/AppSettingsForm.php
+++ b/src/Form/AppSettingsForm.php
@@ -95,7 +95,7 @@ class AppSettingsForm extends ConfigFormBase {
 
     // Someone has overridden the default setting.
     if (!$generalConfig->get('multiple_products')) {
-      $this->messenger()->addWarning($this->t('Access to multiple API Products will be retained until an app is edited and the developer is prompted to confirm a single API Product selection.'));
+      $this->messenger()->addWarning($this->t('Access to multiple API products will be retained until an app is edited and the developer is prompted to confirm a single API product selection.'));
     }
 
     /** @var string[] $default_products */

--- a/src/Form/DeveloperSyncForm.php
+++ b/src/Form/DeveloperSyncForm.php
@@ -85,17 +85,27 @@ class DeveloperSyncForm extends FormBase {
       '#open' => TRUE,
     ];
 
-    $output = '<p>' . $this->t('Developer synchronization will:') . '<p>';
-    $output .= '<ol>';
-    $output .= '<li>' . $this->t('Create Drupal users for any Apigee Edge developers that are in this Drupal system') . '</li>';
-    $output .= '<li>' . $this->t('Create developers in Apigee Edge for all users in this Drupal system that are not already in Apigee Edge') . '</li>';
-    $output .= '</ol>';
-    $output .= '<p>' . $this->t('Note that any Drupal users that are created will have a random password generated and will need to reset their password to log in. The "Run Developer Sync" button will sync the developers, displaying a progress bar on the screen while running. The "Background Developer Sync" button will run the developer sync process in batches each time <a href=":cron_url">cron</a> runs and may take multiple cron runs to complete.', [':cron_url' => Url::fromRoute('system.cron_settings')->toString()]) . '</p>';
-
-    $form['sync']['description']['#markup'] = $output;
+    $form['sync']['description'] = [
+      '#type' => 'container',
+      'p1' => [
+        '#type' => 'markup',
+        '#markup' => '<p>' . $this->t('Developer synchronization will:') . '</p>',
+      ],
+      'list' => [
+        '#theme' => 'item_list',
+        '#items' => [
+          'Create Drupal users for any Apigee Edge developers that are in this Drupal system',
+          'Create developers in Apigee Edge for all users in this Drupal system that are not already in Apigee Edge',
+        ],
+      ],
+      'p2' => [
+        '#type' => 'markup',
+        '#markup' => '<p>' . $this->t('Note that any Drupal users that are created will have a random password generated and will need to reset their password to log in. The "Run developer sync" button will sync the developers, displaying a progress bar on the screen while running. The "Background developer sync" button will run the developer sync process in batches each time <a href=":cron_url">cron</a> runs and may take multiple cron runs to complete.', [':cron_url' => Url::fromRoute('system.cron_settings')->toString()]) . '</p>',
+      ],
+    ];
 
     $form['sync']['sync_submit'] = [
-      '#title' => $this->t('Run Developer Sync'),
+      '#title' => $this->t('Run developer sync'),
       '#type' => 'link',
       '#url' => $this->buildUrl('apigee_edge.developer_sync.run'),
       '#attributes' => [
@@ -106,7 +116,7 @@ class DeveloperSyncForm extends FormBase {
       ],
     ];
     $form['sync']['background_sync_submit'] = [
-      '#title' => $this->t('Background Developer Sync'),
+      '#title' => $this->t('Background developer sync'),
       '#type' => 'link',
       '#url' => $this->buildUrl('apigee_edge.developer_sync.schedule'),
       '#attributes' => [

--- a/src/Form/DeveloperSyncForm.php
+++ b/src/Form/DeveloperSyncForm.php
@@ -95,8 +95,8 @@ class DeveloperSyncForm extends FormBase {
       'list' => [
         '#theme' => 'item_list',
         '#items' => [
-          'Create Drupal users for any Apigee Edge developers that are in this Drupal system',
-          'Create developers in Apigee Edge for all users in this Drupal system that are not already in Apigee Edge',
+          $this->t('Create Drupal users for any Apigee Edge developers that are in this Drupal system'),
+          $this->t('Create developers in Apigee Edge for all users in this Drupal system that are not already in Apigee Edge'),
         ],
       ],
       'p2' => [

--- a/src/Form/DeveloperSyncForm.php
+++ b/src/Form/DeveloperSyncForm.php
@@ -88,8 +88,9 @@ class DeveloperSyncForm extends FormBase {
     $form['sync']['description'] = [
       '#type' => 'container',
       'p1' => [
-        '#type' => 'markup',
-        '#markup' => '<p>' . $this->t('Developer synchronization will:') . '</p>',
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('Developer synchronization will:'),
       ],
       'list' => [
         '#theme' => 'item_list',
@@ -99,8 +100,9 @@ class DeveloperSyncForm extends FormBase {
         ],
       ],
       'p2' => [
-        '#type' => 'markup',
-        '#markup' => '<p>' . $this->t('Note that any Drupal users that are created will have a random password generated and will need to reset their password to log in. The "Run developer sync" button will sync the developers, displaying a progress bar on the screen while running. The "Background developer sync" button will run the developer sync process in batches each time <a href=":cron_url">cron</a> runs and may take multiple cron runs to complete.', [':cron_url' => Url::fromRoute('system.cron_settings')->toString()]) . '</p>',
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('Note that any Drupal users that are created will have a random password generated and will need to reset their password to log in. The "Run developer sync" button will sync the developers, displaying a progress bar on the screen while running. The "Background developer sync" button will run the developer sync process in batches each time <a href=":cron_url">cron</a> runs and may take multiple cron runs to complete.', [':cron_url' => Url::fromRoute('system.cron_settings')->toString()]),
       ],
     ];
 

--- a/src/Form/DeveloperSyncForm.php
+++ b/src/Form/DeveloperSyncForm.php
@@ -84,8 +84,18 @@ class DeveloperSyncForm extends FormBase {
       '#title' => $this->t('Synchronize developers'),
       '#open' => TRUE,
     ];
+
+    $output = '<p>' . $this->t('Developer synchronization will:') . '<p>';
+    $output .= '<ol>';
+    $output .= '<li>' . $this->t('Create Drupal users for any Apigee Edge developers that are in this Drupal system') . '</li>';
+    $output .= '<li>' . $this->t('Create developers in Apigee Edge for all users in this Drupal system that are not already in Apigee Edge') . '</li>';
+    $output .= '</ol>';
+    $output .= '<p>' . $this->t('Note that any Drupal users that are created will have a random password generated and will need to reset their password to log in. The "Run Developer Sync" button will sync the developers, displaying a progress bar on the screen while running. The "Background Developer Sync" button will run the developer sync process in batches each time <a href=":cron_url">cron</a> runs and may take multiple cron runs to complete.', [':cron_url' => Url::fromRoute('system.cron_settings')->toString()]) . '</p>';
+
+    $form['sync']['description']['#markup'] = $output;
+
     $form['sync']['sync_submit'] = [
-      '#title' => $this->t('Now'),
+      '#title' => $this->t('Run Developer Sync'),
       '#type' => 'link',
       '#url' => $this->buildUrl('apigee_edge.developer_sync.run'),
       '#attributes' => [
@@ -96,22 +106,13 @@ class DeveloperSyncForm extends FormBase {
       ],
     ];
     $form['sync']['background_sync_submit'] = [
-      '#title' => $this->t('Background'),
+      '#title' => $this->t('Background Developer Sync'),
       '#type' => 'link',
       '#url' => $this->buildUrl('apigee_edge.developer_sync.schedule'),
       '#attributes' => [
         'class' => [
           'button',
         ],
-      ],
-    ];
-    $form['sync']['sync_info'] = [
-      '#type' => 'html_tag',
-      '#tag' => 'span',
-      '#value' => '?',
-      '#attributes' => [
-        'class' => 'info-circle',
-        'title' => $this->t('A background sync is recommended for large numbers of developers.'),
       ],
     ];
 

--- a/src/Form/ErrorPageSettingsForm.php
+++ b/src/Form/ErrorPageSettingsForm.php
@@ -51,7 +51,7 @@ class ErrorPageSettingsForm extends ConfigFormBase {
 
     $form['error_page'] = [
       '#type' => 'fieldset',
-      '#title' => $this->t('The displayed title and content on the error page.'),
+      '#title' => $this->t('Title and content displayed on error page'),
       '#collapsible' => FALSE,
     ];
 

--- a/src/Form/ProductAccessControlForm.php
+++ b/src/Form/ProductAccessControlForm.php
@@ -86,7 +86,7 @@ class ProductAccessControlForm extends ConfigFormBase {
     $form['access'] = [
       '#type' => 'details',
       '#title' => $this->t('Access by visibility'),
-      '#description' => $this->t('Limit access to API Products by "Access" settings on Apigee Edge.'),
+      '#description' => $this->t('Limit access to API products by "Access" settings on Apigee Edge.'),
       '#open' => TRUE,
       '#tree' => TRUE,
     ];

--- a/src/Plugin/KeyInput/BasicAuthKeyInput.php
+++ b/src/Plugin/KeyInput/BasicAuthKeyInput.php
@@ -49,7 +49,7 @@ class BasicAuthKeyInput extends KeyInputBase {
     $form['organization'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Organization'),
-      '#description' => $this->t('Name of the organization on Apigee Edge. Changing this value could make your site stop working.'),
+      '#description' => $this->t('Name of the Apigee Edge organization. Changing this value could make your site stop working.'),
       '#required' => $key->getKeyType()->getPluginDefinition()['multivalue']['fields']['organization']['required'],
       '#default_value' => $values['organization'],
       '#attributes' => ['autocomplete' => 'off'],
@@ -72,7 +72,7 @@ class BasicAuthKeyInput extends KeyInputBase {
     $form['endpoint'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Apigee Edge endpoint'),
-      '#description' => $this->t('Apigee Edge endpoint where the API calls are being sent. Leave empty to use the default %endpoint endpoint.', [
+      '#description' => $this->t('Apigee Edge endpoint where the API calls are being sent. Leave empty to use the public cloud endpoint %endpoint.', [
         '%endpoint' => ClientInterface::DEFAULT_ENDPOINT,
       ]),
       '#required' => $key->getKeyType()->getPluginDefinition()['multivalue']['fields']['endpoint']['required'],

--- a/src/Plugin/KeyProvider/PrivateFileKeyProvider.php
+++ b/src/Plugin/KeyProvider/PrivateFileKeyProvider.php
@@ -35,7 +35,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @KeyProvider(
  *   id = "apigee_edge_private_file",
  *   label = @Translation("Apigee Edge: Private File"),
- *   description = @Translation("Stores Apigee Edge authentication credentials in a private file.<p><strong>Warning! </strong>Private file storage is suitable only for testing environments. In production environments, use the <em>Apigee Edge: Environment Variables</em> key provider.</p>"),
+ *   description = @Translation("Stores Apigee Edge authentication credentials in a private file.</p>"),
  *   storage_method = "apigee_edge",
  *   key_value = {
  *     "accepted" = TRUE,

--- a/tests/src/Functional/ConfigurationPermissionTest.php
+++ b/tests/src/Functional/ConfigurationPermissionTest.php
@@ -101,8 +101,8 @@ class ConfigurationPermissionTest extends ApigeeEdgeFunctionalTestBase {
         $visit_path($data['path']);
         if ($route === 'apigee_edge.settings.developer.sync') {
           if ($access) {
-            list($schedule_path, $schedule_query) = $this->findLink('Background');
-            list($run_path, $run_query) = $this->findLink('Now');
+            list($schedule_path, $schedule_query) = $this->findLink('Background developer sync');
+            list($run_path, $run_query) = $this->findLink('Run developer sync');
             $visit_path($schedule_path, $schedule_query);
             $visit_path($run_path, $run_query);
           }

--- a/tests/src/Functional/DeveloperAppUITest.php
+++ b/tests/src/Functional/DeveloperAppUITest.php
@@ -156,7 +156,7 @@ class DeveloperAppUITest extends ApigeeEdgeFunctionalTestBase {
       'id_verification' => $name,
     ], 'Delete');
 
-    $this->assertSession()->pageTextContains("The {$name} developer app has been deleted.");
+    $this->assertSession()->pageTextContains("The {$name} app has been deleted.");
     $apps = array_filter($this->getApps(), function (DeveloperApp $app) use ($name): bool {
       return $app->getName() === $name;
     });
@@ -513,7 +513,7 @@ class DeveloperAppUITest extends ApigeeEdgeFunctionalTestBase {
     $this->drupalPostForm($app_edit_url, ['callbackUrl[0][value]' => 'http://example.com'], 'Save');
     $this->assertSession()->pageTextContains("Callback URL field is not in the right format.");
     $this->drupalPostForm($app_edit_url, ['callbackUrl[0][value]' => 'https://example.com'], 'Save');
-    $this->assertSession()->pageTextContains('Developer App details have been successfully updated.');
+    $this->assertSession()->pageTextContains('App details have been successfully updated.');
     $this->assertSession()->pageTextContains('https://example.com');
   }
 

--- a/tests/src/Functional/DeveloperAppUITest.php
+++ b/tests/src/Functional/DeveloperAppUITest.php
@@ -430,7 +430,7 @@ class DeveloperAppUITest extends ApigeeEdgeFunctionalTestBase {
     $controller->setStatus($this->account->getEmail(), Developer::STATUS_INACTIVE);
 
     $this->drupalGet("/user/{$this->account->id()}/apps");
-    $this->assertSession()->pageTextContains('Your developer account has inactive status so you will not be able to use your credentials until your account is enabled. Please contact the Developer Portal support for further assistance.');
+    $this->assertSession()->pageTextContains('Your developer account has inactive status so you will not be able to use your credentials until your account is enabled. Please contact support for further assistance.');
 
     $this->drupalLogin($this->rootUser);
     $this->drupalGet("/user/{$this->account->id()}/apps");
@@ -441,7 +441,7 @@ class DeveloperAppUITest extends ApigeeEdgeFunctionalTestBase {
    * Ensures warning messages are visible if multiple products/app is disabled.
    */
   public function testWarningMessagesIfMultipleProductsDisabled() {
-    $admin_warning_message = 'Access to multiple API Products will be retained until an app is edited and the developer is prompted to confirm a single API Product selection.';
+    $admin_warning_message = 'Access to multiple API products will be retained until an app is edited and the developer is prompted to confirm a single API Product selection.';
     $end_user_warning_message = 'Foos status now require selection of a single Bar; multiple Bar selection is no longer supported. Confirm your Bar selection below.';
     $app_settings_url = Url::fromRoute('apigee_edge.settings.app');
 

--- a/tests/src/Functional/DeveloperAppUITestTrait.php
+++ b/tests/src/Functional/DeveloperAppUITestTrait.php
@@ -118,7 +118,7 @@ trait DeveloperAppUITestTrait {
           'user' => $account->id(),
         ]),
       $data,
-      'Add developer app'
+      'Add app'
     );
   }
 

--- a/tests/src/Functional/DeveloperSyncTest.php
+++ b/tests/src/Functional/DeveloperSyncTest.php
@@ -549,7 +549,7 @@ class DeveloperSyncTest extends ApigeeEdgeFunctionalTestBase {
    */
   public function testDeveloperSync() {
     $this->drupalGet(Url::fromRoute('apigee_edge.settings.developer.sync'));
-    $this->clickLinkProperly('Now');
+    $this->clickLinkProperly('Run developer sync');
     $this->assertSession()->pageTextContains('Apigee Edge developers are in sync with Drupal users.');
     $this->verify();
   }

--- a/tests/src/Functional/StatusReportTest.php
+++ b/tests/src/Functional/StatusReportTest.php
@@ -38,7 +38,7 @@ class StatusReportTest extends ApigeeEdgeFunctionalTestBase {
 
   const CANNOT_CONNECT_SHORT = 'Cannot connect to Apigee Edge server.';
 
-  const CANNOT_CONNECT_LONG = 'Cannot connect to Apigee Edge server. You have either given wrong credential details or the Apigee Edge server is unreachable. Visit the Apigee Edge Configuration page to get more information.';
+  const CANNOT_CONNECT_LONG = 'Cannot connect to Apigee Edge server. You have either given wrong credential details or the Apigee Edge server is unreachable. Visit the Apigee Edge general settings page to get more information.';
 
   const CANNOT_CONNECT_MALFORMED = 'Cannot connect to Apigee Edge server. Check the settings and the requirements of the active key\'s provider. Visit the Key Configuration page to get more information.';
 

--- a/tests/src/FunctionalJavascript/DeveloperAppUITest.php
+++ b/tests/src/FunctionalJavascript/DeveloperAppUITest.php
@@ -106,7 +106,7 @@ class DeveloperAppUITest extends ApigeeEdgeFunctionalJavascriptTestBase {
     $checkValidationMessage('Please match the requested format.');
     $this->assertEquals($pattern_error_message, $this->getSession()->evaluateScript('document.getElementById("edit-callbackurl-0-value").title'));
     $this->drupalPostForm($app_edit_url, ['callbackUrl[0][value]' => 'https://example.com'], 'Save');
-    $this->assertSession()->pageTextContains('Developer App details have been successfully updated.');
+    $this->assertSession()->pageTextContains('App details have been successfully updated.');
     $this->assertSession()->pageTextContains('https://example.com');
   }
 


### PR DESCRIPTION
* Copy changes to general settings
* Change default name of “developer apps” to “apps”
* “Apigee Edge” should not be shortened to “Edge”
* Remove custom styling of developer sync page, change to match cron form
* Removed “please” from copy
* Page titles/menus should only have first work capitalized