### PR TITLE
DRUP-547 Add warning to user and team removal

### DIFF
--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -1162,6 +1162,50 @@ function apigee_edge_user_cancel(array $edit, UserInterface $account, $method) {
 }
 
 /**
+ * Implements hook_user_cancel_methods_alter().
+ */
+function apigee_edge_user_cancel_methods_alter(&$methods) {
+  // Transform available keys to replacements that could be passed to t().
+  $get_replacements = function (array $method_info): array {
+    $replacements = [];
+    array_walk($method_info, function ($value, $key) use (&$replacements) {
+      $replacements["@{$key}"] = $value;
+    });
+
+    return $replacements;
+  };
+
+  // Returns extra information for a method that we would like to display.
+  // "title" is what a user with "administer users" permission can see,
+  // "description" is for regular authenticated users by default.
+  $get_extra_info = function (string $key, $replacements): ?array {
+    $extra_infos = [
+      'user_cancel_block' => [
+        'title' => t("@title Account's credentials will be invalid until this account gets re-activated.", $replacements),
+        'description' => t('@description <strong>All your credentials will be invalid until your account is blocked.</strong>', $replacements),
+      ],
+      'user_cancel_delete' => [
+        'title' => t("@title <strong>All apps and credentials owned by this account will be deleted from Apigee Edge.</strong>", $replacements),
+        'description' => t('@description <strong>All your apps and credentials will be also deleted permanently.</strong>', $replacements),
+      ],
+    ];
+
+    // The same warning should be displayed in these cancellation methods.
+    $extra_infos['user_cancel_block_unpublish'] = $extra_infos['user_cancel_block'];
+    $extra_infos['user_cancel_reassign'] = $extra_infos['user_cancel_delete'];
+
+    return $extra_infos[$key] ?? NULL;
+  };
+
+  foreach ($methods as $method => $info) {
+    $extra_info = $get_extra_info($method, $get_replacements($info));
+    if ($extra_info) {
+      $methods[$method] = array_merge($methods[$method], $extra_info);
+    }
+  }
+}
+
+/**
  * Implements hook_user_delete().
  */
 function apigee_edge_user_delete(UserInterface $account) {

--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -1181,12 +1181,12 @@ function apigee_edge_user_cancel_methods_alter(&$methods) {
   $get_extra_info = function (string $key, $replacements): ?array {
     $extra_infos = [
       'user_cancel_block' => [
-        'title' => t("@title Account's credentials will be invalid until this account gets re-activated.", $replacements),
-        'description' => t('@description <strong>All your credentials will be invalid until your account is blocked.</strong>', $replacements),
+        'title' => t("@title Account's API credentials will be invalid until this account gets re-activated.", $replacements),
+        'description' => t('@description <strong>Your API credentials will be invalid until your account is unblocked.</strong>', $replacements),
       ],
       'user_cancel_delete' => [
-        'title' => t("@title <strong>All apps and credentials owned by this account will be deleted from Apigee Edge.</strong>", $replacements),
-        'description' => t('@description <strong>All your apps and credentials will be also deleted permanently.</strong>', $replacements),
+        'title' => t("@title <strong>All API apps and API credentials owned by this account will be deleted from Apigee Edge.</strong>", $replacements),
+        'description' => t('@description <strong>Your API apps and API credentials will be deleted permanently.</strong>', $replacements),
       ],
     ];
 

--- a/modules/apigee_edge_teams/src/Entity/Form/TeamDeleteForm.php
+++ b/modules/apigee_edge_teams/src/Entity/Form/TeamDeleteForm.php
@@ -50,6 +50,18 @@ class TeamDeleteForm extends EdgeEntityDeleteForm {
   /**
    * {@inheritdoc}
    */
+  public function getDescription() {
+    $original = parent::getDescription();
+
+    return $this->t('<strong>All apps, credentials and @team membership information will be deleted.</strong> @original', [
+      '@original' => $original,
+      '@team' => $this->entityTypeManager->getDefinition($this->entity->getEntityTypeId())->getLowercaseLabel(),
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getCancelUrl() {
     return $this->getRedirectUrl();
   }


### PR DESCRIPTION
Here is what an administrator can see now on the user cancel form:

![user_delete_as_admin](https://user-images.githubusercontent.com/1755573/51613076-0c2b6e00-1f23-11e9-8366-85a7cf1d7990.png)

What simple authenticated users can see based on the configuration of the "When cancelling a user account" on  /admin/config/people/accounts:

![user_cancel_delete](https://user-images.githubusercontent.com/1755573/51613148-2d8c5a00-1f23-11e9-99ca-8a1337b4d2f4.png)
![user_cancel_block](https://user-images.githubusercontent.com/1755573/51613149-2e24f080-1f23-11e9-8410-c41a58188614.png)
![user_cancel_block_unpublish](https://user-images.githubusercontent.com/1755573/51613150-2e24f080-1f23-11e9-9579-54d9be2e5213.png)

... and the additional warning on the team delete form:

![team_delete](https://user-images.githubusercontent.com/1755573/51613186-4268ed80-1f23-11e9-8cc1-d47b47bafce7.png)
