### PR TITLE
Bump minimum required version from Drupal core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=7.1",
         "apigee/apigee-client-php": "^2.0",
         "cweagans/composer-patches": "^1.6.5",
-        "drupal/core": "^8.6",
+        "drupal/core": "^8.6.3",
         "drupal/entity": "^1.0",
         "drupal/key": "^1.7",
         "php-http/guzzle6-adapter": "^1.1.1"
@@ -34,9 +34,6 @@
             }
         },
         "patches": {
-            "drupal/core": {
-                "(For testing) Time Ago summary does not render on Manage Display for Datetime": "https://www.drupal.org/files/issues/2018-08-06/2686409-61.patch"
-            },
             "drupal/key": {
                 "Fix implementation of NoneKeyInput": "https://www.drupal.org/files/issues/2018-06-27/key-fix-implementation-of-nonekeyinput-2982124-2.patch"
             }


### PR DESCRIPTION
Because 8.6.3 finally contains the fix for the removed patch.

https://github.com/drupal/core/commit/8084912350e4d996db7653c1235d2e2cb1c7b32e

Because of that patches could not be applied on Drupal core in the highest builds: https://travis-ci.org/mxr576/apigee-devportal-drupal/jobs/452941809#L737

Proof: https://travis-ci.org/mxr576/apigee-devportal-drupal/builds/454080659