### PR TITLE
Add RevisioningWorkaroundTrait to ApiProduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,7 @@ module.**
   to make sure Drupal users and Apigee Edge developers are synchronized.
 * This module does not come with an entity view page for API products at this moment. (See
   [#72](https://github.com/apigee/apigee-edge-drupal/issues/72).) Unless you have a custom module enabled that provides
-  this functionality, do not use the "Rendered entity" field formatter on API product entity reference fields because
-  that could lead to a White Screen of Death (WSOD) error. (Related [issue](http://dgo.to/2951487) on Drupal.org)
+  this functionality, do not use the "Rendered entity" field formatter on API product entity reference fields.
 
 ## Requirements
 

--- a/src/Entity/ApiProduct.php
+++ b/src/Entity/ApiProduct.php
@@ -44,6 +44,12 @@ use Apigee\Edge\Structure\AttributesProperty;
  */
 class ApiProduct extends EdgeEntityBase implements ApiProductInterface {
 
+  // The majority of Drupal core & contrib assumes that an entity to be
+  // displayed is a content entity, and because it is a content entity it also
+  // must support revisioning. This incorrect assumption justifies the
+  // reason why this is here.
+  use RevisioningWorkaroundTrait;
+
   /**
    * ApiProduct constructor.
    *

--- a/src/Entity/ApiProduct.php
+++ b/src/Entity/ApiProduct.php
@@ -46,8 +46,9 @@ class ApiProduct extends EdgeEntityBase implements ApiProductInterface {
 
   // The majority of Drupal core & contrib assumes that an entity to be
   // displayed is a content entity, and because it is a content entity it also
-  // must support revisioning. This incorrect assumption justifies the
-  // reason why this is here.
+  // must support revisioning.
+  // Having this trait addresses the following issue in the EntityViewBuilder.
+  // https://www.drupal.org/node/2951487
   use RevisioningWorkaroundTrait;
 
   /**

--- a/src/Entity/RevisioningWorkaroundTrait.php
+++ b/src/Entity/RevisioningWorkaroundTrait.php
@@ -23,9 +23,9 @@ namespace Drupal\apigee_edge\Entity;
 use Drupal\Core\Entity\EntityStorageInterface;
 
 /**
- * Some Drupal core & contrib modules assumes all entity is revisionable.
+ * Some Drupal core & contrib modules assume all entities are revisionable.
  *
- * Because all entity is either a content or a contrib entity. Well, this is
+ * Because all entities are either a content or a contrib entity. Well, this is
  * not true. The Apigee Edge entities are the perfect counterexamples for this.
  *
  * This trait contains some workarounds to make all components happy until


### PR DESCRIPTION
Adding the `RevisioningWorkaroundTrait` to _ApiProduct_ will fix the issue we were having when someone tried to display a product (other than the label). It will also allow removing the a core patch from the Kickstart profile (https://github.com/apigee/apigee-devportal-kickstart-drupal/pull/55).

Related:

- https://github.com/apigee/apigee-edge-drupal/pull/171
- https://github.com/apigee/apigee-edge-drupal/pull/172
