### PR TITLE
DRUP-530 Fix error when viewing an API product.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,11 @@
             "services": {
                 "drush.services.yml": "^9"
             }
+        },
+        "patches": {
+            "drupal/core": {
+                "EntityViewBuilder::getBuildDefaults doesn't respect the EntityInterface of the $entity parameter": "https://www.drupal.org/files/issues/2019-01-10/2951487_15_no-tests.patch"
+            }
         }
     }
 }


### PR DESCRIPTION
When rendering an API product (such as setting a view mode other than label on the API docs entity), the system returns the error:

> Error: Call to undefined method Drupal\apigee_edge\Entity\ApiProduct::isDefaultRevision() in Drupal\Core\Entity\EntityViewBuilder->getBuildDefaults() (line 181 of /var/www/html/apigee_kickstarter_d8/web/core/lib/Drupal/Core/Entity/EntityViewBuilder.php) 

This is due to a [core bug](https://www.drupal.org/project/drupal/issues/2951487). This PR adds the fix with a patch to composer.