### PR TITLE
[DRUP-724] Update requirements, installation and patches section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,9 @@ considered to be in development. Experimental modules are included in the "Apige
   
 ## Applying Patches
 
-The Apigee Edge module may require Drupal core or contributed module
-patches to be able to work properly. These patches can be applied
-automatically when Apigee Edge module gets installed but for that your
-Drupal installation must fulfill the following requirements:
+The Apigee Edge module may require Drupal core or contributed module patches to be able to work properly. These patches
+can be applied automatically when Apigee Edge module gets installed but for that your Drupal installation must fulfill 
+the following requirements:
 
 1. [cweagans/composer-patches](https://packagist.org/packages/cweagans/composer-patches) >= 1.6.5 has to be installed.
 2. ["Allowing patches to be applied from dependencies
@@ -74,9 +73,8 @@ for drupal/core has to be set in Drupal's composer.json.
 You can find the currently required patches, if any, in the Apigee Edge module's [composer.json](https://github.com/apigee/apigee-edge-drupal/blob/8.x-1.x/composer.json)
 and in the Apigee Edge PHP API Client's [composer.json](https://github.com/apigee/apigee-client-php/blob/2.x/composer.json).
 
-**If you do not have all required patches applied in your Drupal
-installation you may experience some problems with the Apigee Edge
-module.**
+**If you do not have all required patches applied in your Drupal installation you may experience some problems with the 
+Apigee Edge module.**
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -24,29 +24,15 @@ Following the same concept of [Drupal 8 Experimental modules](https://www.drupal
 some submodules are marked as "Experimental". They are provided for evaluation and testing purposes but are still 
 considered to be in development. Experimental modules are included in the "Apigee (Experimental)" package
  on the "Extend" page of a Drupal site (/admin/modules).
+ 
+## Requirements
+
+* The Apigee Edge module requires **Drupal 8.7.x** or higher and PHP 7.1 or higher.
+* Drupal 8's minimum requirement is phpdocumentor/reflection-docblock:2.0.4 but at least 3.0 is required by this module. If you get the error  "Your requirements could not be resolved to an installable set of packages" it may be because you are running reflection-docblock version 2. You can update `phpdocumentor/reflection-docblock` with the following command: `composer update phpdocumentor/reflection-docblock --with-dependencies`.
+* **Check [composer.json](https://github.com/apigee/apigee-edge-drupal/blob/8.x-1.x/composer.json) for any required patches.** Patches prefixed with "(For testing)" are only required for running tests. Those are not necessary for using this module. Patches can be applied with the [cweagans/composer-patches](https://packagist.org/packages/cweagans/composer-patches) plugin automatically or manually. See [Applying Patches](#applying-patches) section below.
+* (For developers) The locked commit from `behat/mink` library is required otherwise tests may fail. This caused by a Drupal core [bug](https://www.drupal.org/project/drupal/issues/2956279). See the related pull request for behat/mink [here](https://github.com/minkphp/Mink/pull/760).
 
 ## Installing
-
-**Note**: The Apigee Edge module requires Drupal 8.6.x or higher and PHP 7.1 or higher.
-
-The Apigee Edge module may require Drupal core or contributed module
-patches to be able to work properly. These patches can be applied
-automatically when Apigee Edge module gets installed but for that your
-Drupal installation must fulfill the following requirements:
-
-1. [cweagans/composer-patches](https://packagist.org/packages/cweagans/composer-patches) >= 1.6.5 has to be installed.
-2. ["Allowing patches to be applied from dependencies
-"](https://github.com/cweagans/composer-patches/tree/1.6.5#allowing-patches-to-be-applied-from-dependencies)
-has to be enabled in Drupal's composer.json.
-3. Proper [patch level](https://github.com/cweagans/composer-patches/pull/101#issue-104810467)
-for drupal/core has to be set in Drupal's composer.json.
-
-You can find the currently required patches in the Apigee Edge module's [composer.json](https://github.com/apigee/apigee-edge-drupal/blob/8.x-1.x/composer.json)
-and in the Apigee Edge PHP API Client's [composer.json](https://github.com/apigee/apigee-client-php/blob/2.x/composer.json).
-
-**If you do not have all required patches applied in your Drupal
-installation you may experience some problems with the Apigee Edge
-module.**
 
 1. Install the Apigee Edge module using [Composer](https://getcomposer.org/).
   Composer will download the Apigee Edge module and all its dependencies.
@@ -73,12 +59,27 @@ module.**
 * This module does not come with an entity view page for API products at this moment. (See
   [#72](https://github.com/apigee/apigee-edge-drupal/issues/72).) Unless you have a custom module enabled that provides
   this functionality, do not use the "Rendered entity" field formatter on API product entity reference fields.
+  
+## Applying Patches
 
-## Requirements
+The Apigee Edge module may require Drupal core or contributed module
+patches to be able to work properly. These patches can be applied
+automatically when Apigee Edge module gets installed but for that your
+Drupal installation must fulfill the following requirements:
 
-* Drupal 8's minimum requirement is phpdocumentor/reflection-docblock:2.0.4 but at least 3.0 is required by this module. If you get the error  "Your requirements could not be resolved to an installable set of packages" it may be because you are running reflection-docblock version 2. You can update `phpdocumentor/reflection-docblock` with the following command: `composer update phpdocumentor/reflection-docblock --with-dependencies`.
-* **Check [composer.json](https://github.com/apigee/apigee-edge-drupal/blob/8.x-1.x/composer.json) for required patches.** Patches prefixed with "(For testing)" are only required for running tests. Those are not necessary for using this module. Patches can be applied with the [cweagans/composer-patches](https://packagist.org/packages/cweagans/composer-patches) plugin automatically or manually.
-* (For developers) The locked commit from `behat/mink` library is required otherwise tests may fail. This caused by a Drupal core [bug](https://www.drupal.org/project/drupal/issues/2956279). See the related pull request for behat/mink [here](https://github.com/minkphp/Mink/pull/760).
+1. [cweagans/composer-patches](https://packagist.org/packages/cweagans/composer-patches) >= 1.6.5 has to be installed.
+2. ["Allowing patches to be applied from dependencies
+"](https://github.com/cweagans/composer-patches/tree/1.6.5#allowing-patches-to-be-applied-from-dependencies)
+has to be enabled in Drupal's composer.json.
+3. Proper [patch level](https://github.com/cweagans/composer-patches/pull/101#issue-104810467)
+for drupal/core has to be set in Drupal's composer.json.
+
+You can find the currently required patches, if any, in the Apigee Edge module's [composer.json](https://github.com/apigee/apigee-edge-drupal/blob/8.x-1.x/composer.json)
+and in the Apigee Edge PHP API Client's [composer.json](https://github.com/apigee/apigee-client-php/blob/2.x/composer.json).
+
+**If you do not have all required patches applied in your Drupal
+installation you may experience some problems with the Apigee Edge
+module.**
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,6 @@ considered to be in development. Experimental modules are included in the "Apige
 * When you first install the module, existing users in the Drupal site may not have a developer account in Apigee Edge.
   You can run [developer synchronization](https://www.drupal.org/docs/8/modules/apigee-edge/synchronize-developers-with-apigee-edge)
   to make sure Drupal users and Apigee Edge developers are synchronized.
-* This module does not come with an entity view page for API products at this moment. (See
-  [#72](https://github.com/apigee/apigee-edge-drupal/issues/72).) Unless you have a custom module enabled that provides
-  this functionality, do not use the "Rendered entity" field formatter on API product entity reference fields.
   
 ## Applying Patches
 


### PR DESCRIPTION
As per DRUP-724, this PR updates the patches section in the README. 

I suggest we do not remove it completely but move it to its own section instead. This way we do not have to update the README everytime we add or remove patches down the line.

This also moves the requirements section before installation and adds a link to the patches section.

CONTRIBUTING.md looks good.