### PR TITLE
Fix errors regarding the API Docs entity settings route.

### DIFF
--- a/modules/apigee_edge_apidocs/apigee_edge_apidocs.links.menu.yml
+++ b/modules/apigee_edge_apidocs/apigee_edge_apidocs.links.menu.yml
@@ -6,7 +6,7 @@ entity.apidoc.collection:
   parent: system.admin_structure
   weight: 100
 
-apigee_edge_apidocs.settings
+apigee_edge_apidocs.settings:
   title: 'API Docs'
   description: 'Configure API Doc settings'
   route_name: apigee_edge_apidocs.settings

--- a/modules/apigee_edge_apidocs/src/ApiDocListBuilder.php
+++ b/modules/apigee_edge_apidocs/src/ApiDocListBuilder.php
@@ -54,7 +54,7 @@ class ApiDocListBuilder extends EntityListBuilder {
   public function render() {
     $build['description'] = [
       '#markup' => $this->t('Manage your API documentation. You can manage the fields on the <a href=":url">API Docs settings page</a>.', [
-        ':url' => Url::fromRoute('apidoc.settings')->toString(),
+        ':url' => Url::fromRoute('apigee_edge_apidocs.settings')->toString(),
       ]),
     ];
     $build['table'] = parent::render();

--- a/modules/apigee_edge_apidocs/src/Entity/ApiDoc.php
+++ b/modules/apigee_edge_apidocs/src/Entity/ApiDoc.php
@@ -69,7 +69,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
  *     "delete-form" = "/admin/structure/apidoc/{apidoc}/delete",
  *     "collection" = "/admin/structure/apidoc",
  *   },
- *   field_ui_base_route = "apidoc.settings"
+ *   field_ui_base_route = "apigee_edge_apidocs.settings"
  * )
  */
 class ApiDoc extends ContentEntityBase implements ApiDocInterface {


### PR DESCRIPTION
Fixes the following error regarding the "apidoc.settings" route:

`Symfony\Component\Routing\Exception\RouteNotFoundException: Route "apidoc.settings" does not exist. in Drupal\Core\Routing\RouteProvider->getRouteByName()...`