### PR TITLE
GH: Identify Drupal specific file types as PHP files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,9 @@ CONTRIBUTING.md                 export-ignore
 .github                         export-ignore
 .travis                         export-ignore
 tests                           export-ignore
+
+# Drupal specific files should be identified & highlighted as PHP files on Github.
+*.module linguist-language=PHP
+*.install linguist-language=PHP
+*.profile linguist-language=PHP
+*.theme linguist-language=PHP


### PR DESCRIPTION
At this moment there is no syntax-highlighting on Drupal specific files. This small tweak ensures GH identifies these files as PHP files.

After this gets committed the syntax highlighting may not work until someone modifies a Drupal-specific file: https://github.com/github/linguist/issues/4491#issuecomment-481680110

Before:
![image](https://user-images.githubusercontent.com/1755573/55934496-09423e80-5c31-11e9-8df3-5a3c828a54c0.png)

After:
![image](https://user-images.githubusercontent.com/1755573/55934482-f92a5f00-5c30-11e9-8795-3803c209f63d.png)
