### PR TITLE
Remove unnecessary conflict with an older alpha release of the PHP API Client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,6 @@
         "phpunit/phpunit": "^6.5",
         "webflo/drupal-core-require-dev": "^8.6"
     },
-    "conflict": {
-        "apigee/apigee-client-php": "<2.0.0-alpha6"
-    },
     "config": {
         "sort-packages": true
     },


### PR DESCRIPTION
2.0.0 has been released from the PHP API client:
https://github.com/apigee/apigee-client-php/releases/tag/2.0.0

https://travis-ci.org/mxr576/apigee-devportal-drupal/builds/460272777