### PR TITLE
Bump minimum Drupal core requirement

### DIFF
--- a/apigee_edge.info.yml
+++ b/apigee_edge.info.yml
@@ -13,7 +13,7 @@ dependencies:
   - drupal:filter
   - drupal:options
   - key:key
-  - drupal:system (>=8.6.0)
+  - drupal:system (>=8.7.0)
 
 configure: apigee_edge.settings
 


### PR DESCRIPTION
in info.yml as well.

The missing piece from on #188.

https://travis-ci.org/mxr576/apigee-devportal-drupal/builds/538649187