### PR TITLE
DRUP-747 SDKConnector refactoring, mock API responses in tests and extra test for Authentication form

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,31 +27,31 @@ env:
     - PHP_VERSION=7.1 DEPENDENCIES="" TEST_ROOT="modules/contrib/apigee_edge/tests"
     - PHP_VERSION=7.1 DEPENDENCIES="" TEST_ROOT="modules/contrib/apigee_edge/tests" DB_DRIVER=pgsql DB_IMAGE=wodby/postgres:9.6-1.3.1
     - PHP_VERSION=7.2 DEPENDENCIES="" TEST_ROOT="modules/contrib/apigee_edge/tests" PHP_IMAGE=wodby/drupal-php:7.2-dev-4.5.0
-    - PHP_VERSION=7.1 DRUPAL_CORE=8.7.x-dev DEPENDENCIES="--prefer-lowest" TEST_ROOT="modules/contrib/apigee_edge/tests"
+    - PHP_VERSION=7.1 DRUPAL_CORE=8.7.x-dev PHP_API_CLIENT_DEV=true DEPENDENCIES="--prefer-lowest" TEST_ROOT="modules/contrib/apigee_edge/tests"
     # Apigee Edge API product RBAC module tests.
     - PHP_VERSION=7.1 DEPENDENCIES="--prefer-lowest" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_apiproduct_rbac/tests"
     - PHP_VERSION=7.1 DEPENDENCIES="" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_apiproduct_rbac/tests"
     - PHP_VERSION=7.1 DEPENDENCIES="" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_apiproduct_rbac/tests" DB_DRIVER=pgsql DB_IMAGE=wodby/postgres:9.6-1.3.1
     - PHP_VERSION=7.2 DEPENDENCIES="" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_apiproduct_rbac/tests" PHP_IMAGE=wodby/drupal-php:7.2-dev-4.5.0
-    - PHP_VERSION=7.1 DRUPAL_CORE=8.7.x-dev DEPENDENCIES="--prefer-lowest" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_apiproduct_rbac/tests"
+    - PHP_VERSION=7.1 DRUPAL_CORE=8.7.x-dev PHP_API_CLIENT_DEV=true DEPENDENCIES="--prefer-lowest" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_apiproduct_rbac/tests"
     # Apigee Edge Teams module tests.
     - PHP_VERSION=7.1 DEPENDENCIES="--prefer-lowest" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_teams/tests"
     - PHP_VERSION=7.1 DEPENDENCIES="" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_teams/tests"
     - PHP_VERSION=7.1 DEPENDENCIES="" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_teams/tests" DB_DRIVER=pgsql DB_IMAGE=wodby/postgres:9.6-1.3.1
     - PHP_VERSION=7.2 DEPENDENCIES="" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_teams/tests" PHP_IMAGE=wodby/drupal-php:7.2-dev-4.5.0
-    - PHP_VERSION=7.1 DRUPAL_CORE=8.7.x-dev DEPENDENCIES="--prefer-lowest" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_teams/tests"
+    - PHP_VERSION=7.1 DRUPAL_CORE=8.7.x-dev PHP_API_CLIENT_DEV=true DEPENDENCIES="--prefer-lowest" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_teams/tests"
     # Apigee Edge API Docs module tests.
     - PHP_VERSION=7.1 DEPENDENCIES="--prefer-lowest" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_apidocs/tests"
     - PHP_VERSION=7.1 DEPENDENCIES="" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_apidocs/tests"
     - PHP_VERSION=7.1 DEPENDENCIES="" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_apidocs/tests" DB_DRIVER=pgsql DB_IMAGE=wodby/postgres:9.6-1.3.1
     - PHP_VERSION=7.2 DEPENDENCIES="" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_apidocs/tests" PHP_IMAGE=wodby/drupal-php:7.2-dev-4.5.0
-    - PHP_VERSION=7.1 DRUPAL_CORE=8.7.x-dev DEPENDENCIES="--prefer-lowest" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_apidocs/tests"
+    - PHP_VERSION=7.1 DRUPAL_CORE=8.7.x-dev PHP_API_CLIENT_DEV=true DEPENDENCIES="--prefer-lowest" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_apidocs/tests"
 matrix:
   allow_failures:
-    - env: PHP_VERSION=7.1 DRUPAL_CORE=8.7.x-dev DEPENDENCIES="--prefer-lowest" TEST_ROOT="modules/contrib/apigee_edge/tests"
-    - env: PHP_VERSION=7.1 DRUPAL_CORE=8.7.x-dev DEPENDENCIES="--prefer-lowest" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_apiproduct_rbac/tests"
-    - env: PHP_VERSION=7.1 DRUPAL_CORE=8.7.x-dev DEPENDENCIES="--prefer-lowest" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_teams/tests"
-    - env: PHP_VERSION=7.1 DRUPAL_CORE=8.7.x-dev DEPENDENCIES="--prefer-lowest" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_apidocs/tests"
+    - env: PHP_VERSION=7.1 DRUPAL_CORE=8.7.x-dev PHP_API_CLIENT_DEV=true DEPENDENCIES="--prefer-lowest" TEST_ROOT="modules/contrib/apigee_edge/tests"
+    - env: PHP_VERSION=7.1 DRUPAL_CORE=8.7.x-dev PHP_API_CLIENT_DEV=true DEPENDENCIES="--prefer-lowest" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_apiproduct_rbac/tests"
+    - env: PHP_VERSION=7.1 DRUPAL_CORE=8.7.x-dev PHP_API_CLIENT_DEV=true DEPENDENCIES="--prefer-lowest" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_teams/tests"
+    - env: PHP_VERSION=7.1 DRUPAL_CORE=8.7.x-dev PHP_API_CLIENT_DEV=true DEPENDENCIES="--prefer-lowest" TEST_ROOT="modules/contrib/apigee_edge/modules/apigee_edge_apidocs/tests"
   fast_finish: true
 
 # TODO Cache Docker images and PHP service build (common parts of the built, like Drupal core install, for a day).

--- a/.travis/docker-compose.override.yml
+++ b/.travis/docker-compose.override.yml
@@ -10,6 +10,7 @@ services:
       - log:/mnt/files/log
     environment:
       DRUPAL_CORE: ${DRUPAL_CORE:-}
+      PHP_API_CLIENT_DEV: ${PHP_API_CLIENT_DEV:-false}
       DEPENDENCIES: ${DEPENDENCIES:-}
       # We can not pass these environment variables with `docker-compose run -e` until
       # this has not been improved. https://github.com/wodby/php/pull/21#issuecomment-361200733

--- a/.travis/prepare-test-env.sh
+++ b/.travis/prepare-test-env.sh
@@ -40,6 +40,15 @@ if [[ -n "${DRUPAL_CORE}" ]]; then
   composer require drupal/core:${DRUPAL_CORE} webflo/drupal-core-require-dev:${DRUPAL_CORE} ${COMPOSER_GLOBAL_OPTIONS};
 fi
 
+# Allow to run tests with the latest dev version of the Apigee PHP API Client.
+if [[ "${PHP_API_CLIENT_DEV}" = true ]]; then
+  # Little trick that fakes the latest dev version as the latest tagged version
+  # in the 2.x branch.
+  composer require apigee/apigee-client-php:"2.x-dev as 2.1024.0" ${COMPOSER_GLOBAL_OPTIONS};
+  # For some reasons without this the client files does not get registered.
+  composer update none
+fi
+
 # Downgrade dependencies if needed.
 # (This fix is necessary since PR#130 had been merged because after that lowest
 # builds started to fail. Probably caused by a merge plugin issue because this

--- a/apigee_edge.services.yml
+++ b/apigee_edge.services.yml
@@ -15,7 +15,7 @@ services:
 
   apigee_edge.sdk_connector:
     class: Drupal\apigee_edge\SDKConnector
-    arguments: ['@http_client_factory', '@key.repository', '@config.factory', '@module_handler', '@info_parser']
+    arguments: ['@http_client_factory', '@key.repository', '@config.factory', '@module_handler', '@info_parser', '@service_container']
 
   apigee_edge.key_entity_form_enhancer:
     class: Drupal\apigee_edge\KeyEntityFormEnhancer

--- a/apigee_edge.services.yml
+++ b/apigee_edge.services.yml
@@ -15,7 +15,7 @@ services:
 
   apigee_edge.sdk_connector:
     class: Drupal\apigee_edge\SDKConnector
-    arguments: ['@http_client_factory', '@key.repository', '@entity_type.manager', '@config.factory', '@module_handler', '@info_parser']
+    arguments: ['@http_client_factory', '@key.repository', '@config.factory', '@module_handler', '@info_parser']
 
   apigee_edge.key_entity_form_enhancer:
     class: Drupal\apigee_edge\KeyEntityFormEnhancer

--- a/modules/apigee_edge_debug/apigee_edge_debug.services.yml
+++ b/modules/apigee_edge_debug/apigee_edge_debug.services.yml
@@ -8,7 +8,7 @@ services:
     decorates: apigee_edge.sdk_connector
     decoration_priority: -10
     public: false
-    arguments: ['@apigee_edge_debug.sdk_connector.inner', '@http_client_factory', '@key.repository', '@entity_type.manager',  '@config.factory', '@module_handler', '@info_parser']
+    arguments: ['@apigee_edge_debug.sdk_connector.inner']
     properties:
       # Without this property for decorated services, serialization will fail. @see: https://www.drupal.org/project/drupal/issues/2536370
       _serviceId: apigee_edge.sdk_connector

--- a/modules/apigee_edge_debug/src/SDKConnector.php
+++ b/modules/apigee_edge_debug/src/SDKConnector.php
@@ -23,6 +23,7 @@ namespace Drupal\apigee_edge_debug;
 use Apigee\Edge\ClientInterface;
 use Drupal\apigee_edge\SDKConnector as OriginalSDKConnector;
 use Drupal\apigee_edge\SDKConnectorInterface;
+use Drupal\Component\Utility\NestedArray;
 use Drupal\key\KeyInterface;
 use Http\Message\Authentication;
 
@@ -92,7 +93,7 @@ final class SDKConnector implements SDKConnectorInterface {
       return $this->defaultClient;
     }
 
-    return $this->innerService->getClient($authentication, $endpoint, array_merge($options, $extra_options));
+    return $this->innerService->getClient($authentication, $endpoint, NestedArray::mergeDeep($options, $extra_options));
   }
 
   /**

--- a/src/OauthAuthentication.php
+++ b/src/OauthAuthentication.php
@@ -35,7 +35,7 @@ class OauthAuthentication extends Oauth {
   protected function authClient(): ClientInterface {
     /** @var \Drupal\apigee_edge\SDKConnectorInterface $sdk_connector */
     $sdk_connector = \Drupal::service('apigee_edge.sdk_connector');
-    return $sdk_connector->buildClient(new BasicAuth($this->clientId, $this->clientSecret), $this->auth_server);
+    return $sdk_connector->getClient(new BasicAuth($this->clientId, $this->clientSecret), $this->auth_server);
   }
 
 }

--- a/src/SDKConnectorInterface.php
+++ b/src/SDKConnectorInterface.php
@@ -29,45 +29,43 @@ use Http\Message\Authentication;
 interface SDKConnectorInterface {
 
   /**
-   * Gets the organization.
+   * Gets the organization used by the API client.
    *
    * @return string
-   *   The organization.
+   *   The organization or an empty string if the Apigee Edge authentication
+   *   key has not been saved yet.
    */
   public function getOrganization(): string;
 
   /**
-   * Returns the http client.
+   * Returns a pre-configured API client.
+   *
+   * @param null|\Http\Message\Authentication $authentication
+   *   The authentication method, default is retrieved from the active key.
+   * @param null|string $endpoint
+   *   API endpoint, default is https://api.enterprise.apigee.com/v1.
+   * @param array $options
+   *   The API Client configuration options.
    *
    * @return \Apigee\Edge\ClientInterface
-   *   The http client.
+   *   The API client.
+   *
+   * @throws \Drupal\apigee_edge\Exception\AuthenticationKeyException
+   *   If the API client could not be built, ex.: missing Apigee Edge
+   *   authentication key.
    */
-  public function getClient(): ClientInterface;
+  public function getClient(?Authentication $authentication = NULL, ?string $endpoint = NULL, array $options = []): ClientInterface;
 
   /**
    * Test connection with the Edge Management Server.
    *
    * @param \Drupal\key\KeyInterface|null $key
-   *   Key entity to check connection with Edge,
-   *   if NULL, then use the stored key.
+   *   Key entity with Apigee Edge credentials or NULL if the saved key should
+   *   be used.
    *
-   * @throws \Exception
+   * @throws \Drupal\apigee_edge\Exception\AuthenticationKeyException
+   *   If the authentication fails with the saved- or provided key.
    */
-  public function testConnection(KeyInterface $key = NULL);
-
-  /**
-   * Returns a pre-configured API client with the provided credentials.
-   *
-   * @param \Http\Message\Authentication $authentication
-   *   Authentication.
-   * @param null|string $endpoint
-   *   API endpoint, default is https://api.enterprise.apigee.com/v1.
-   * @param array $options
-   *   Client configuration option.
-   *
-   * @return \Apigee\Edge\ClientInterface
-   *   Configured API client.
-   */
-  public function buildClient(Authentication $authentication, ?string $endpoint = NULL, array $options = []): ClientInterface;
+  public function testConnection(KeyInterface $key = NULL): void;
 
 }

--- a/tests/modules/apigee_edge_test/apigee_edge_test.services.yml
+++ b/tests/modules/apigee_edge_test/apigee_edge_test.services.yml
@@ -27,6 +27,18 @@ services:
       # Without this property for decorated services, serialization will fail. @see: https://www.drupal.org/project/drupal/issues/2536370
       _serviceId: apigee_edge.sdk_connector
 
+  apigee_edge_test.http_middleware.mock_api_request:
+    class: Drupal\apigee_edge_test\HttpClientMiddleware\MockApiRequestEventDispatcher
+    arguments: ['@event_dispatcher']
+    tags:
+      - { name: http_client_middleware }
+
+  apigee_edge_test.mock_api_request_subscriber.api_response_from_state:
+    class: Drupal\apigee_edge_test\EventSubscriber\MockApiRequestSubscriber\ApiResponseFromState
+    arguments: ['@state', '@settings']
+    tags:
+      - { name: event_subscriber }
+
   apigee_edge_test.converter.user_developer:
     class: Drupal\apigee_edge_test\UserDeveloperConverter
     decorates: apigee_edge.converter.user_developer

--- a/tests/modules/apigee_edge_test/apigee_edge_test.services.yml
+++ b/tests/modules/apigee_edge_test/apigee_edge_test.services.yml
@@ -22,7 +22,7 @@ services:
     decorates: apigee_edge_debug.sdk_connector
     decoration_priority: 0
     public: false
-    arguments: ['@apigee_edge_test.sdk_connector.inner', '@logger.channel.apigee_edge_test', '@http_client_factory', '@key.repository', '@entity_type.manager', '@config.factory', '@module_handler', '@info_parser']
+    arguments: ['@apigee_edge_test.sdk_connector.inner', '@logger.channel.apigee_edge_test']
     properties:
       # Without this property for decorated services, serialization will fail. @see: https://www.drupal.org/project/drupal/issues/2536370
       _serviceId: apigee_edge.sdk_connector

--- a/tests/modules/apigee_edge_test/src/Event/ApiRequestEvent.php
+++ b/tests/modules/apigee_edge_test/src/Event/ApiRequestEvent.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_edge_test\Event;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * A mock-able API request event to the Apigee backend.
+ *
+ * An event subscriber (mock API request subscriber) can decide whether it
+ * reacts to an API request or not. Every API request subscriber gets called for
+ * an API request - unless stopPropagation() method had been called on an event
+ * by a subscriber which aborts the execution of further subscribers - multiple
+ * subscriber can perform an action for a request but only one mock API response
+ * gets return to an API request.
+ *
+ * @see \Drupal\apigee_edge_test\HttpClientMiddleware\MockApiRequestEventDispatcher
+ */
+final class ApiRequestEvent extends Event {
+
+  /**
+   * The event name.
+   *
+   * @var string
+   */
+  public const EVENT_NAME = 'apigee_edge_test.mock_http_request_event';
+
+  /**
+   * A mock API response if any.
+   *
+   * @var \Psr\Http\Message\ResponseInterface|null
+   */
+  protected $response;
+
+  /**
+   * The API request.
+   *
+   * @var \Psr\Http\Message\RequestInterface
+   */
+  private $request;
+
+  /**
+   * ApiRequestEvent constructor.
+   *
+   * @param \Psr\Http\Message\RequestInterface $request
+   *   The API request.
+   */
+  public function __construct(RequestInterface $request) {
+    $this->request = $request;
+  }
+
+  /**
+   * The API request.
+   *
+   * @return \Psr\Http\Message\RequestInterface
+   *   The API request.
+   */
+  public function getRequest(): RequestInterface {
+    return $this->request;
+  }
+
+  /**
+   * The mock API response, if any.
+   *
+   * @return \Psr\Http\Message\ResponseInterface|null
+   *   The mock API response for the request or null.
+   */
+  public function getResponse(): ?ResponseInterface {
+    return $this->response;
+  }
+
+  /**
+   * The mock API response for a request.
+   *
+   * @param \Psr\Http\Message\ResponseInterface|null $response
+   *   The mock API response or null if there is no response.
+   */
+  public function setResponse(?ResponseInterface $response): void {
+    $this->response = $response;
+  }
+
+}

--- a/tests/modules/apigee_edge_test/src/EventSubscriber/MockApiRequestSubscriber/ApiResponseFromState.php
+++ b/tests/modules/apigee_edge_test/src/EventSubscriber/MockApiRequestSubscriber/ApiResponseFromState.php
@@ -1,0 +1,165 @@
+<?php
+
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_edge_test\EventSubscriber\MockApiRequestSubscriber;
+
+use Drupal\apigee_edge_test\Event\ApiRequestEvent;
+use Drupal\Core\Site\Settings;
+use Drupal\Core\State\State;
+use GuzzleHttp\Psr7;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Returns mock API responses from the Drupal State key-value store.
+ *
+ * It uses the State as a FIFO storage.
+ */
+final class ApiResponseFromState implements EventSubscriberInterface {
+
+  /**
+   * The settings that controls whether mocked requests get captured or not.
+   *
+   * @var string
+   */
+  public const SETTINGS_CAPTURE_REQUESTS = 'apigee_edge_test_state_response_provider_capture_requests';
+
+  /**
+   * The key that this provider uses as storage for mock responses.
+   *
+   * @var string
+   */
+  private const STATE_KEY_RESPONSE_STORAGE = 'apigee_edge_test.mock_response_provider.state.response_storage';
+
+  /**
+   * The key that this provider uses as storage to captured mocked requests.
+   *
+   * @var string
+   */
+  private const STATE_KEY_REQUEST_STORAGE = 'apigee_edge_test.mock_response_provider.state.request_storage';
+
+  /**
+   * The state backend.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  private $state;
+
+  /**
+   * Settings.
+   *
+   * @var \Drupal\Core\Site\Settings
+   */
+  private $settings;
+
+  /**
+   * ApiResponseFromState constructor.
+   *
+   * @param \Drupal\Core\State\State $state
+   *   The state backend.
+   * @param \Drupal\Core\Site\Settings $settings
+   *   Settings.
+   */
+  public function __construct(State $state, Settings $settings) {
+    $this->state = $state;
+    $this->settings = $settings;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      ApiRequestEvent::EVENT_NAME => 'handle',
+    ];
+  }
+
+  /**
+   * Returns a mock API response from the state storage if it is not empty.
+   *
+   * @param \Drupal\apigee_edge_test\Event\ApiRequestEvent $event
+   *   The API request event.
+   */
+  public function handle(ApiRequestEvent $event): void {
+    $queued_responses = $this->getQueuedResponses();
+    if (!empty($queued_responses)) {
+      /** @var \Psr\Http\Message\ResponseInterface $response */
+      $response = array_shift($queued_responses);
+      $response = Psr7\parse_response($response);
+      $event->setResponse($response);
+      $this->state->set(static::STATE_KEY_RESPONSE_STORAGE, $queued_responses);
+      if ($this->settings->get(static::SETTINGS_CAPTURE_REQUESTS, FALSE)) {
+        $request_storage = $this->state->get(static::STATE_KEY_REQUEST_STORAGE, []);
+        $request_storage[] = Psr7\str($event->getRequest());
+        $this->state->set(static::STATE_KEY_REQUEST_STORAGE, $request_storage);
+      }
+      // Do not call other providers because either a request-independent API
+      // response is available in the storage or there should not be any
+      // response in the storage.
+      $event->stopPropagation();
+    }
+  }
+
+  /**
+   * Adds an API response to the queue.
+   *
+   * @param \Psr\Http\Message\ResponseInterface $response
+   *   A mock API response.
+   */
+  public function queueResponse(ResponseInterface $response): void {
+    // We must clear the static cache here because items can stack in there in
+    // tests.
+    $this->state->resetCache();
+    $queued_responses = $this->state->get(static::STATE_KEY_RESPONSE_STORAGE, []);
+    $queued_responses[] = Psr7\str($response);
+    $this->state->set(static::STATE_KEY_RESPONSE_STORAGE, $queued_responses);
+  }
+
+  /**
+   * Returns queued API responses.
+   *
+   * @return \Psr\Http\Message\ResponseInterface[]
+   *   Mock API responses in the queue.
+   */
+  public function getQueuedResponses(): array {
+    return $this->state->get(static::STATE_KEY_RESPONSE_STORAGE, []);
+  }
+
+  /**
+   * Clears queued mock API responses and captured mocked API requests.
+   */
+  public function clear(): void {
+    $this->state->delete(static::STATE_KEY_RESPONSE_STORAGE);
+    $this->state->delete(static::STATE_KEY_REQUEST_STORAGE);
+  }
+
+  /**
+   * Returns mocked API requests that got mocked if capturing was enabled.
+   *
+   * @return \Psr\Http\Message\RequestInterface[]
+   *   Captured API requests that got mocked.
+   */
+  public function getMockedRequests(): array {
+    return array_map(static function (string $item) {
+      return Psr7\parse_request($item);
+    }, $this->state->get(static::STATE_KEY_REQUEST_STORAGE, []));
+  }
+
+}

--- a/tests/modules/apigee_edge_test/src/HttpClientMiddleware/MockApiRequestEventDispatcher.php
+++ b/tests/modules/apigee_edge_test/src/HttpClientMiddleware/MockApiRequestEventDispatcher.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Copyright 2018 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_edge_test\HttpClientMiddleware;
+
+use Drupal\apigee_edge_test\Event\ApiRequestEvent;
+use Drupal\apigee_edge_test\SDKConnector;
+use GuzzleHttp\Promise\FulfilledPromise;
+use Psr\Http\Message\RequestInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * Allows to mock Apigee API requests.
+ */
+final class MockApiRequestEventDispatcher {
+
+  /**
+   * The event dispatcher.
+   *
+   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+   */
+  private $eventDispatcher;
+
+  /**
+   * MockApiRequestEventDispatcher constructor.
+   *
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
+   *   The event dispatcher.
+   */
+  public function __construct(EventDispatcherInterface $event_dispatcher) {
+    $this->eventDispatcher = $event_dispatcher;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __invoke() {
+    return function (callable $handler) {
+      return function (RequestInterface $request, array $options) use ($handler) {
+        if ($request->hasHeader(SDKConnector::HEADER)) {
+          $event = new ApiRequestEvent($request);
+          $this->eventDispatcher->dispatch(ApiRequestEvent::EVENT_NAME, $event);
+
+          if ($event->getResponse()) {
+            return new FulfilledPromise($event->getResponse());
+          }
+        }
+
+        // No mock API subscriber provided a mock response for this HTTP
+        // request. Let's call the real API backend.
+        return $handler($request, $options);
+      };
+    };
+  }
+
+}

--- a/tests/modules/apigee_edge_test/src/SDKConnector.php
+++ b/tests/modules/apigee_edge_test/src/SDKConnector.php
@@ -23,68 +23,88 @@ namespace Drupal\apigee_edge_test;
 use Apigee\Edge\Client;
 use Apigee\Edge\ClientInterface;
 use Apigee\Edge\Exception\ApiResponseException;
-use Drupal\apigee_edge\SDKConnector as DecoratedSDKConnector;
 use Drupal\apigee_edge\SDKConnectorInterface;
-use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Extension\InfoParserInterface;
-use Drupal\Core\Extension\ModuleHandlerInterface;
-use Drupal\Core\Http\ClientFactory;
-use Drupal\Core\Logger\LoggerChannelInterface;
-use Drupal\key\KeyRepositoryInterface;
+use Drupal\key\KeyInterface;
 use Http\Client\Exception;
 use Http\Message\Authentication;
 use Psr\Http\Message\RequestInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Service decorator for SDKConnector.
  */
-final class SDKConnector extends DecoratedSDKConnector implements SDKConnectorInterface {
+final class SDKConnector implements SDKConnectorInterface {
 
   /**
    * The decorated SDK connector service.
    *
-   * @var \Drupal\apigee_edge\SDKConnector
+   * @var \Drupal\apigee_edge\SDKConnectorInterface
    */
   private $innerService;
 
   /**
    * A logger instance.
    *
-   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   * @var \Psr\Log\LoggerInterface
    */
   private $logger;
+
+  /**
+   * The API client initialized from the saved credentials and default config.
+   *
+   * @var null|\Apigee\Edge\ClientInterface
+   *
+   * @see getClient()
+   */
+  private $defaultClient;
 
   /**
    * Constructs a new SDKConnector.
    *
    * @param \Drupal\apigee_edge\SDKConnectorInterface $inner_service
    *   The decorated SDK connector service.
-   * @param \Drupal\Core\Logger\LoggerChannelInterface $logger
-   *   Logger interface.
-   * @param \Drupal\Core\Http\ClientFactory $clientFactory
-   *   Http client.
-   * @param \Drupal\key\KeyRepositoryInterface $key_repository
-   *   The key repository.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   Entity type manager service.
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The factory for configuration objects.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $moduleHandler
-   *   Module handler service.
-   * @param \Drupal\Core\Extension\InfoParserInterface $infoParser
-   *   Info file parser service.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The logger.
    */
-  public function __construct(SDKConnectorInterface $inner_service, LoggerChannelInterface $logger, ClientFactory $clientFactory, KeyRepositoryInterface $key_repository, EntityTypeManagerInterface $entity_type_manager, ConfigFactoryInterface $config_factory, ModuleHandlerInterface $moduleHandler, InfoParserInterface $infoParser) {
+  public function __construct(SDKConnectorInterface $inner_service, LoggerInterface $logger) {
     $this->innerService = $inner_service;
     $this->logger = $logger;
-    parent::__construct($clientFactory, $key_repository, $entity_type_manager, $config_factory, $moduleHandler, $infoParser);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function buildClient(Authentication $authentication, ?string $endpoint = NULL, array $options = []): ClientInterface {
+  public function getOrganization(): string {
+    return $this->innerService->getOrganization();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getClient(?Authentication $authentication = NULL, ?string $endpoint = NULL, array $options = []): ClientInterface {
+    // If method got called without default parameters, initialize and/or
+    // return the default API client from the internal cache.
+    if (!isset($authentication, $endpoint) && empty($options)) {
+      if ($this->defaultClient === NULL) {
+        $this->defaultClient = $this->innerService->getClient($authentication, $endpoint, $this->getOptionsWithRetryPlugin($options));
+      }
+
+      return $this->defaultClient;
+    }
+
+    return $this->innerService->getClient($authentication, $endpoint, $this->getOptionsWithRetryPlugin($options));
+  }
+
+  /**
+   * Returns the options array with the retry decider plugin.
+   *
+   * @param array $options
+   *   Array if API client options.
+   *
+   * @return array
+   *   Array of API client options.
+   */
+  private function getOptionsWithRetryPlugin(array $options): array {
     $decider = function (RequestInterface $request, Exception $e) {
       // Only retry API calls that failed with this specific error.
       if ($e instanceof ApiResponseException && $e->getEdgeErrorCode() === 'messaging.adaptors.http.flow.ApplicationNotFound') {
@@ -99,11 +119,11 @@ final class SDKConnector extends DecoratedSDKConnector implements SDKConnectorIn
       return FALSE;
     };
     // Use the retry plugin in tests.
-    return $this->innerService->buildClient($authentication, $endpoint, [
+    return array_merge($options, [
       Client::CONFIG_RETRY_PLUGIN_CONFIG => [
         'retries' => 5,
         'exception_decider' => $decider,
-        'exception_delay' => function (RequestInterface $request, Exception $e, $retries) : int {
+        'exception_delay' => static function (RequestInterface $request, Exception $e, $retries) : int {
           return $retries * 15000000;
         },
       ],
@@ -113,8 +133,8 @@ final class SDKConnector extends DecoratedSDKConnector implements SDKConnectorIn
   /**
    * {@inheritdoc}
    */
-  protected function httpClientConfiguration(): array {
-    return $this->innerService->httpClientConfiguration();
+  public function testConnection(KeyInterface $key = NULL): void {
+    $this->innerService->testConnection($key);
   }
 
 }

--- a/tests/src/FunctionalJavascript/Form/AuthenticationFormJsTest.php
+++ b/tests/src/FunctionalJavascript/Form/AuthenticationFormJsTest.php
@@ -312,7 +312,6 @@ class AuthenticationFormJsTest extends ApigeeEdgeFunctionalJavascriptTestBase {
     // Press the Save/Save configuration button and save invalid credentials.
     $this->pressKeySaveButton('op', $visitFormAsAdmin);
     // END OF EDGE CASE 1.
-
     // Fill in the form with valid credentials again.
     $page->fillField('Username', $this->username);
     $page->fillField('Password', $this->password);

--- a/tests/src/FunctionalJavascript/Form/AuthenticationFormJsTest.php
+++ b/tests/src/FunctionalJavascript/Form/AuthenticationFormJsTest.php
@@ -285,7 +285,7 @@ class AuthenticationFormJsTest extends ApigeeEdgeFunctionalJavascriptTestBase {
     $random_username = $this->randomMachineName() . '@example.com';
     $random_pass = $this->randomMachineName();
     $random_org = $this->randomMachineName();
-    $random_endpoint = "http://{$this->randomGenerator->word(16)}.example.com";
+    $random_endpoint = "http://{$this->randomGenerator->word(16)}.example.com/v1";
     $page->fillField('Username', $random_username);
     $page->fillField('Password', $random_pass);
     $page->fillField('Organization', $random_org);
@@ -341,10 +341,10 @@ class AuthenticationFormJsTest extends ApigeeEdgeFunctionalJavascriptTestBase {
 
     // Test invalid endpoint.
     $invalid_domain = "{$this->randomGenerator->word(16)}.example.com";
-    $page->fillField('Apigee Edge endpoint', "http://{$invalid_domain}/");
-    $this->assertSendRequestMessage('.messages--error', "Failed to connect to Apigee Edge. The given endpoint (http://{$invalid_domain}/) is incorrect or something is wrong with the connection. Error message: ");
-    $web_assert->elementContains('css', 'textarea[data-drupal-selector="edit-debug-text"]', "\"endpoint\": \"http:\/\/{$invalid_domain}\/\"");
-    $web_assert->fieldValueEquals('Apigee Edge endpoint', "http://{$invalid_domain}/");
+    $page->fillField('Apigee Edge endpoint', "http://{$invalid_domain}/v1");
+    $this->assertSendRequestMessage('.messages--error', "Failed to connect to Apigee Edge. The given endpoint (http://{$invalid_domain}/v1) is incorrect or something is wrong with the connection. Error message: ");
+    $web_assert->elementContains('css', 'textarea[data-drupal-selector="edit-debug-text"]', "\"endpoint\": \"http:\/\/{$invalid_domain}\/v1\"");
+    $web_assert->fieldValueEquals('Apigee Edge endpoint', "http://{$invalid_domain}/v1");
     $page->fillField('Apigee Edge endpoint', '');
 
     // Test invalid authorization server.


### PR DESCRIPTION
For DRUP-747 we have to be able to replace the API client returned by the SDKConnector in a test. This could be possible without refactoring it but it is better for everyone if we do a last refactoring on the SDKConnector service before the stable release.

I wanted to do this refactoring for a long time ago this seems the best time to do that. These changes simplify the logic, apply OOP- and service decorator best practices on the SDKConnector. Because 99% of code relies on the SdkConnector::getClient() method this is a smaller BC breaking change.

Check the commit message for more details.

Latest Travis build: https://travis-ci.org/mxr576/apigee-devportal-drupal/builds/535298059