### PR TITLE
[DRUP-738] Rename the default RBAC attribute value from `APIGEE_EDGE_…

### DIFF
--- a/modules/apigee_edge_apiproduct_rbac/config/install/apigee_edge_apiproduct_rbac.settings.yml
+++ b/modules/apigee_edge_apiproduct_rbac/config/install/apigee_edge_apiproduct_rbac.settings.yml
@@ -1,3 +1,3 @@
 langcode: en
-attribute_name: 'APIGEE_EDGE_APIPRODUCT_RBAC'
+attribute_name: 'DRUPAL_RBAC'
 grant_access_if_attribute_missing: false


### PR DESCRIPTION
…APIPRODUCT_RBAC` to `DRUPAL_RBAC`.