### PR TITLE
[BUG] Use sync must not depend on the debug module

### DIFF
--- a/src/Job/UserDeveloperSyncJobTrait.php
+++ b/src/Job/UserDeveloperSyncJobTrait.php
@@ -37,7 +37,7 @@ trait UserDeveloperSyncJobTrait {
    *   Logger interface.
    */
   protected function logger() : LoggerChannelInterface {
-    return \Drupal::service('logger.channel.apigee_edge_debug');
+    return \Drupal::service('logger.channel.apigee_edge');
   }
 
   /**


### PR DESCRIPTION
Incorrect logger channel injected to the user sync service therefore the
Apigee Edge module started to depend on the Debug submodule.

https://travis-ci.org/mxr576/apigee-devportal-drupal/builds/546613257