### PR TITLE
App analytics timezone fix

### DIFF
--- a/src/Form/AppAnalyticsFormBase.php
+++ b/src/Form/AppAnalyticsFormBase.php
@@ -197,7 +197,7 @@ abstract class AppAnalyticsFormBase extends FormBase {
       '#type' => 'html_tag',
       '#tag' => 'div',
       '#value' => $this->t('Your timezone: @timezone (UTC@offset)', [
-        '@timezone' => $this->currentUser()->getTimeZone(),
+        '@timezone' => drupal_get_user_timezone(),
         '@offset' => $offset,
       ]),
     ];
@@ -224,11 +224,9 @@ abstract class AppAnalyticsFormBase extends FormBase {
     if ($this->validateQueryString($form, $metric, $since, $until)) {
       $form['controls']['metrics']['#default_value'] = $metric;
       $since_datetime = DrupalDatetime::createFromTimestamp($since);
-      $since_datetime->setTimezone(new \Datetimezone($this->currentUser()
-        ->getTimeZone()));
+      $since_datetime->setTimezone(new \Datetimezone(drupal_get_user_timezone()));
       $until_datetime = DrupalDatetime::createFromTimestamp($until);
-      $until_datetime->setTimezone(new \Datetimezone($this->currentUser()
-        ->getTimeZone()));
+      $until_datetime->setTimezone(new \Datetimezone(drupal_get_user_timezone()));
       $form['controls']['since']['#default_value'] = $since_datetime;
       $form['controls']['until']['#default_value'] = $until_datetime;
       $form['controls']['quick_date_picker']['#default_value'] = 'custom';
@@ -353,7 +351,7 @@ abstract class AppAnalyticsFormBase extends FormBase {
       watchdog_exception('apigee_edge', $e);
     }
 
-    $date_time_zone = new \DateTimeZone($this->currentUser()->getTimeZone());
+    $date_time_zone = new \DateTimeZone(drupal_get_user_timezone());
     $timezone_offset = $date_time_zone->getOffset(new \DateTime());
     $form['#attached']['drupalSettings']['analytics']['timezone_offset'] = $timezone_offset / 60;
 

--- a/tests/src/Functional/DeveloperAppAnalyticsTest.php
+++ b/tests/src/Functional/DeveloperAppAnalyticsTest.php
@@ -204,8 +204,9 @@ class DeveloperAppAnalyticsTest extends ApigeeEdgeFunctionalTestBase {
    * Asserts the visited analytics page.
    */
   protected function assertAnalyticsPage() {
+    $timezone = drupal_get_user_timezone();
     $this->assertSession()->pageTextContains("Analytics of {$this->developerApp->label()}");
-    $this->assertSession()->pageTextContains("Your timezone: {$this->loggedInUser->getTimeZone()}");
+    $this->assertSession()->pageTextContains("Your timezone: {$timezone}");
     $this->assertSession()->pageTextContains('No performance data is available for the criteria you supplied.');
     $this->assertSession()->pageTextNotContains('Export CSV');
   }


### PR DESCRIPTION
Automatically fallback to system's timezone if a user's timezone is not defined.

![image](https://user-images.githubusercontent.com/1755573/54840829-25a42880-4cce-11e9-8cc5-6c2e16bb1c93.png)

Travis build: https://travis-ci.org/mxr576/apigee-devportal-drupal/builds/510018190