### PR TITLE
Licence information fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "drupal/apigee_edge",
-    "license": "GPL-2.0",
+    "license": "GPL-2.0-or-later",
     "type": "drupal-module",
     "description": "Apigee Edge for Drupal.",
     "require": {
@@ -19,9 +19,6 @@
         "egulias/email-validator": "1.2.14",
         "phpunit/phpunit": "^6.5",
         "webflo/drupal-core-require-dev": "^8.6"
-    },
-    "conflict": {
-        "apigee/apigee-client-php": "<2.0.0-alpha6"
     },
     "config": {
         "sort-packages": true

--- a/modules/apigee_edge_apiproduct_rbac/composer.json
+++ b/modules/apigee_edge_apiproduct_rbac/composer.json
@@ -2,7 +2,7 @@
     "name": "drupal/apigee_edge_apiproduct_rbac",
     "description": "Role based access control for API products.",
     "type": "drupal-module",
-    "license": "GPL-2.0",
+    "license": "GPL-2.0-or-later",
     "require": {
         "php": ">=7.1",
         "drupal/apigee_edge": "*"

--- a/modules/apigee_edge_debug/composer.json
+++ b/modules/apigee_edge_debug/composer.json
@@ -2,7 +2,7 @@
     "name": "drupal/apigee_edge_debug",
     "description": "Debug helper Apigee Edge Drupal integration.",
     "type": "drupal-module",
-    "license": "GPL-2.0",
+    "license": "GPL-2.0-or-later",
     "require": {
         "php": ">=7.1",
         "drupal/apigee_edge": "*",


### PR DESCRIPTION
```sh
$ composer validate
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
License "GPL-2.0" is a deprecated SPDX license identifier, use "GPL-2.0-or-later" instead
The package "behat/mink" is pointing to a commit-ref, this is bad practice and can cause unforeseen issues.
```

Drupal core also uses the same license: https://github.com/drupal/core/blob/8.6.x/composer.json#L5