### PR TITLE
Change config link for teams module

### DIFF
--- a/modules/apigee_edge_teams/apigee_edge_teams.info.yml
+++ b/modules/apigee_edge_teams/apigee_edge_teams.info.yml
@@ -8,6 +8,6 @@ core: 8.x
 dependencies:
 - apigee_edge:apigee_edge
 
-configure: apigee_edge.settings
+configure: apigee_edge_teams.settings.team
 
 php: "7.1"


### PR DESCRIPTION
When viewing the Apigee Edge Teams module from admin/modules, the 'configure' link for the module directs the user to the general configs page for Edge connections. It would be more useful for the 'configure' link for the Teams module to direct the user to admin/config/apigee-edge/team-settings, which is the config page specific to the Teams module. Suggesting to update the config link for the Apigee Edge Teams module to do this. 

Per the CONTRIBUTING.md file, I did check this feature branch here: https://travis-ci.org/kbrinner/apigee-edge-drupal/branches. However, the tests are failing for the 8.x-1.x build. The same tests are failing for my branch, so I'm going to go ahead and create the PR despite the failed tests :) 