### PR TITLE
[DRUP-388] Store the private file key in the `.apigee_edge` folder.

### DIFF
--- a/src/Plugin/KeyProvider/PrivateFileKeyProvider.php
+++ b/src/Plugin/KeyProvider/PrivateFileKeyProvider.php
@@ -144,7 +144,7 @@ class PrivateFileKeyProvider extends KeyProviderBase implements KeyPluginFormInt
    *   The file URI.
    */
   protected function getFileUri(KeyInterface $key): string {
-    return "private://{$key->id()}_apigee_edge.json";
+    return "private://.apigee_edge/{$key->id()}.json";
   }
 
 }

--- a/tests/src/Kernel/Form/AuthenticationFormTest.php
+++ b/tests/src/Kernel/Form/AuthenticationFormTest.php
@@ -92,7 +92,11 @@ class AuthenticationFormTest extends KernelTestBase {
     $active_key = Key::load($this->config(AuthenticationForm::CONFIG_NAME)->get('active_key'));
     static::assertSame($active_key->id(), $form_state->getFormObject()->getEntity()->id());
 
-    $decoded = Json::decode($active_key->getKeyValue());
+    $key_value = $active_key->getKeyValue();
+    $decoded = Json::decode($key_value);
+
+    // Get the key contents directly from the file (location test).
+    static::assertSame($key_value, file_get_contents("private://.apigee_edge/{$active_key->id()}.json"));
 
     static::assertSame(EdgeKeyTypeInterface::EDGE_AUTH_TYPE_BASIC, $form['connection_settings']['auth_type']['#value']);
     static::assertEmpty($form['connection_settings']['organization']['#value']);

--- a/tests/src/Kernel/OauthTokenStorageTest.php
+++ b/tests/src/Kernel/OauthTokenStorageTest.php
@@ -174,7 +174,7 @@ class OauthTokenStorageTest extends KernelTestBase {
   /**
    * Test that the tokens are removed when cacke is cleared.
    */
-  public function testFileLocationSetings() {
+  public function testFileLocationSettings() {
     $this->config(AuthenticationForm::CONFIG_NAME)
       ->set('oauth_token_storage_location', 'private://.apigee_edge_custom')
       ->save();


### PR DESCRIPTION
This is a bug because the `\Drupal\apigee_edge\Form\AuthenticationForm::generateNewAuthKey()` is checking the `private://.apigee_edge/{$new_key_id}.json` for a good storage location.