### PR TITLE
Make Team permission handler service lazy

### DIFF
--- a/modules/apigee_edge_teams/apigee_edge_teams.services.yml
+++ b/modules/apigee_edge_teams/apigee_edge_teams.services.yml
@@ -54,6 +54,7 @@ services:
   apigee_edge_teams.team_permissions:
     class: Drupal\apigee_edge_teams\TeamPermissionHandler
     arguments: ['@module_handler', '@class_resolver', '@apigee_edge_teams.team_membership_manager', '@entity_type.manager']
+    lazy: true
     calls:
       - [setStringTranslation, ['@string_translation']]
 

--- a/modules/apigee_edge_teams/apigee_edge_teams.services.yml
+++ b/modules/apigee_edge_teams/apigee_edge_teams.services.yml
@@ -49,7 +49,8 @@ services:
 
   apigee_edge_teams.team_membership_manager:
     class: Drupal\apigee_edge_teams\TeamMembershipManager
-    arguments: [ '@entity_type.manager', '@apigee_edge_teams.company_members_controller_factory', '@apigee_edge.controller.developer', '@apigee_edge.controller.cache.developer_companies', '@cache_tags.invalidator', '@logger.channel.apigee_edge_teams']
+    arguments: [ '@entity_type.manager', '@apigee_edge_teams.company_members_controller_factory', '@apigee_edge.controller.developer', '@apigee_edge_teams.team_member_api_product_access_handler', '@apigee_edge.controller.cache.developer_companies', '@cache_tags.invalidator', '@logger.channel.apigee_edge_teams']
+    lazy: true
 
   apigee_edge_teams.team_permissions:
     class: Drupal\apigee_edge_teams\TeamPermissionHandler

--- a/modules/apigee_edge_teams/src/ProxyClass/TeamMembershipManager.php
+++ b/modules/apigee_edge_teams/src/ProxyClass/TeamMembershipManager.php
@@ -1,0 +1,106 @@
+<?php
+// @codingStandardsIgnoreFile
+
+/**
+ * This file was generated via php core/scripts/generate-proxy-class.php 'Drupal\apigee_edge_teams\TeamMembershipManager' "web/modules/contrib/apigee_edge/modules/apigee_edge_teams/src/".
+ */
+
+namespace Drupal\apigee_edge_teams\ProxyClass {
+
+  use Symfony\Component\DependencyInjection\ContainerInterface;
+
+  /**
+     * Provides a proxy class for \Drupal\apigee_edge_teams\TeamMembershipManager.
+     *
+     * @see  \Drupal\Core\ProxyBuilder\ProxyBuilder
+     */
+    class TeamMembershipManager implements \Drupal\apigee_edge_teams\TeamMembershipManagerInterface
+    {
+
+        use \Drupal\Core\DependencyInjection\DependencySerializationTrait;
+
+        /**
+         * The id of the original proxied service.
+         *
+         * @var string
+         */
+        protected $drupalProxyOriginalServiceId;
+
+        /**
+         * The real proxied service, after it was lazy loaded.
+         *
+         * @var \Drupal\apigee_edge_teams\TeamMembershipManager
+         */
+        protected $service;
+
+        /**
+         * The service container.
+         *
+         * @var \Symfony\Component\DependencyInjection\ContainerInterface
+         */
+        protected $container;
+
+        /**
+         * Constructs a ProxyClass Drupal proxy object.
+         *
+         * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+         *   The container.
+         * @param string $drupal_proxy_original_service_id
+         *   The service ID of the original service.
+         */
+        public function __construct(ContainerInterface $container, $drupal_proxy_original_service_id)
+        {
+            $this->container = $container;
+            $this->drupalProxyOriginalServiceId = $drupal_proxy_original_service_id;
+        }
+
+        /**
+         * Lazy loads the real service from the container.
+         *
+         * @return object
+         *   Returns the constructed real service.
+         */
+        protected function lazyLoadItself()
+        {
+            if (!isset($this->service)) {
+                $this->service = $this->container->get($this->drupalProxyOriginalServiceId);
+            }
+
+            return $this->service;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getMembers(string $team): array
+        {
+            return $this->lazyLoadItself()->getMembers($team);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function addMembers(string $team, array $developers): void
+        {
+            $this->lazyLoadItself()->addMembers($team, $developers);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function removeMembers(string $team, array $developers): void
+        {
+            $this->lazyLoadItself()->removeMembers($team, $developers);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getTeams(string $developer): array
+        {
+            return $this->lazyLoadItself()->getTeams($developer);
+        }
+
+    }
+
+}

--- a/modules/apigee_edge_teams/src/ProxyClass/TeamPermissionHandler.php
+++ b/modules/apigee_edge_teams/src/ProxyClass/TeamPermissionHandler.php
@@ -1,0 +1,101 @@
+<?php
+// @codingStandardsIgnoreFile
+
+/**
+ * This file was generated via php core/scripts/generate-proxy-class.php 'Drupal\apigee_edge_teams\TeamPermissionHandler' "web/modules/contrib/apigee_edge/modules/apigee_edge_teams/src/".
+ */
+
+namespace Drupal\apigee_edge_teams\ProxyClass {
+
+  use Drupal\apigee_edge_teams\Entity\TeamInterface;
+  use Drupal\apigee_edge_teams\TeamPermissionHandlerInterface;
+  use Drupal\Core\Session\AccountInterface;
+  use Drupal\Core\StringTranslation\TranslationInterface;
+  use Symfony\Component\DependencyInjection\ContainerInterface;
+
+  /**
+     * Provides a proxy class for \Drupal\apigee_edge_teams\TeamPermissionHandler.
+     *
+     * @see  \Drupal\Core\ProxyBuilder\ProxyBuilder
+     */
+    class TeamPermissionHandler implements TeamPermissionHandlerInterface
+    {
+
+        use \Drupal\Core\DependencyInjection\DependencySerializationTrait;
+
+        /**
+         * The id of the original proxied service.
+         *
+         * @var string
+         */
+        protected $drupalProxyOriginalServiceId;
+
+        /**
+         * The real proxied service, after it was lazy loaded.
+         *
+         * @var \Drupal\apigee_edge_teams\TeamPermissionHandler
+         */
+        protected $service;
+
+        /**
+         * The service container.
+         *
+         * @var \Symfony\Component\DependencyInjection\ContainerInterface
+         */
+        protected $container;
+
+        /**
+         * Constructs a ProxyClass Drupal proxy object.
+         *
+         * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+         *   The container.
+         * @param string $drupal_proxy_original_service_id
+         *   The service ID of the original service.
+         */
+        public function __construct(ContainerInterface $container, $drupal_proxy_original_service_id)
+        {
+            $this->container = $container;
+            $this->drupalProxyOriginalServiceId = $drupal_proxy_original_service_id;
+        }
+
+        /**
+         * Lazy loads the real service from the container.
+         *
+         * @return object
+         *   Returns the constructed real service.
+         */
+        protected function lazyLoadItself()
+        {
+            if (!isset($this->service)) {
+                $this->service = $this->container->get($this->drupalProxyOriginalServiceId);
+            }
+
+            return $this->service;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+      public function getPermissions(): array {
+            return $this->lazyLoadItself()->getPermissions();
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function getDeveloperPermissionsByTeam(TeamInterface $team, AccountInterface $account): array
+        {
+            return $this->lazyLoadItself()->getDeveloperPermissionsByTeam($team, $account);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function setStringTranslation(TranslationInterface $translation)
+        {
+            return $this->lazyLoadItself()->setStringTranslation($translation);
+        }
+
+    }
+
+}


### PR DESCRIPTION
Fixes #140

I do not think the reported problem would require an extra test in this module. I mean we should not verify whether the reported by @Jaesin exist or not after this fixed gets merged. The service remains lazy loaded.

The latest Travis build: https://travis-ci.org/mxr576/apigee-devportal-drupal/builds/499723141