### PR TITLE
Correctly show the entity label when the API Doc entity gets saved.

### DIFF
--- a/modules/apigee_edge_apidocs/src/Form/ApiDocForm.php
+++ b/modules/apigee_edge_apidocs/src/Form/ApiDocForm.php
@@ -51,7 +51,7 @@ class ApiDocForm extends ContentEntityForm {
       ]));
     }
     else {
-      $this->messenger()->addMessage($this->t('Saved the $label @entity_type_label.', [
+      $this->messenger()->addMessage($this->t('Saved the %label @entity_type_label.', [
         '%label' => $entity->label(),
         '@entity_type_label' => $singular_label,
       ]));


### PR DESCRIPTION
When saving an API Doc entity, the message displayed to the user is _"Saved the $label API Doc."_. This PR fixes the message to correctly show the entity name/label instead of $label.