### PR TITLE
Bumped minimum required version from apigee/apigee-client-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Apigee Edge for Drupal.",
     "require": {
         "php": ">=7.1",
-        "apigee/apigee-client-php": "2.x-dev",
+        "apigee/apigee-client-php": "^2.0.1",
         "cweagans/composer-patches": "^1.6.5",
         "drupal/core": "^8.6.3",
         "drupal/entity": "^1.0",


### PR DESCRIPTION
Reason: https://github.com/apigee/apigee-client-php/blob/2.x/CHANGELOG.md#other

https://travis-ci.org/mxr576/apigee-devportal-drupal/builds/489436436