### PR TITLE
[DRUP-609] Add API Product reference to API Docs.

### DIFF
--- a/modules/apigee_edge_apidocs/src/Entity/ApiDoc.php
+++ b/modules/apigee_edge_apidocs/src/Entity/ApiDoc.php
@@ -204,6 +204,18 @@ class ApiDoc extends ContentEntityBase implements ApiDocInterface {
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);
 
+    $fields['api_product'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(t('API Product'))
+      ->setDescription(t('The API Product this is documenting.'))
+      ->setSetting('target_type', 'api_product')
+      ->setDisplayOptions('form', [
+        'label' => 'above',
+        'type' => 'entity_reference_autocomplete',
+        'weight' => 0,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDisplayConfigurable('view', TRUE);
+
     $fields['status'] = BaseFieldDefinition::create('boolean')
       ->setLabel(t('Publishing status'))
       ->setDescription(t('A boolean indicating whether the API Doc is published.'))

--- a/modules/apigee_edge_apidocs/tests/src/Kernel/ApiDocTest.php
+++ b/modules/apigee_edge_apidocs/tests/src/Kernel/ApiDocTest.php
@@ -42,6 +42,7 @@ class ApiDocTest extends KernelTestBase {
       'name' => 'API 1',
       'description' => 'Test API 1',
       'spec' => NULL,
+      'api_product' => NULL,
     ]);
     $this->assertNotNull($entity);
     $this->assertEquals(SAVED_NEW, $entity->save());


### PR DESCRIPTION
API Docs should have an entity reference to API Products, so that views can be created to map API products to specs.
Note: By default the API product reference field is hidden on the "view", because we don't have renderer for the product yet (DRUP-400).