### PR TITLE
DRUP-624 Add revisions to API Docs

### DIFF
--- a/modules/apigee_edge_apidocs/apigee_edge_apidocs.links.task.yml
+++ b/modules/apigee_edge_apidocs/apigee_edge_apidocs.links.task.yml
@@ -19,3 +19,9 @@ entity.apidoc.delete_form:
   base_route:  entity.apidoc.canonical
   title: 'Delete'
   weight: 10
+
+entity.apidoc.version_history:
+  route_name:  entity.apidoc.version_history
+  base_route:  entity.apidoc.canonical
+  title: 'Revisions'
+  weight: 15

--- a/modules/apigee_edge_apidocs/apigee_edge_apidocs.permissions.yml
+++ b/modules/apigee_edge_apidocs/apigee_edge_apidocs.permissions.yml
@@ -17,3 +17,11 @@ view published apidoc entities:
 
 view unpublished apidoc entities:
   title: 'View unpublished API Docs'
+
+view all apidoc revisions:
+  title: 'View API Docs revisions'
+  description: 'To view a revision, you also need permission to view the item.'
+
+revert all apidoc revisions:
+  title: 'Revert API Docs revisions'
+  description: 'To revert a revision, you also need permission to edit the item.'

--- a/modules/apigee_edge_apidocs/src/ApiDocAccessControlHandler.php
+++ b/modules/apigee_edge_apidocs/src/ApiDocAccessControlHandler.php
@@ -22,6 +22,7 @@ namespace Drupal\apigee_edge_apidocs;
 
 use Drupal\Core\Entity\EntityAccessControlHandler;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Access\AccessResult;
 
@@ -33,6 +34,20 @@ use Drupal\Core\Access\AccessResult;
 class ApiDocAccessControlHandler extends EntityAccessControlHandler {
 
   /**
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(EntityTypeInterface $entity_type) {
+    parent::__construct($entity_type);
+
+    $this->entityTypeManager = \Drupal::entityTypeManager();
+  }
+
+  /**
    * {@inheritdoc}
    */
   protected function checkAccess(EntityInterface $entity, $operation, AccountInterface $account) {
@@ -40,6 +55,12 @@ class ApiDocAccessControlHandler extends EntityAccessControlHandler {
 
     if (!$parent_access->isAllowed()) {
       /** @var \Drupal\apigee_edge_apidocs\Entity\ApiDocInterface $entity */
+
+      // Access control for revisions.
+      if (!$entity->isDefaultRevision()) {
+        return $this->checkAccessRevisions($entity, $operation, $account);
+      }
+
       switch ($operation) {
         case 'view':
           if (!$entity->isPublished()) {
@@ -57,6 +78,60 @@ class ApiDocAccessControlHandler extends EntityAccessControlHandler {
 
     // Unknown operation, no opinion.
     return $parent_access;
+  }
+
+  /**
+   * Additional access control for revisions.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface   $entity
+   * @param                                       $operation
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *
+   * @return bool
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function checkAccessRevisions(EntityInterface $entity, $operation, AccountInterface $account) {
+    $entity_access = $this->entityTypeManager->getAccessControlHandler($this->entityTypeId);
+
+    /** @var \Drupal\Core\Entity\EntityStorageInterface $entity_storage */
+    $entity_storage = $this->entityTypeManager->getStorage($this->entityTypeId);
+
+    // Must have access to the same operation on the default revision.
+    $default_revision = $entity_storage->load($entity->id());
+    $entity_access_default = $default_revision->access($operation, $account);
+    if (!$entity_access_default) {
+      return AccessResult::forbidden();
+    }
+
+    $map = [
+      'view' => "view all {$this->entityTypeId} revisions",
+      'update' => "revert all {$this->entityTypeId} revisions",
+      'delete' => "delete all {$this->entityTypeId} revisions",
+    ];
+    $bundle = $entity->bundle();
+    $type_map = [
+      'view' => "view {$this->entityTypeId} $bundle revisions",
+      'update' => "revert {$this->entityTypeId} $bundle revisions",
+      'delete' => "delete {$this->entityTypeId} $bundle revisions",
+    ];
+
+    if (!$entity || !isset($map[$operation]) || !isset($type_map[$operation])) {
+      // If there was no entity to check against, or the $op was not one of the
+      // supported ones, we return access denied.
+      return AccessResult::forbidden();
+    }
+
+    $admin_permission = $this->entityType->getAdminPermission();
+
+    // Perform basic permission checks first.
+    if ($account->hasPermission($map[$operation]) ||
+      $account->hasPermission($type_map[$operation]) ||
+      ($admin_permission && $account->hasPermission($admin_permission))) {
+      return AccessResult::allowed();
+    }
+
+    return AccessResult::forbidden();
   }
 
   /**

--- a/modules/apigee_edge_apidocs/src/ApiDocAccessControlHandler.php
+++ b/modules/apigee_edge_apidocs/src/ApiDocAccessControlHandler.php
@@ -34,6 +34,8 @@ use Drupal\Core\Access\AccessResult;
 class ApiDocAccessControlHandler extends EntityAccessControlHandler {
 
   /**
+   * The entity type manager.
+   *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
@@ -83,17 +85,20 @@ class ApiDocAccessControlHandler extends EntityAccessControlHandler {
   /**
    * Additional access control for revisions.
    *
-   * @param \Drupal\Core\Entity\EntityInterface   $entity
-   * @param                                       $operation
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity for which to check access.
+   * @param string $operation
+   *   The entity operation.
    * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user for which to check access.
    *
-   * @return bool
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
   protected function checkAccessRevisions(EntityInterface $entity, $operation, AccountInterface $account) {
-    $entity_access = $this->entityTypeManager->getAccessControlHandler($this->entityTypeId);
-
     /** @var \Drupal\Core\Entity\EntityStorageInterface $entity_storage */
     $entity_storage = $this->entityTypeManager->getStorage($this->entityTypeId);
 

--- a/modules/apigee_edge_apidocs/src/ApiDocAccessControlHandler.php
+++ b/modules/apigee_edge_apidocs/src/ApiDocAccessControlHandler.php
@@ -21,17 +21,20 @@
 namespace Drupal\apigee_edge_apidocs;
 
 use Drupal\Core\Entity\EntityAccessControlHandler;
+use Drupal\Core\Entity\EntityHandlerInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Access\AccessResult;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Access controller for the API Doc entity.
  *
  * @see \Drupal\apigee_edge_apidocs\Entity\ApiDoc.
  */
-class ApiDocAccessControlHandler extends EntityAccessControlHandler {
+class ApiDocAccessControlHandler extends EntityAccessControlHandler implements EntityHandlerInterface {
 
   /**
    * The entity type manager.
@@ -41,12 +44,26 @@ class ApiDocAccessControlHandler extends EntityAccessControlHandler {
   protected $entityTypeManager;
 
   /**
+   * Constructs an access control handler instance.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
+   *   The entity type definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   */
+  public function __construct(EntityTypeInterface $entity_type, EntityTypeManagerInterface $entityTypeManager) {
+    parent::__construct($entity_type);
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
    * {@inheritdoc}
    */
-  public function __construct(EntityTypeInterface $entity_type) {
-    parent::__construct($entity_type);
-
-    $this->entityTypeManager = \Drupal::entityTypeManager();
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
+    return new static(
+      $entity_type,
+      $container->get('entity_type.manager')
+    );
   }
 
   /**

--- a/modules/apigee_edge_apidocs/src/ApiDocAccessControlHandler.php
+++ b/modules/apigee_edge_apidocs/src/ApiDocAccessControlHandler.php
@@ -111,9 +111,6 @@ class ApiDocAccessControlHandler extends EntityAccessControlHandler implements E
    *
    * @return \Drupal\Core\Access\AccessResultInterface
    *   The access result.
-   *
-   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
-   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
   protected function checkAccessRevisions(EntityInterface $entity, $operation, AccountInterface $account) {
     /** @var \Drupal\Core\Entity\EntityStorageInterface $entity_storage */
@@ -121,8 +118,8 @@ class ApiDocAccessControlHandler extends EntityAccessControlHandler implements E
 
     // Must have access to the same operation on the default revision.
     $default_revision = $entity_storage->load($entity->id());
-    $entity_access_default = $default_revision->access($operation, $account);
-    if (!$entity_access_default) {
+    $has_default_entity_rev_access = $default_revision->access($operation, $account);
+    if (!$has_default_entity_rev_access) {
       return AccessResult::forbidden();
     }
 

--- a/modules/apigee_edge_apidocs/src/Entity/ApiDoc.php
+++ b/modules/apigee_edge_apidocs/src/Entity/ApiDoc.php
@@ -139,13 +139,6 @@ class ApiDoc extends EditorialContentEntityBase implements ApiDocInterface {
   /**
    * {@inheritdoc}
    */
-  public function getRevisionUser() {
-    return $this->get('revision_user')->entity;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function preSave(EntityStorageInterface $storage) {
     parent::preSave($storage);
 
@@ -164,9 +157,9 @@ class ApiDoc extends EditorialContentEntityBase implements ApiDocInterface {
 
     if (!$this->isNewRevision() && isset($this->original) && empty($record->revision_log_message)) {
       // If we are updating an existing entity without adding a new revision, we
-      // need to make sure $entity->revision_log is reset whenever it is empty.
-      // Therefore, this code allows us to avoid clobbering an existing log
-      // entry with an empty one.
+      // need to make sure $entity->revision_log_message is reset whenever it is
+      // empty. Therefore, this code allows us to avoid clobbering an existing
+      // log  entry with an empty one.
       $record->revision_log_message = $this->original->revision_log_message->value;
     }
   }

--- a/modules/apigee_edge_apidocs/src/Entity/ApiDoc.php
+++ b/modules/apigee_edge_apidocs/src/Entity/ApiDoc.php
@@ -170,7 +170,7 @@ class ApiDoc extends EditorialContentEntityBase implements ApiDocInterface {
    * @return bool
    *   TRUE if a new revision should be created by default.
    */
-  public static function shouldCreateNewRevision() {
+  public function shouldCreateNewRevision() {
     $config = \Drupal::config('apigee_edge_apidocs.settings');
     $default_revision = $config->get('default_revision');
     return is_null($default_revision) ? TRUE : (bool) $default_revision;

--- a/modules/apigee_edge_apidocs/src/Entity/ApiDoc.php
+++ b/modules/apigee_edge_apidocs/src/Entity/ApiDoc.php
@@ -146,13 +146,6 @@ class ApiDoc extends EditorialContentEntityBase implements ApiDocInterface {
   /**
    * {@inheritdoc}
    */
-  public function save() {
-    return parent::save();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function preSave(EntityStorageInterface $storage) {
     parent::preSave($storage);
 
@@ -176,6 +169,18 @@ class ApiDoc extends EditorialContentEntityBase implements ApiDocInterface {
       // entry with an empty one.
       $record->revision_log_message = $this->original->revision_log_message->value;
     }
+  }
+
+  /**
+   * Gets whether a new revision should be created by default.
+   *
+   * @return bool
+   *   TRUE if a new revision should be created by default.
+   */
+  public static function shouldCreateNewRevision() {
+    $config = \Drupal::config('apigee_edge_apidocs.settings');
+    $default_revision = $config->get('default_revision');
+    return is_null($default_revision) ? TRUE : (bool) $default_revision;
   }
 
   /**

--- a/modules/apigee_edge_apidocs/src/Entity/ApiDocInterface.php
+++ b/modules/apigee_edge_apidocs/src/Entity/ApiDocInterface.php
@@ -85,25 +85,4 @@ interface ApiDocInterface extends ContentEntityInterface, EntityChangedInterface
    */
   public function setCreatedTime(int $timestamp) : self;
 
-  /**
-   * Returns the API Doc published status indicator.
-   *
-   * Unpublished API Doc are only visible to restricted users.
-   *
-   * @return bool
-   *   TRUE if the API Doc is published.
-   */
-  public function isPublished() : bool;
-
-  /**
-   * Sets the published status of a API Doc.
-   *
-   * @param bool $published
-   *   TRUE to set this API Doc to published, FALSE to set it to unpublished.
-   *
-   * @return \Drupal\apigee_edge_apidocs\Entity\ApiDocInterface
-   *   The called API Doc entity.
-   */
-  public function setPublished(bool $published) : self;
-
 }

--- a/modules/apigee_edge_apidocs/src/Entity/ApiDocInterface.php
+++ b/modules/apigee_edge_apidocs/src/Entity/ApiDocInterface.php
@@ -22,11 +22,12 @@ namespace Drupal\apigee_edge_apidocs\Entity;
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityChangedInterface;
+use Drupal\Core\Entity\EntityPublishedInterface;
 
 /**
  * Provides an interface for defining API Doc entities.
  */
-interface ApiDocInterface extends ContentEntityInterface, EntityChangedInterface {
+interface ApiDocInterface extends ContentEntityInterface, EntityChangedInterface, EntityPublishedInterface {
 
   /**
    * Gets the API Doc name.

--- a/modules/apigee_edge_apidocs/src/Form/ApiDocForm.php
+++ b/modules/apigee_edge_apidocs/src/Form/ApiDocForm.php
@@ -36,7 +36,7 @@ class ApiDocForm extends ContentEntityForm {
     $entity = $this->getEntity();
 
     // Always use the default revision setting.
-    $new_revision_default = $entity::shouldCreateNewRevision();
+    $new_revision_default = $entity->shouldCreateNewRevision();
     return $new_revision_default;
   }
 

--- a/modules/apigee_edge_apidocs/src/Form/ApiDocForm.php
+++ b/modules/apigee_edge_apidocs/src/Form/ApiDocForm.php
@@ -20,18 +20,25 @@
 
 namespace Drupal\apigee_edge_apidocs\Form;
 
-use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Entity\ContentEntityForm;
-use Drupal\Core\Entity\EntityRepositoryInterface;
-use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Messenger\MessengerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Form controller for API Doc edit forms.
  */
 class ApiDocForm extends ContentEntityForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getNewRevisionDefault() {
+    /* @var \Drupal\apigee_edge_apidocs\Entity\ApiDoc $entity */
+    $entity = $this->getEntity();
+
+    // Always use the default revision setting.
+    $new_revision_default = $entity::shouldCreateNewRevision();
+    return $new_revision_default;
+  }
 
   /**
    * {@inheritdoc}

--- a/modules/apigee_edge_apidocs/src/Form/ApiDocSettingsForm.php
+++ b/modules/apigee_edge_apidocs/src/Form/ApiDocSettingsForm.php
@@ -85,6 +85,8 @@ class ApiDocSettingsForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
+    /* @var \Drupal\apigee_edge_apidocs\Entity\ApiDoc $entity */
+    $entity = $this->entityTypeManager->getStorage('apidoc')->create();
     $form['apidoc_settings']['#markup'] = $this->t('Settings for API Docs. Manage field settings using the tabs above.');
 
     $form['additional_settings'] = [
@@ -97,11 +99,11 @@ class ApiDocSettingsForm extends FormBase {
       '#group' => 'additional_settings',
     ];
     $workflow_options = [
-      'new_revision' => ApiDoc::shouldCreateNewRevision(),
+      'new_revision' => $entity->shouldCreateNewRevision(),
     ];
     // Prepare workflow options to be used for 'checkboxes' form element.
-    $keys = array_keys(array_filter($workflow_options));
-    $workflow_options = array_combine($keys, $keys);
+    $workflow_options_keys = array_keys(array_filter($workflow_options));
+    $workflow_options = array_combine($workflow_options_keys, $workflow_options_keys);
     $form['workflow']['options'] = [
       '#type' => 'checkboxes',
       '#title' => $this->t('Default options'),

--- a/modules/apigee_edge_apidocs/src/Form/ApiDocSettingsForm.php
+++ b/modules/apigee_edge_apidocs/src/Form/ApiDocSettingsForm.php
@@ -21,8 +21,10 @@
 namespace Drupal\apigee_edge_apidocs\Form;
 
 use Drupal\apigee_edge_apidocs\Entity\ApiDoc;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Class ApiDocSettingsForm.
@@ -30,6 +32,29 @@ use Drupal\Core\Form\FormStateInterface;
  * Settings for the ApiDoc entity type.
  */
 class ApiDocSettingsForm extends FormBase {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -42,10 +67,11 @@ class ApiDocSettingsForm extends FormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    $entity_type = \Drupal::entityTypeManager()
+    $entity_type = $this->entityTypeManager
       ->getStorage('apidoc')
       ->getEntityType();
-    $config = $this->configFactory()->getEditable('apigee_edge_apidocs.settings');
+    $config = $this->configFactory()
+      ->getEditable('apigee_edge_apidocs.settings');
 
     $options = $form_state->getValue('options');
     $config->set('default_revision', (bool) $options['new_revision'])->save();
@@ -53,7 +79,7 @@ class ApiDocSettingsForm extends FormBase {
     $args = [
       '@type' => $entity_type->getLabel(),
     ];
-    drupal_set_message($this->t('@type settings have been updated.', $args));
+    $this->messenger($this->t('@type settings have been updated.', $args));
   }
 
   /**
@@ -68,7 +94,7 @@ class ApiDocSettingsForm extends FormBase {
 
     $form['workflow'] = [
       '#type' => 'details',
-      '#title' => t('Publishing options'),
+      '#title' => $this->t('Publishing options'),
       '#group' => 'additional_settings',
     ];
     $workflow_options = [
@@ -79,10 +105,10 @@ class ApiDocSettingsForm extends FormBase {
     $workflow_options = array_combine($keys, $keys);
     $form['workflow']['options'] = [
       '#type' => 'checkboxes',
-      '#title' => t('Default options'),
+      '#title' => $this->t('Default options'),
       '#default_value' => $workflow_options,
       '#options' => [
-        'new_revision' => t('Create new revision'),
+        'new_revision' => $this->t('Create new revision'),
       ],
     ];
 

--- a/modules/apigee_edge_apidocs/src/Form/ApiDocSettingsForm.php
+++ b/modules/apigee_edge_apidocs/src/Form/ApiDocSettingsForm.php
@@ -20,13 +20,14 @@
 
 namespace Drupal\apigee_edge_apidocs\Form;
 
+use Drupal\apigee_edge_apidocs\Entity\ApiDoc;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Class ApiDocSettingsForm.
  *
- * @todo Add settings or remove the class and the route.
+ * Settings for the ApiDoc entity type.
  */
 class ApiDocSettingsForm extends FormBase {
 
@@ -41,6 +42,18 @@ class ApiDocSettingsForm extends FormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
+    $entity_type = \Drupal::entityTypeManager()
+      ->getStorage('apidoc')
+      ->getEntityType();
+    $config = $this->configFactory()->getEditable('apigee_edge_apidocs.settings');
+
+    $options = $form_state->getValue('options');
+    $config->set('default_revision', (bool) $options['new_revision'])->save();
+
+    $args = [
+      '@type' => $entity_type->getLabel(),
+    ];
+    drupal_set_message($this->t('@type settings have been updated.', $args));
   }
 
   /**
@@ -48,6 +61,36 @@ class ApiDocSettingsForm extends FormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     $form['apidoc_settings']['#markup'] = $this->t('Settings for API Docs. Manage field settings using the tabs above.');
+
+    $form['additional_settings'] = [
+      '#type' => 'vertical_tabs',
+    ];
+
+    $form['workflow'] = [
+      '#type' => 'details',
+      '#title' => t('Publishing options'),
+      '#group' => 'additional_settings',
+    ];
+    $workflow_options = [
+      'new_revision' => ApiDoc::shouldCreateNewRevision(),
+    ];
+    // Prepare workflow options to be used for 'checkboxes' form element.
+    $keys = array_keys(array_filter($workflow_options));
+    $workflow_options = array_combine($keys, $keys);
+    $form['workflow']['options'] = [
+      '#type' => 'checkboxes',
+      '#title' => t('Default options'),
+      '#default_value' => $workflow_options,
+      '#options' => [
+        'new_revision' => t('Create new revision'),
+      ],
+    ];
+
+    $form['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Save'),
+    ];
+
     return $form;
   }
 

--- a/modules/apigee_edge_apidocs/src/Form/ApiDocSettingsForm.php
+++ b/modules/apigee_edge_apidocs/src/Form/ApiDocSettingsForm.php
@@ -76,10 +76,9 @@ class ApiDocSettingsForm extends FormBase {
     $options = $form_state->getValue('options');
     $config->set('default_revision', (bool) $options['new_revision'])->save();
 
-    $args = [
+    $this->messenger()->addStatus($this->t('@type settings have been updated.', [
       '@type' => $entity_type->getLabel(),
-    ];
-    $this->messenger($this->t('@type settings have been updated.', $args));
+    ]));
   }
 
   /**

--- a/modules/apigee_edge_apidocs/tests/src/Kernel/ApidocEntityRevisionsAccessTest.php
+++ b/modules/apigee_edge_apidocs/tests/src/Kernel/ApidocEntityRevisionsAccessTest.php
@@ -93,7 +93,7 @@ class ApidocEntityRevisionsAccessTest extends KernelTestBase {
     $this->entityTypeStorage = $this->entityTypeManager->getStorage('apidoc');
 
     // Create a published apidoc.
-    $apidoc = ApiDoc::create([
+    $apidoc = $this->entityTypeStorage->create([
       'name' => 'API 1',
       'description' => 'Test API v1',
       'spec' => NULL,
@@ -137,7 +137,7 @@ class ApidocEntityRevisionsAccessTest extends KernelTestBase {
    */
   public function testApiDocRevisionsAccessLoggedIn() {
     $user = $this->createUser([]);
-    \Drupal::currentUser()->setAccount($user);
+    $this->container->get('account_switcher')->switchTo($user);
 
     $entity_v1 = $this->entityTypeStorage->loadRevision($this->apidocV1Id);
 
@@ -162,7 +162,7 @@ class ApidocEntityRevisionsAccessTest extends KernelTestBase {
       'edit apidoc entities',
       'revert all apidoc revisions',
     ]);
-    \Drupal::currentUser()->setAccount($user);
+    $this->container->get('account_switcher')->switchTo($user);
 
     $entity_v1 = $this->entityTypeStorage->loadRevision($this->apidocV1Id);
 
@@ -183,7 +183,7 @@ class ApidocEntityRevisionsAccessTest extends KernelTestBase {
     $user = $this->createUser([
       'administer apidoc entities',
     ]);
-    \Drupal::currentUser()->setAccount($user);
+    $this->container->get('account_switcher')->switchTo($user);
 
     $entity_v1 = $this->entityTypeStorage->loadRevision($this->apidocV1Id);
 

--- a/modules/apigee_edge_apidocs/tests/src/Kernel/ApidocEntityRevisionsAccessTest.php
+++ b/modules/apigee_edge_apidocs/tests/src/Kernel/ApidocEntityRevisionsAccessTest.php
@@ -1,0 +1,200 @@
+<?php
+
+/**
+ * Copyright 2019 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\Tests\apigee_edge_apidocs\Kernel;
+
+use Drupal\apigee_edge_apidocs\Entity\ApiDoc;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+
+/**
+ * Tests the ApiDoc entity access permissions.
+ *
+ * @group apigee_edge
+ * @group apigee_edge_apidocs
+ */
+class ApidocEntityRevisionsAccessTest extends KernelTestBase {
+
+  use UserCreationTrait;
+
+  /**
+   * A published API Doc.
+   *
+   * @var \Drupal\apigee_edge_apidocs\Entity\ApiDoc
+   */
+  protected $apidoc;
+
+  /**
+   * An Api Doc revision id.
+   *
+   * @var int
+   */
+  protected $apidocV1Id;
+
+  /**
+   * An Api Doc revision id.
+   *
+   * @var int
+   */
+  protected $apidocV2Id;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The entity type storage instance.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $entityTypeStorage;
+
+  protected static $modules = [
+    'system',
+    'user',
+    'text',
+    'file',
+    'apigee_edge',
+    'key',
+    'apigee_edge_apidocs',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('apidoc');
+    $this->installSchema('system', ['sequences']);
+
+    $this->entityTypeManager = $this->container->get('entity_type.manager');
+    $this->entityTypeStorage = $this->entityTypeManager->getStorage('apidoc');
+
+    // Create a published apidoc.
+    $apidoc = ApiDoc::create([
+      'name' => 'API 1',
+      'description' => 'Test API v1',
+      'spec' => NULL,
+      'api_product' => NULL,
+      'status' => 1,
+    ]);
+    $apidoc->save();
+    $this->apidocV1Id = $apidoc->getRevisionId();
+
+    // Create a new revision.
+    $apidoc->setDescription('Test API v2');
+    $apidoc->setRevisionLogMessage('v2');
+    $apidoc->setNewRevision();
+    $apidoc->save();
+    $this->apidocV2Id = $apidoc->getRevisionId();
+
+    $this->apidoc = $apidoc;
+
+    // Discard user 1, we will not need it because it bypasses access control.
+    $this->createUser();
+  }
+
+  /**
+   * Test ApiDocs revision access as anonymous.
+   */
+  public function testApiDocRevisionsAccessAnon() {
+    $entity_v1 = $this->entityTypeStorage->loadRevision($this->apidocV1Id);
+
+    $tests = [
+      'view' => 'Anonymous should not be able to view an unpublished revision.',
+      'update' => 'Anonymous should not be able to update a revision.',
+    ];
+
+    foreach ($tests as $op => $message) {
+      $this->assertFalse($entity_v1->access($op), $message);
+    }
+  }
+
+  /**
+   * Test ApiDocs revision access a logged in user.
+   */
+  public function testApiDocRevisionsAccessLoggedIn() {
+    $user = $this->createUser([]);
+    \Drupal::currentUser()->setAccount($user);
+
+    $entity_v1 = $this->entityTypeStorage->loadRevision($this->apidocV1Id);
+
+    $tests = [
+      'view' => 'LoggedIn should not be able to view an unpublished revision.',
+      'update' => 'LoggedIn should not be able to update a revision.',
+    ];
+
+    foreach ($tests as $op => $message) {
+      $this->assertFalse($entity_v1->access($op, $user), $message);
+    }
+  }
+
+  /**
+   * Test ApiDocs revision access as a logged in user with some permissions.
+   */
+  public function testApiDocRevisionsAccessPermissions() {
+    $user = $this->createUser([
+      'view published apidoc entities',
+      'view unpublished apidoc entities',
+      'view all apidoc revisions',
+      'edit apidoc entities',
+      'revert all apidoc revisions',
+    ]);
+    \Drupal::currentUser()->setAccount($user);
+
+    $entity_v1 = $this->entityTypeStorage->loadRevision($this->apidocV1Id);
+
+    $tests = [
+      'view' => 'User should be able to view an unpublished revision.',
+      'update' => 'User should be able to update a revision.',
+    ];
+
+    foreach ($tests as $op => $message) {
+      $this->assertTrue($entity_v1->access($op, $user), $message);
+    }
+  }
+
+  /**
+   * Test ApiDocs revision access as a logged in user with admin permissions.
+   */
+  public function testApiDocRevisionsAccessAdmin() {
+    $user = $this->createUser([
+      'administer apidoc entities',
+    ]);
+    \Drupal::currentUser()->setAccount($user);
+
+    $entity_v1 = $this->entityTypeStorage->loadRevision($this->apidocV1Id);
+
+    $tests = [
+      'view' => 'User should be able to view an unpublished revision.',
+      'update' => 'User should be able to update a revision.',
+    ];
+
+    foreach ($tests as $op => $message) {
+      $this->assertTrue($entity_v1->access($op, $user), $message);
+    }
+  }
+
+}

--- a/modules/apigee_edge_apidocs/tests/src/Kernel/ApidocEntityTest.php
+++ b/modules/apigee_edge_apidocs/tests/src/Kernel/ApidocEntityTest.php
@@ -18,7 +18,7 @@
  * MA 02110-1301, USA.
  */
 
-namespace Drupal\Tests\content_entity_example\Kernel;
+namespace Drupal\Tests\apigee_edge_apidocs\Kernel;
 
 use Drupal\apigee_edge_apidocs\Entity\ApiDoc;
 use Drupal\KernelTests\KernelTestBase;

--- a/modules/apigee_edge_apidocs/tests/src/Kernel/ApidocEntityTest.php
+++ b/modules/apigee_edge_apidocs/tests/src/Kernel/ApidocEntityTest.php
@@ -104,7 +104,7 @@ class ApidocEntityTest extends KernelTestBase {
     $entity->setRevisionLogMessage($new_log);
     $entity->save();
     $v2_id = $entity->getRevisionId();
-    $this->assertTrue($v2_id > $v1_id);
+    $this->assertLessThan($v2_id, $v1_id);
 
     // Test saving without a new revision.
     $entity->setDescription('Test API v3');

--- a/modules/apigee_edge_apidocs/tests/src/Kernel/ApidocEntityTest.php
+++ b/modules/apigee_edge_apidocs/tests/src/Kernel/ApidocEntityTest.php
@@ -109,7 +109,7 @@ class ApidocEntityTest extends KernelTestBase {
     // Test saving without a new revision.
     $entity->setDescription('Test API v3');
     $entity->save();
-    $this->assertTrue($v2_id === $entity->getRevisionId());
+    $this->assertEquals($v2_id, $entity->getRevisionId());
 
     // Test that the revision log message wasn't overriden.
     $this->assertEquals($new_log, $entity->getRevisionLogMessage());
@@ -125,7 +125,7 @@ class ApidocEntityTest extends KernelTestBase {
     // Load and check reverted values.
     $this->entityTypeManager->getStorage('apidoc')->resetCache();
     $reverted = ApiDoc::load($entity->id());
-    $this->assertTrue($reverted->getRevisionId() > $v1_id);
+    $this->assertLessThan($reverted->getRevisionId(), $v1_id);
     $this->assertTrue($reverted->isDefaultRevision());
     $this->assertEquals($description_v1, $reverted->getDescription());
   }


### PR DESCRIPTION
This will add revisioning to the API Docs entities:

- A log message when editing.
- Revision history for the entity.
- Viewing past revisions.
- Reverting to past revisions.
- Granular permissions to view and revert revisions.
- Tests.
