### PR TITLE
[#115] Add a config to enable additional debug messages on the error page

### DIFF
--- a/apigee_edge.services.yml
+++ b/apigee_edge.services.yml
@@ -115,6 +115,8 @@ services:
       - '@logger.channel.apigee_edge'
       - '@redirect.destination'
       - '@router.no_access_checks'
+      - '@config.factory'
+      - '@messenger'
     tags:
       - { name: event_subscriber }
 

--- a/config/install/apigee_edge.error_page.yml
+++ b/config/install/apigee_edge.error_page.yml
@@ -3,3 +3,4 @@ error_page_title: 'Connection error'
 error_page_content:
  value: 'Cannot reach management server. An administrator should check the configuration of this site.'
  format: 'plain_text'
+error_page_debug_messages: true

--- a/config/schema/apigee_edge.schema.yml
+++ b/config/schema/apigee_edge.schema.yml
@@ -13,6 +13,9 @@ apigee_edge.error_page:
         value:
           type: text
           label: 'Error page content'
+    error_page_debug_messages:
+      type: boolean
+      label: 'Show additional debug messages'
 
 apigee_edge.auth:
   type: config_object

--- a/src/EventSubscriber/EdgeExceptionSubscriber.php
+++ b/src/EventSubscriber/EdgeExceptionSubscriber.php
@@ -20,10 +20,16 @@
 namespace Drupal\apigee_edge\EventSubscriber;
 
 use Apigee\Edge\Exception\ApiException;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\EventSubscriber\DefaultExceptionHtmlSubscriber;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Routing\RedirectDestinationInterface;
 use Drupal\Core\Utility\Error;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 
 /**
  * Handles uncaught ApiExceptions.
@@ -32,6 +38,42 @@ use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
  * SDK-level ApiException event appears in the HttpKernel component.
  */
 final class EdgeExceptionSubscriber extends DefaultExceptionHtmlSubscriber {
+
+  /**
+   * The messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * The config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * EdgeExceptionSubscriber constructor.
+   *
+   * @param \Symfony\Component\HttpKernel\HttpKernelInterface $http_kernel
+   *   The HTTP kernel.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The logger service.
+   * @param \Drupal\Core\Routing\RedirectDestinationInterface $redirect_destination
+   *   The redirect destination service.
+   * @param \Symfony\Component\Routing\Matcher\UrlMatcherInterface $access_unaware_router
+   *   A router implementation which does not check access.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory service.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
+   */
+  public function __construct(HttpKernelInterface $http_kernel, LoggerInterface $logger, RedirectDestinationInterface $redirect_destination, UrlMatcherInterface $access_unaware_router, ConfigFactoryInterface $config_factory, MessengerInterface $messenger) {
+    parent::__construct($http_kernel, $logger, $redirect_destination, $access_unaware_router);
+    $this->messenger = $messenger;
+    $this->configFactory = $config_factory;
+  }
 
   /**
    * {@inheritdoc}
@@ -51,6 +93,11 @@ final class EdgeExceptionSubscriber extends DefaultExceptionHtmlSubscriber {
       $context = Error::decodeException($event->getException());
       $this->logger->critical('@message %function (line %line of %file). <pre>@backtrace_string</pre>', $context);
       $this->makeSubrequest($event, '/api-communication-error', Response::HTTP_SERVICE_UNAVAILABLE);
+
+      // Display additional debug messages.
+      if ($this->configFactory->get('apigee_edge.error_page')->get('error_page_debug_messages')) {
+        $this->messenger->addError($event->getException()->getMessage());
+      }
     }
   }
 

--- a/src/Exception/DeveloperDoesNotExistException.php
+++ b/src/Exception/DeveloperDoesNotExistException.php
@@ -45,7 +45,7 @@ class DeveloperDoesNotExistException extends ApiException implements ApigeeEdgeE
    * @param \Throwable|null $previous
    *   Previous exception.
    */
-  public function __construct(string $email, string $message = 'Developer with @email email address not found.', int $code = 0, \Throwable $previous = NULL) {
+  public function __construct(string $email, string $message = 'Developer with @email email address not found. Running the developer sync could fix this.', int $code = 0, \Throwable $previous = NULL) {
     $this->email = $email;
     $message = strtr($message, ['@email' => $email]);
     parent::__construct($message, $code, $previous);

--- a/src/Form/ErrorPageSettingsForm.php
+++ b/src/Form/ErrorPageSettingsForm.php
@@ -68,6 +68,13 @@ class ErrorPageSettingsForm extends ConfigFormBase {
       '#default_value' => $config->get('error_page_content.value'),
     ];
 
+    $form['error_page']['error_page_debug_messages'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Show debug messages.'),
+      '#description' => $this->t('If checked, additional debug messages will be displayed on the error page. This can be turned off on production.'),
+      '#default_value' => $config->get('error_page_debug_messages'),
+    ];
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -79,6 +86,7 @@ class ErrorPageSettingsForm extends ConfigFormBase {
       ->set('error_page_title', $form_state->getValue('error_page_title'))
       ->set('error_page_content.format', $form_state->getValue(['error_page_content', 'format']))
       ->set('error_page_content.value', $form_state->getValue(['error_page_content', 'value']))
+      ->set('error_page_debug_messages', $form_state->getValue('error_page_debug_messages'))
       ->save();
 
     parent::submitForm($form, $form_state);


### PR DESCRIPTION
Fixes #115 
> This message is confusing since the management server is configured properly and is able to reach the Apigee Edge management server, the actual issue is that the developer is not found in Apigee Edge.

As per #115 this PR adds a config to turn on additional debug messages on the error page. Instead of showing only the generic error message this also displays the message from the exception.

This setting can be turned off on production sites.

![Error_page_settings___Drupal_8_m10n](https://user-images.githubusercontent.com/124599/59681723-a0a1b000-91e5-11e9-89a3-94321698481b.jpg)

![Connection_error___Drupal_8_m10n](https://user-images.githubusercontent.com/124599/59681778-badb8e00-91e5-11e9-8455-31f9ac6251c1.jpg)

@cnovak @mxr576 Let me know what you think.
