### PR TITLE
DRUP-688 Revisioning workaround

### DIFF
--- a/src/Entity/FieldableEdgeEntityBase.php
+++ b/src/Entity/FieldableEdgeEntityBase.php
@@ -37,6 +37,12 @@ use Drupal\Core\Field\FieldStorageDefinitionInterface;
  */
 abstract class FieldableEdgeEntityBase extends EdgeEntityBase implements FieldableEdgeEntityInterface {
 
+  // The majority of Drupal core & contrib assumes that if an entity is
+  // fieldable then it must be a content entity and because it is content entity
+  // it also must support revisioning. This incorrect assumption justifies the
+  // reason why this is here.
+  use RevisioningWorkaroundTrait;
+
   /**
    * Whether entity validation is required before saving the entity.
    *
@@ -528,37 +534,6 @@ abstract class FieldableEdgeEntityBase extends EdgeEntityBase implements Fieldab
    */
   public function getIterator() {
     return new \ArrayIterator($this->getFields());
-  }
-
-  /**
-   * This is a workaround to avoid a fatal error coming from the Editor module.
-   *
-   * The editor module assumes that if an entity implements the
-   * FieldableEntityInterface, then it must be a revisionable, like a content
-   * entity, so it calls the getRevisionId(), and fails with a fatal error.
-   *
-   * @see https://www.drupal.org/project/drupal/issues/2942529
-   */
-  public function getRevisionId() {
-    return NULL;
-  }
-
-  /**
-   * Prevents "Call to undefined method" error.
-   *
-   * The Quickedit core module calls this function in
-   * quickedit_entity_view_alter() because the entity view
-   * controller is an instance of the EntitViewController class.
-   *
-   * @return bool
-   *   FALSE return value Prevents quickedit core module
-   *   from modifying the field structure in quickedit_preprocess_field().
-   *
-   * @see quickedit_entity_view_alter()
-   * @see quickedit_preprocess_field()
-   */
-  public function isLatestRevision() {
-    return FALSE;
   }
 
 }

--- a/src/Entity/RevisioningWorkaroundTrait.php
+++ b/src/Entity/RevisioningWorkaroundTrait.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_edge\Entity;
+
+use Drupal\Core\Entity\EntityStorageInterface;
+
+/**
+ * Some Drupal core & contrib modules assumes all entity is revisionable.
+ *
+ * Because all entity is either a content or a contrib entity. Well, this is
+ * not true. The Apigee Edge entities are the perfect counterexamples for this.
+ *
+ * This trait contains some workarounds to make all components happy until
+ * this incorrect assumption hasn't been removed from core and contrib modules.
+ *
+ * @see \Drupal\Core\Entity\RevisionableInterface
+ * @see https://www.drupal.org/project/drupal/issues/2942529
+ * @see https://www.drupal.org/project/drupal/issues/3045384
+ *
+ * @internal
+ */
+trait RevisioningWorkaroundTrait {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isNewRevision() {
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setNewRevision($value = TRUE) {
+    throw new \LogicException('Entity does not support revisions');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRevisionId() {
+    return NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getLoadedRevisionId() {
+    return NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function updateLoadedRevisionId() {
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isDefaultRevision($new_value = NULL) {
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function wasDefaultRevision() {
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isLatestRevision() {
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function preSaveRevision(EntityStorageInterface $storage, \stdClass $record) {
+  }
+
+}

--- a/src/Entity/RevisioningWorkaroundTrait.php
+++ b/src/Entity/RevisioningWorkaroundTrait.php
@@ -33,6 +33,7 @@ use Drupal\Core\Entity\EntityStorageInterface;
  *
  * @see \Drupal\Core\Entity\RevisionableInterface
  * @see https://www.drupal.org/project/drupal/issues/2942529
+ * @see https://www.drupal.org/project/drupal/issues/2951487
  * @see https://www.drupal.org/project/drupal/issues/3045384
  *
  * @internal

--- a/src/Entity/Storage/EdgeEntityStorageBase.php
+++ b/src/Entity/Storage/EdgeEntityStorageBase.php
@@ -190,9 +190,7 @@ abstract class EdgeEntityStorageBase extends DrupalEntityStorageBase implements 
   /**
    * {@inheritdoc}
    */
-  public function deleteRevision($revision_id) {
-    return NULL;
-  }
+  public function deleteRevision($revision_id) {}
 
   /**
    * Returns the wrapped controller instance used by this storage.


### PR DESCRIPTION
Contains a workaround for revisioning support that also can be used to address #171 in a better way.

This trait can be used in entity classes where the revisioning "support" is required for some reasons.

Other related PRs/issues from different projects:
* https://github.com/apigee/apigee-m10n-drupal/pull/80
* https://github.com/apigee/apigee-devportal-kickstart-drupal/pull/55

Latest Travis build: https://travis-ci.org/mxr576/apigee-devportal-drupal/builds/515043910