### PR TITLE
Key module patch is not needed anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ module.**
 ### Troubleshooting
 
 * **[File entity](https://www.drupal.org/project/file_entity) module.** If you installed the File entity module then you are going to need the latest patch from [this issue](https://www.drupal.org/project/file_entity/issues/2977747) otherwise you can run into some problems.
-* **[Key](https://www.drupal.org/project/key) module.** If you are using OAuth then you are going to need the latest patch from [this issue](https://www.drupal.org/project/key/issues/2982124) otherwise you can run into some problems.
 
 ### Development
 


### PR DESCRIPTION
Patch got merged and we bumped the minimum required version from the Key module.
https://github.com/apigee/apigee-edge-drupal/commit/6da462db9a831e4c89bc04a583f27c0c6f18a261