### PR TITLE
DRUP-626 Fix logic issue with team API product access on team app forms

### DIFF
--- a/modules/apigee_edge_teams/config/install/apigee_edge_teams.team_settings.yml
+++ b/modules/apigee_edge_teams/config/install/apigee_edge_teams.team_settings.yml
@@ -2,3 +2,6 @@ langcode: en
 entity_label_singular: ''
 entity_label_plural: ''
 cache_expiration: 900
+manage_team_apps_api_product_access:
+  - public
+  - private

--- a/modules/apigee_edge_teams/config/install/apigee_edge_teams.team_settings.yml
+++ b/modules/apigee_edge_teams/config/install/apigee_edge_teams.team_settings.yml
@@ -2,6 +2,6 @@ langcode: en
 entity_label_singular: ''
 entity_label_plural: ''
 cache_expiration: 900
-manage_team_apps_api_product_access:
+non_member_team_apps_visible_api_products:
   - public
   - private

--- a/modules/apigee_edge_teams/config/schema/apigee_edge_teams.schema.yml
+++ b/modules/apigee_edge_teams/config/schema/apigee_edge_teams.schema.yml
@@ -10,6 +10,10 @@ apigee_edge_teams.team_settings:
       label: 'How to refer to a Team on the UI (plural)'
     cache_expiration:
       type: integer
+    manage_team_apps_api_product_access:
+      type: sequence
+      sequence:
+        type: string
 
 apigee_edge_teams.team_app_settings:
   type: config_object

--- a/modules/apigee_edge_teams/config/schema/apigee_edge_teams.schema.yml
+++ b/modules/apigee_edge_teams/config/schema/apigee_edge_teams.schema.yml
@@ -10,7 +10,7 @@ apigee_edge_teams.team_settings:
       label: 'How to refer to a Team on the UI (plural)'
     cache_expiration:
       type: integer
-    manage_team_apps_api_product_access:
+    non_member_team_apps_visible_api_products:
       type: sequence
       sequence:
         type: string

--- a/modules/apigee_edge_teams/src/Entity/Form/TeamAppCreateForm.php
+++ b/modules/apigee_edge_teams/src/Entity/Form/TeamAppCreateForm.php
@@ -20,60 +20,15 @@
 
 namespace Drupal\apigee_edge_teams\Entity\Form;
 
-use Drupal\apigee_edge\Entity\Controller\ApiProductControllerInterface;
-use Drupal\apigee_edge_teams\Entity\Controller\TeamAppCredentialControllerFactoryInterface;
 use Drupal\apigee_edge_teams\Entity\TeamInterface;
-use Drupal\apigee_edge_teams\TeamMemberApiProductAccessHandlerInterface;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\ReplaceCommand;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Render\RendererInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * General form handler for the team app create.
  */
 class TeamAppCreateForm extends TeamAppCreateFormBase {
-
-  /**
-   * The renderer service.
-   *
-   * @var \Drupal\Core\Render\RendererInterface
-   */
-  private $renderer;
-
-  /**
-   * TeamAppCreateForm constructor.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\apigee_edge\Entity\Controller\ApiProductControllerInterface $api_product_controller
-   *   The API Product controller service.
-   * @param \Drupal\apigee_edge_teams\Entity\Controller\TeamAppCredentialControllerFactoryInterface $app_credential_controller_factory
-   *   The team app credential controller factory.
-   * @param \Drupal\apigee_edge_teams\TeamMemberApiProductAccessHandlerInterface $team_member_api_product_access_handler
-   *   The Team API product access handler.
-   * @param \Drupal\Core\Render\RendererInterface $renderer
-   *   The renderer service.
-   */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, ApiProductControllerInterface $api_product_controller, TeamAppCredentialControllerFactoryInterface $app_credential_controller_factory, TeamMemberApiProductAccessHandlerInterface $team_member_api_product_access_handler, RendererInterface $renderer) {
-    parent::__construct($entity_type_manager, $api_product_controller, $app_credential_controller_factory, $team_member_api_product_access_handler);
-    $this->renderer = $renderer;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('entity_type.manager'),
-      $container->get('apigee_edge.controller.api_product'),
-      $container->get('apigee_edge_teams.controller.team_app_credential_controller_factory'),
-      $container->get('apigee_edge_teams.team_member_api_product_access_handler'),
-      $container->get('renderer')
-    );
-  }
 
   /**
    * {@inheritdoc}
@@ -108,6 +63,7 @@ class TeamAppCreateForm extends TeamAppCreateFormBase {
    * {@inheritdoc}
    */
   protected function alterFormWithApiProductElement(array &$form, FormStateInterface $form_state): void {
+    parent::alterFormWithApiProductElement($form, $form_state);
     $form['api_products']['#prefix'] = '<div id="api-products-ajax-wrapper">';
     $form['api_products']['#suffix'] = '</div>';
   }
@@ -123,9 +79,9 @@ class TeamAppCreateForm extends TeamAppCreateFormBase {
    * @return \Drupal\Core\Ajax\AjaxResponse
    *   The AJAX response.
    */
-  public function updateApiProductList(array $form, FormStateInterface $form_state) : AjaxResponse {
+  public static function updateApiProductList(array $form, FormStateInterface $form_state) : AjaxResponse {
     $response = new AjaxResponse();
-    $response->addCommand(new ReplaceCommand('#api-products-ajax-wrapper', $this->renderer->render($form['api_products'])));
+    $response->addCommand(new ReplaceCommand('#api-products-ajax-wrapper', \Drupal::service('renderer')->render($form['api_products'])));
     return $response;
   }
 

--- a/modules/apigee_edge_teams/src/Entity/Form/TeamAppCreateFormBase.php
+++ b/modules/apigee_edge_teams/src/Entity/Form/TeamAppCreateFormBase.php
@@ -26,6 +26,7 @@ use Drupal\apigee_edge\Entity\Form\AppCreateForm;
 use Drupal\apigee_edge_teams\Entity\Controller\TeamAppCredentialControllerFactoryInterface;
 use Drupal\apigee_edge_teams\TeamMemberApiProductAccessHandlerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -72,6 +73,14 @@ abstract class TeamAppCreateFormBase extends AppCreateForm {
       $container->get('apigee_edge_teams.controller.team_app_credential_controller_factory'),
       $container->get('apigee_edge_teams.team_member_api_product_access_handler')
     );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterFormWithApiProductElement(array &$form, FormStateInterface $form_state): void {
+    parent::alterFormWithApiProductElement($form, $form_state);
+    $form['api_products'] += $this->nonMemberApiProductAccessWarningElement($form, $form_state);
   }
 
   /**

--- a/modules/apigee_edge_teams/src/Entity/Form/TeamAppCreateFormForTeam.php
+++ b/modules/apigee_edge_teams/src/Entity/Form/TeamAppCreateFormForTeam.php
@@ -54,7 +54,6 @@ class TeamAppCreateFormForTeam extends TeamAppCreateFormBase {
       '#type' => 'value',
       '#value' => $this->team->id(),
     ];
-
   }
 
 }

--- a/modules/apigee_edge_teams/src/Entity/Form/TeamAppEditForm.php
+++ b/modules/apigee_edge_teams/src/Entity/Form/TeamAppEditForm.php
@@ -24,6 +24,8 @@ use Drupal\apigee_edge\Entity\Controller\AppCredentialControllerInterface;
 use Drupal\apigee_edge\Entity\Form\AppEditForm;
 use Drupal\apigee_edge_teams\Entity\Controller\TeamAppCredentialControllerFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Url;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -73,6 +75,17 @@ class TeamAppEditForm extends AppEditForm {
    */
   protected function appCredentialController(string $owner, string $app_name): AppCredentialControllerInterface {
     return $this->appCredentialControllerFactory->teamAppCredentialController($owner, $app_name);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array $form, FormStateInterface $form_state) {
+    $form = parent::form($form, $form_state);
+    foreach (Element::children($form['credential']) as $credential) {
+      $form['credential'][$credential]['api_products'] += $this->nonMemberApiProductAccessWarningElement($form, $form_state);
+    }
+    return $form;
   }
 
   /**

--- a/modules/apigee_edge_teams/src/Entity/Form/TeamAppFormTrait.php
+++ b/modules/apigee_edge_teams/src/Entity/Form/TeamAppFormTrait.php
@@ -208,12 +208,12 @@ trait TeamAppFormTrait {
     // form. (For example because it has "Manage team apps" site-wide
     // permission.) It should see a warning and only those API products should
     // be visible that visibility is matching with the configured
-    // manage_team_apps_api_product_access config key value.
+    // non_member_team_apps_visible_api_products config key value.
     // @see nonMemberApiProductAccessWarningElement()
     if (!in_array($team_name, $this->getTeamMembershipMananger()->getTeams(\Drupal::currentUser()->getEmail()))) {
       $filter = function (ApiProductInterface $api_product) use ($team) {
         $visibility = $api_product->getAttributeValue('access') ?? 'public';
-        return in_array($visibility, $this->getConfigObject('apigee_edge_teams.team_settings')->get('manage_team_apps_api_product_access'));
+        return in_array($visibility, $this->getConfigObject('apigee_edge_teams.team_settings')->get('non_member_team_apps_visible_api_products'));
       };
     }
     else {

--- a/modules/apigee_edge_teams/src/Entity/Form/TeamAppFormTrait.php
+++ b/modules/apigee_edge_teams/src/Entity/Form/TeamAppFormTrait.php
@@ -24,6 +24,9 @@ use Apigee\Edge\Exception\ApiException;
 use Apigee\Edge\Exception\ClientErrorException;
 use Drupal\apigee_edge\Entity\ApiProductInterface;
 use Drupal\apigee_edge_teams\TeamMemberApiProductAccessHandlerInterface;
+use Drupal\apigee_edge_teams\TeamMembershipManagerInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -124,9 +127,76 @@ trait TeamAppFormTrait {
   }
 
   /**
+   * Allows to access to the injected team membership manager.
+   *
+   * @return \Drupal\apigee_edge_teams\TeamMembershipManagerInterface
+   *   The team membership manager.
+   */
+  private function getTeamMembershipMananger(): TeamMembershipManagerInterface {
+    if (property_exists($this, 'teamMembershipManager') && $this->teamMembershipManager instanceof TeamMembershipManagerInterface) {
+      return $this->teamMembershipManager;
+    }
+
+    return \Drupal::service('apigee_edge_teams.team_membership_manager');
+  }
+
+  /**
+   * Returns a config object.
+   *
+   * @param string $config
+   *   Config object name.
+   *
+   * @return \Drupal\Core\Config\ImmutableConfig
+   *   The config object.
+   */
+  private function getConfigObject(string $config): ImmutableConfig {
+    /** @var \Drupal\Core\Config\ConfigFactoryInterface $config_factory */
+    $config_factory = \Drupal::service('config.factory');
+    if (method_exists($this, 'configFactory') && $this->configFactory() instanceof ConfigFactoryInterface) {
+      $config_factory = $this->configFactory();
+    }
+    elseif (property_exists($this, 'configFactory') && $this->configFactory instanceof ConfigFactoryInterface) {
+      $config_factory = $this->configFactory;
+    }
+
+    return $config_factory->get($config);
+  }
+
+  /**
+   * Renders a render element with a warning for non-members.
+   *
+   * @param array $form
+   *   Form render array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Form state object.
+   *
+   * @return array
+   *   An associative array with a key 'non_member_api_product_access_warning'
+   *   and its value is a status message element which may or may not contain
+   *   a warning message.
+   */
+  protected function nonMemberApiProductAccessWarningElement(array $form, FormStateInterface $form_state): array {
+    $element = [
+      '#theme' => 'status_messages',
+      '#message_list' => [],
+      '#weight' => -100,
+    ];
+
+    if (!in_array($this->getTeamName($form, $form_state), $this->getTeamMembershipMananger()->getTeams(\Drupal::currentUser()->getEmail()))) {
+      $element['#message_list']['warning'][] = t('You are not member of this @team. You may see @api_products here that a @team member can not see.', [
+        '@team' => $this->getEntityTypeManager()->getDefinition('team')->getLowercaseLabel(),
+        '@api_products' => $this->getEntityTypeManager()->getDefinition('api_product')->getPluralLabel(),
+      ]);
+    }
+
+    return ['non_member_api_product_access_warning' => $element];
+  }
+
+  /**
    * {@inheritdoc}
    */
   protected function apiProductList(array $form, FormStateInterface $form_state): array {
+    $team_name = $this->getTeamName($form, $form_state);
     /** @var \Drupal\apigee_edge_teams\Entity\TeamInterface|null $team */
     $team = $this->getEntityTypeManager()->getStorage('team')->load($team_name);
     // Sanity check, team should always exists with team name in this context.
@@ -134,9 +204,41 @@ trait TeamAppFormTrait {
       return [];
     }
 
-    return array_filter($this->getEntityTypeManager()->getStorage('api_product')->loadMultiple(), function (ApiProductInterface $api_product) use ($team) {
-      return $this->getTeamMemberApiProductAccessHandler()->access($api_product, 'assign', $team);
-    });
+    // If the user is not member of the team, but it still has access to this
+    // form. (For example because it has "Manage team apps" site-wide
+    // permission.) It should see a warning and only those API products should
+    // be visible that visibility is matching with the configured
+    // manage_team_apps_api_product_access config key value.
+    // @see nonMemberApiProductAccessWarningElement()
+    if (!in_array($team_name, $this->getTeamMembershipMananger()->getTeams(\Drupal::currentUser()->getEmail()))) {
+      $filter = function (ApiProductInterface $api_product) use ($team) {
+        $visibility = $api_product->getAttributeValue('access') ?? 'public';
+        return in_array($visibility, $this->getConfigObject('apigee_edge_teams.team_settings')->get('manage_team_apps_api_product_access'));
+      };
+    }
+    else {
+      $filter = function (ApiProductInterface $api_product) use ($team) {
+        return $this->getTeamMemberApiProductAccessHandler()->access($api_product, 'assign', $team);
+      };
+    }
+
+    return array_filter($this->getEntityTypeManager()->getStorage('api_product')->loadMultiple(), $filter);
+  }
+
+  /**
+   * Gets the name of the team from the form.
+   *
+   * @param array $form
+   *   Form render array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Form state object.
+   *
+   * @return string
+   *   Name (id) of the team.
+   */
+  protected function getTeamName(array &$form, FormStateInterface $form_state): string {
+    $team_name = $form_state->getValue('owner') ?? $form['owner']['#value'] ?? $form['owner']['#default_value'];
+    return $team_name;
   }
 
 }

--- a/modules/apigee_edge_teams/src/Entity/Form/TeamAppFormTrait.php
+++ b/modules/apigee_edge_teams/src/Entity/Form/TeamAppFormTrait.php
@@ -126,8 +126,7 @@ trait TeamAppFormTrait {
   /**
    * {@inheritdoc}
    */
-  protected function apiProductList(array &$form, FormStateInterface $form_state): array {
-    $team_name = $form_state->getValue('owner') ?? $form['owner']['#value'] ?? $form['owner']['#default_value'];
+  protected function apiProductList(array $form, FormStateInterface $form_state): array {
     /** @var \Drupal\apigee_edge_teams\Entity\TeamInterface|null $team */
     $team = $this->getEntityTypeManager()->getStorage('team')->load($team_name);
     // Sanity check, team should always exists with team name in this context.

--- a/modules/apigee_edge_teams/src/Form/TeamPermissionsForm.php
+++ b/modules/apigee_edge_teams/src/Form/TeamPermissionsForm.php
@@ -87,16 +87,16 @@ class TeamPermissionsForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $form['manage_team_apps_api_product_access'] = [
+    $form['non_member_team_apps_visible_api_products'] = [
       '#type' => 'checkboxes',
-      '#title' => $this->t('Visible API products for users with "Manage teams apps" site-wide permission on team app add/edit forms'),
-      '#description' => $this->t("If a user is not member a team but it has \"Manage team apps\" site-wide permission then it can create team apps for the team and edit any team apps owned by the team. This configuration allows to limit the visible API products on team app add/edit forms for users with this site-wide permission.<br>Suggestion: keep this configuration in sync with the team administrator's API product access settings."),
+      '#title' => $this->t('Visible API products on team app add/edit forms for users who are not member of a team'),
+      '#description' => $this->t("This configuration allows to limit the visible API products on team app add/edit forms for users who are not a member of the team but still has access to these forms. For example, if a user is not member a team, but it has \"Manage team apps\" site-wide permission then it can create team apps for the team and edit any team apps owned by the team.<br>Suggestion: keep this configuration in sync with the team administrator's API product access settings."),
       '#options' => [
         'public' => $this->t('Public'),
         'private' => $this->t('Private'),
         'internal' => $this->t('Internal'),
       ],
-      '#default_value' => $this->config('apigee_edge_teams.team_settings')->get('manage_team_apps_api_product_access'),
+      '#default_value' => $this->config('apigee_edge_teams.team_settings')->get('non_member_team_apps_visible_api_products'),
     ];
 
     $role_names = [];
@@ -203,7 +203,7 @@ class TeamPermissionsForm extends FormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    $this->configFactory()->getEditable('apigee_edge_teams.team_settings')->set('manage_team_apps_api_product_access', array_keys(array_filter($form_state->getValue('manage_team_apps_api_product_access', []))))->save();
+    $this->configFactory()->getEditable('apigee_edge_teams.team_settings')->set('non_member_team_apps_visible_api_products', array_keys(array_filter($form_state->getValue('non_member_team_apps_visible_api_products', []))))->save();
 
     /** @var \Drupal\apigee_edge_teams\Entity\Storage\TeamRoleStorageInterface $storage */
     $storage = $this->entityTypeManager->getStorage('team_role');

--- a/modules/apigee_edge_teams/src/Form/TeamPermissionsForm.php
+++ b/modules/apigee_edge_teams/src/Form/TeamPermissionsForm.php
@@ -87,6 +87,18 @@ class TeamPermissionsForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['manage_team_apps_api_product_access'] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Visible API products for users with "Manage teams apps" site-wide permission on team app add/edit forms'),
+      '#description' => $this->t("If a user is not member a team but it has \"Manage team apps\" site-wide permission then it can create team apps for the team and edit any team apps owned by the team. This configuration allows to limit the visible API products on team app add/edit forms for users with this site-wide permission.<br>Suggestion: keep this configuration in sync with the team administrator's API product access settings."),
+      '#options' => [
+        'public' => $this->t('Public'),
+        'private' => $this->t('Private'),
+        'internal' => $this->t('Internal'),
+      ],
+      '#default_value' => $this->config('apigee_edge_teams.team_settings')->get('manage_team_apps_api_product_access'),
+    ];
+
     $role_names = [];
     $role_permissions = [];
     $roles = $this->getTeamRoles();
@@ -191,6 +203,8 @@ class TeamPermissionsForm extends FormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->configFactory()->getEditable('apigee_edge_teams.team_settings')->set('manage_team_apps_api_product_access', array_keys(array_filter($form_state->getValue('manage_team_apps_api_product_access', []))))->save();
+
     /** @var \Drupal\apigee_edge_teams\Entity\Storage\TeamRoleStorageInterface $storage */
     $storage = $this->entityTypeManager->getStorage('team_role');
     foreach ($form_state->getValue('role_names') as $role_name => $name) {

--- a/modules/apigee_edge_teams/tests/src/Functional/UiTest.php
+++ b/modules/apigee_edge_teams/tests/src/Functional/UiTest.php
@@ -30,7 +30,7 @@ use Drupal\Tests\field_ui\Traits\FieldUiTestTrait;
  * @group apigee_edge
  * @group apigee_edge_teams
  */
-class UITest extends ApigeeEdgeTeamsFunctionalTestBase {
+class UiTest extends ApigeeEdgeTeamsFunctionalTestBase {
 
   use EntityUtilsTrait;
   use FieldUiTestTrait;

--- a/modules/apigee_edge_teams/tests/src/Functional/UiTest.php
+++ b/modules/apigee_edge_teams/tests/src/Functional/UiTest.php
@@ -258,40 +258,12 @@ class UiTest extends ApigeeEdgeTeamsFunctionalTestBase {
     $this->assertSession()->linkExists($team_modified_display_name);
     $this->assertSession()->linkExists($team_app_1_modified_display_name);
 
-    // Create a new team app using the team app add form for admins.
-    $this->clickLink('Add team app');
-    $team_app_2_name = $team_app_2_display_name = strtolower($this->getRandomGenerator()->name());
-    $this->submitForm([
-      'owner' => $team_name,
-      'name' => $team_app_2_name,
-      'displayName[0][value]' => $team_app_2_display_name,
-      "api_products[{$this->product->getName()}]" => $this->product->getName(),
-    ], 'Add team app');
-    $this->assertSession()->pageTextContains('Team App has been successfully created.');
-    $this->assertSession()->linkExists($team_app_2_display_name);
-
-    // Login with the other user and ensure that both team apps are visible on
-    // the team app collection by team page.
-    $this->drupalLogin($this->otherAccount);
-    $this->drupalGet($this->team->toUrl('collection'));
-    $this->clickLink($team_modified_display_name);
-    $this->clickLink('Team Apps');
-    $this->assertSession()->linkExists($team_app_1_modified_display_name);
-    $this->assertSession()->linkExists($team_app_2_display_name);
-
     // Try to delete the first team app without verification code then with a
     // correct one.
     $this->clickLink($team_app_1_modified_display_name);
     $this->clickLink('Delete');
     $this->submitForm([], 'Delete');
     $this->assertSession()->pageTextContains('The name does not match the team app you are attempting to delete.');
-
-    $this->submitForm([
-      'verification_code' => $team_app_1_name,
-    ], 'Delete');
-    $this->assertSession()->pageTextContains("The {$team_app_1_modified_display_name} team app has been deleted.");
-    $this->assertSession()->linkNotExists($team_app_1_modified_display_name);
-    $this->assertSession()->linkExists($team_app_2_display_name);
 
     // Remove the other user from the team's member list.
     $this->drupalLogin($this->account);

--- a/modules/apigee_edge_teams/tests/src/FunctionalJavascript/ManageTeamAppsApiProductAccessTest.php
+++ b/modules/apigee_edge_teams/tests/src/FunctionalJavascript/ManageTeamAppsApiProductAccessTest.php
@@ -1,0 +1,244 @@
+<?php
+
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\Tests\apigee_edge_teams\FunctionalJavascript;
+
+use Drupal\apigee_edge\Entity\ApiProductInterface;
+use Drupal\Core\Url;
+use Drupal\FunctionalJavascriptTests\WebDriverWebAssert;
+use Drupal\Tests\apigee_edge\FunctionalJavascript\ApigeeEdgeFunctionalJavascriptTestBase;
+
+/**
+ * Extra validation for API product access on team app forms.
+ */
+class ManageTeamAppsApiProductAccessTest extends ApigeeEdgeFunctionalJavascriptTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'apigee_edge_teams',
+  ];
+
+  /**
+   * A user account with "Manage team apps" permission.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $account;
+
+  /**
+   * A team entity.
+   *
+   * @var \Drupal\apigee_edge_teams\Entity\TeamInterface
+   */
+  protected $team;
+
+  /**
+   * A team app entity.
+   *
+   * @var \Drupal\apigee_edge_teams\Entity\TeamAppInterface
+   */
+  protected $teamApp;
+
+  /**
+   * A public API product.
+   *
+   * @var \Drupal\apigee_edge\Entity\ApiProductInterface
+   */
+  protected $publicProduct;
+
+  /**
+   * A private API product.
+   *
+   * @var \Drupal\apigee_edge\Entity\ApiProductInterface
+   */
+  protected $privateProduct;
+
+  /**
+   * An internal API product.
+   *
+   * @var \Drupal\apigee_edge\Entity\ApiProductInterface
+   */
+  protected $internalProduct;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    // Users with manage team apps permissions can see private API products.
+    $this->config('apigee_edge_teams.team_settings')->set('manage_team_apps_api_product_access', ['private'])->save();
+
+    $this->account = $this->createAccount([
+      'manage team apps',
+    ]);
+
+    $apiProductStorage = $this->container->get('entity_type.manager')->getStorage('api_product');
+    /** @var \Drupal\apigee_edge\Entity\ApiProductInterface $api_product */
+    $api_product = $apiProductStorage->create([
+      'name' => $this->randomMachineName(),
+      'displayName' => $this->randomMachineName() . " (public)",
+      'approvalType' => ApiProductInterface::APPROVAL_TYPE_AUTO,
+    ]);
+    $api_product->setAttribute('access', 'public');
+    $api_product->save();
+    $this->publicProduct = $api_product;
+
+    /** @var \Drupal\apigee_edge\Entity\ApiProductInterface $api_product */
+    $api_product = $apiProductStorage->create([
+      'name' => $this->randomMachineName(),
+      'displayName' => $this->randomMachineName() . " (private)",
+      'approvalType' => ApiProductInterface::APPROVAL_TYPE_AUTO,
+    ]);
+    $api_product->setAttribute('access', 'private');
+    $api_product->save();
+
+    $this->privateProduct = $api_product;
+
+    /** @var \Drupal\apigee_edge\Entity\ApiProductInterface $api_product */
+    $api_product = $apiProductStorage->create([
+      'name' => $this->randomMachineName(),
+      'displayName' => $this->randomMachineName() . " (internal)",
+      'approvalType' => ApiProductInterface::APPROVAL_TYPE_AUTO,
+    ]);
+    $api_product->setAttribute('access', 'internal');
+    $api_product->save();
+
+    $this->internalProduct = $api_product;
+
+    /** @var \Drupal\apigee_edge_teams\Entity\Storage\TeamStorageInterface $teamStorage */
+    $teamStorage = $this->container->get('entity_type.manager')->getStorage('team');
+    // Use the machine name as both value because it makes easier the debugging.
+    $teamName = strtolower($this->randomMachineName());
+    $team = $teamStorage->create([
+      'name' => $teamName,
+      'displayName' => $teamName,
+    ]);
+    $team->save();
+    $this->team = $team;
+    /** @var \Drupal\apigee_edge_teams\Entity\Storage\TeamAppStorageInterface $teamAppStorage */
+    $teamAppStorage = $this->container->get('entity_type.manager')->getStorage('team_app');
+    $teamApp = $teamAppStorage->create([
+      'name' => $this->randomMachineName(),
+      'companyName' => $this->team->getName(),
+    ]);
+    $teamApp->save();
+    $this->teamApp = $teamApp;
+    /** @var \Drupal\apigee_edge_teams\Entity\Controller\TeamAppCredentialControllerFactoryInterface $teamAppCredentialControllerFactory */
+    $teamAppCredentialControllerFactory = $this->container->get('apigee_edge_teams.controller.team_app_credential_controller_factory');
+    $credentialController = $teamAppCredentialControllerFactory->teamAppCredentialController($this->team->id(), $this->teamApp->getName());
+    $credentials = $this->teamApp->getCredentials();
+    /** @var \Apigee\Edge\Api\Management\Entity\AppCredential $credential */
+    $credential = reset($credentials);
+
+    // Assign both public and private API products to the app.
+    $credentialController->addProducts($credential->getConsumerKey(), [$this->publicProduct->id(), $this->privateProduct->id()]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown() {
+    if ($this->account !== NULL) {
+      try {
+        $this->account->delete();
+      }
+      catch (\Exception $exception) {
+        $this->logException($exception);
+      }
+    }
+
+    if ($this->team !== NULL) {
+      try {
+        $this->team->delete();
+      }
+      catch (\Exception $exception) {
+        $this->logException($exception);
+      }
+    }
+
+    if ($this->publicProduct !== NULL) {
+      try {
+        $this->publicProduct->delete();
+      }
+      catch (\Exception $exception) {
+        $this->logException($exception);
+      }
+    }
+    if ($this->privateProduct !== NULL) {
+      try {
+        $this->privateProduct->delete();
+      }
+      catch (\Exception $exception) {
+        $this->logException($exception);
+      }
+    }
+    if ($this->internalProduct !== NULL) {
+      try {
+        $this->internalProduct->delete();
+      }
+      catch (\Exception $exception) {
+        $this->logException($exception);
+      }
+    }
+
+    parent::tearDown();
+  }
+
+  /**
+   * Test API product access of a user with Manage team apps permission.
+   */
+  public function testManageTeamAppsApiProductAccess() {
+    $assert_session = $this->assertSession();
+    $message = 'You are not member of this team. You may see APIs here that a team member can not see.';
+    $shouldSeeOnAddForm = function (WebDriverWebAssert $assert_session, string $message) {
+      $this->assertNotEmpty(
+        // Wait as much as we can.
+        $assert_session->waitForText($message, 1200000)
+      );
+      // Based on the default configuration a user with "Manage team apps"
+      // permission should see the private API product but not the public
+      // or the internal one.
+      $this->assertSession()->pageTextContains($this->privateProduct->label());
+      $this->assertSession()->pageTextNotContains($this->publicProduct->label());
+      $this->assertSession()->pageTextNotContains($this->internalProduct->label());
+    };
+    $this->drupalLogin($this->account);
+
+    // Validate team app add forms.
+    $this->drupalGet($this->teamApp->toUrl('add-form'));
+    $shouldSeeOnAddForm($assert_session, $message);
+    $assert_session->selectExists('Owner')->selectOption($this->team->id());
+    $this->drupalGet(Url::fromRoute('entity.team_app.add_form_for_team', ['team' => $this->team->id()]));
+    $shouldSeeOnAddForm($assert_session, $message);
+
+    // Validate team app edit form.
+    $this->drupalGet($this->teamApp->toUrl('edit-form'));
+    // The page should contain both public and private API products, because
+    // the team app is in association with the public API product.
+    $this->assertSession()->pageTextContains($this->privateProduct->label());
+    $this->assertSession()->pageTextContains($this->publicProduct->label());
+    // But it still should not contain the internal API product.
+    $this->assertSession()->pageTextNotContains($this->internalProduct->label());
+    $this->assertSession()->pageTextContains($message);
+  }
+
+}

--- a/modules/apigee_edge_teams/tests/src/FunctionalJavascript/ManageTeamAppsApiProductAccessTest.php
+++ b/modules/apigee_edge_teams/tests/src/FunctionalJavascript/ManageTeamAppsApiProductAccessTest.php
@@ -209,11 +209,7 @@ class ManageTeamAppsApiProductAccessTest extends ApigeeEdgeFunctionalJavascriptT
   public function testManageTeamAppsApiProductAccess() {
     $assert_session = $this->assertSession();
     $message = 'You are not member of this team. You may see APIs here that a team member can not see.';
-    $shouldSeeOnAddForm = function (WebDriverWebAssert $assert_session, string $message) {
-      $this->assertNotEmpty(
-        // Wait as much as we can.
-        $assert_session->waitForText($message, 1200000)
-      );
+    $verifyApiProductAccessOnAddForm = function (WebDriverWebAssert $assert_session, string $message) {
       // Based on the default configuration a user with "Manage team apps"
       // permission should see the private API product but not the public
       // or the internal one.
@@ -225,10 +221,14 @@ class ManageTeamAppsApiProductAccessTest extends ApigeeEdgeFunctionalJavascriptT
 
     // Validate team app add forms.
     $this->drupalGet($this->teamApp->toUrl('add-form'));
-    $shouldSeeOnAddForm($assert_session, $message);
+    $verifyApiProductAccessOnAddForm($assert_session, $message);
     $assert_session->selectExists('Owner')->selectOption($this->team->id());
+    $assert_session->assertWaitOnAjaxRequest(1200000);
+    $this->assertSession()->pageTextContains($message);
+
     $this->drupalGet(Url::fromRoute('entity.team_app.add_form_for_team', ['team' => $this->team->id()]));
-    $shouldSeeOnAddForm($assert_session, $message);
+    $verifyApiProductAccessOnAddForm($assert_session, $message);
+    $this->assertSession()->pageTextContains($message);
 
     // Validate team app edit form.
     $this->drupalGet($this->teamApp->toUrl('edit-form'));

--- a/modules/apigee_edge_teams/tests/src/FunctionalJavascript/ManageTeamAppsApiProductAccessTest.php
+++ b/modules/apigee_edge_teams/tests/src/FunctionalJavascript/ManageTeamAppsApiProductAccessTest.php
@@ -85,7 +85,7 @@ class ManageTeamAppsApiProductAccessTest extends ApigeeEdgeFunctionalJavascriptT
   protected function setUp() {
     parent::setUp();
     // Users with manage team apps permissions can see private API products.
-    $this->config('apigee_edge_teams.team_settings')->set('manage_team_apps_api_product_access', ['private'])->save();
+    $this->config('apigee_edge_teams.team_settings')->set('non_member_team_apps_visible_api_products', ['private'])->save();
 
     $this->account = $this->createAccount([
       'manage team apps',

--- a/src/Entity/Form/AppForm.php
+++ b/src/Entity/Form/AppForm.php
@@ -103,7 +103,7 @@ abstract class AppForm extends FieldableEdgeEntityForm {
    * @return \Drupal\apigee_edge\Entity\ApiProductInterface[]
    *   Array of API product entities.
    */
-  abstract protected function apiProductList(array &$form, FormStateInterface $form_state): array;
+  abstract protected function apiProductList(array $form, FormStateInterface $form_state): array;
 
   /**
    * Returns the label of the Save button on the form.

--- a/src/Entity/Form/DeveloperAppEditForm.php
+++ b/src/Entity/Form/DeveloperAppEditForm.php
@@ -78,7 +78,7 @@ class DeveloperAppEditForm extends AppEditForm {
   /**
    * {@inheritdoc}
    */
-  protected function apiProductList(array &$form, FormStateInterface $form_state): array {
+  protected function apiProductList(array $form, FormStateInterface $form_state): array {
     /** @var \Drupal\apigee_edge\Entity\DeveloperAppInterface $app */
     $app = $this->entity;
 

--- a/src/Entity/Form/DeveloperAppFormTrait.php
+++ b/src/Entity/Form/DeveloperAppFormTrait.php
@@ -124,7 +124,7 @@ trait DeveloperAppFormTrait {
   /**
    * {@inheritdoc}
    */
-  protected function apiProductList(array &$form, FormStateInterface $form_state): array {
+  protected function apiProductList(array $form, FormStateInterface $form_state): array {
     $email = $form_state->getValue('owner') ?? $form['owner']['#value'] ?? $form['owner']['#default_value'];
     /** @var \Drupal\user\UserInterface|null $account */
     $account = user_load_by_mail($email);


### PR DESCRIPTION
Users with "Manage team apps" site-wide permission can access to any team's team app create/edit forms. Because they are not necessarily a member of the team the membership based API product access cannot be applied to them.

Suggested solution: Introduce a new configuration option to set API products that these users should be able to assign to new or existing team apps.

![image](https://user-images.githubusercontent.com/1755573/53637978-0eb96b80-3c25-11e9-95a4-f682d392e064.png)

![image](https://user-images.githubusercontent.com/1755573/53637997-1da01e00-3c25-11e9-86a5-960eb105f0f9.png)

Travis: https://travis-ci.org/mxr576/apigee-devportal-drupal/builds/511476497