### PR TITLE
DRUP-688 Get around core bug by implementing isDefaultRevision on edge entities

### DIFF
--- a/src/Entity/EdgeEntityBase.php
+++ b/src/Entity/EdgeEntityBase.php
@@ -154,4 +154,24 @@ abstract class EdgeEntityBase extends Entity implements EdgeEntityInterface {
     return $label;
   }
 
+  /**
+   * This is a workaround to avoid a fatal error coming from core.
+   *
+   * Although not needed for Edge Entities, this method is used to get
+   * around core bug, because most of Drupal's core code assumes entities are
+   * either content or config.
+   *
+   * @param bool $new_value
+   *   (optional) This parameter is ignored.
+   *
+   * @return bool
+   *   For Edge Entities this will always return TRUE.
+   *
+   * @see https://www.drupal.org/project/drupal/issues/2951487
+   * @see https://github.com/apigee/apigee-m10n-drupal/issues/79
+   */
+  public function isDefaultRevision($new_value = NULL) {
+    return TRUE;
+  }
+
 }

--- a/src/Entity/EdgeEntityInterface.php
+++ b/src/Entity/EdgeEntityInterface.php
@@ -81,4 +81,29 @@ interface EdgeEntityInterface extends SdkEntityInterface, DrupalEntityInterface 
    */
   public function decorated(): SdkEntityInterface;
 
+  /**
+   * This is a workaround to avoid a fatal error coming from core.
+   *
+   * Although not needed for Edge Entities, this method is used to get
+   * around core bug, because most of Drupal's core code assumes entities are
+   * either content or config.
+   *
+   * @param bool $new_value
+   *   (optional) A Boolean to (re)set the isDefaultRevision flag.
+   *
+   * @return bool
+   *   TRUE if the entity is the default revision, FALSE otherwise. If
+   *   $new_value was passed, the previous value is returned.
+   *
+   * This is a workaround to avoid a fatal error coming from core.
+   *
+   * For Edge Entities this will always return TRUE, and is needed to get
+   * around around a bug because Drupal Core mostly assumes entities are either
+   * content or config.
+   *
+   * @see https://www.drupal.org/project/drupal/issues/2951487
+   * @see https://github.com/apigee/apigee-m10n-drupal/issues/79
+   */
+  public function isDefaultRevision($new_value = NULL);
+
 }


### PR DESCRIPTION
Drupal core assumes entities are revisionable on its EntityViewBuilder. Rather than requiring a core patch, this PR adds an `isDefaultRevision()` method to Edge entities to get around that.

Related:

- https://www.drupal.org/project/drupal/issues/2951487
- https://github.com/apigee/apigee-m10n-drupal/issues/79

**Notes:** when this gets merged, we'll also need to remove the patch from both the Kickstart install profile and apigee_m10n:

- https://github.com/apigee/apigee-m10n-drupal/pull/80
- https://github.com/apigee/apigee-devportal-kickstart-drupal/pull/55
