### PR TITLE
[#250] Validate test connection by checking for a valid org.

### DIFF
--- a/src/KeyEntityFormEnhancer.php
+++ b/src/KeyEntityFormEnhancer.php
@@ -20,6 +20,7 @@
 
 namespace Drupal\apigee_edge;
 
+use Apigee\Edge\Exception\ApiException;
 use Apigee\Edge\Exception\ApiRequestException;
 use Apigee\Edge\Exception\OauthAuthenticationException;
 use Apigee\Edge\HttpClient\Plugin\Authentication\Oauth;
@@ -529,6 +530,12 @@ final class KeyEntityFormEnhancer {
               '%endpoint' => $key_type->getEndpoint($key),
             ]);
           }
+        }
+        elseif ($exception instanceof ApiException) {
+          $suggestion = $this->t('@fail_text The given endpoint (%endpoint) is incorrect or something is wrong with the connection.', [
+            '@fail_text' => $fail_text,
+            '%endpoint' => $key_type->getEndpoint($key),
+          ]);
         }
       }
     }

--- a/src/KeyEntityFormEnhancer.php
+++ b/src/KeyEntityFormEnhancer.php
@@ -20,10 +20,10 @@
 
 namespace Drupal\apigee_edge;
 
-use Apigee\Edge\Exception\ApiException;
 use Apigee\Edge\Exception\ApiRequestException;
 use Apigee\Edge\Exception\OauthAuthenticationException;
 use Apigee\Edge\HttpClient\Plugin\Authentication\Oauth;
+use Drupal\apigee_edge\Exception\InvalidArgumentException;
 use Drupal\apigee_edge\Exception\KeyProviderRequirementsException;
 use Drupal\apigee_edge\Plugin\EdgeKeyTypeInterface;
 use Drupal\apigee_edge\Plugin\KeyProviderRequirementsInterface;
@@ -531,7 +531,10 @@ final class KeyEntityFormEnhancer {
             ]);
           }
         }
-        elseif ($exception instanceof ApiException) {
+
+        // If SDKConnector::testConnection() fails to retrieve a valid org,
+        // then this exception is thrown.
+        elseif ($exception instanceof InvalidArgumentException) {
           $suggestion = $this->t('@fail_text The given endpoint (%endpoint) is incorrect or something is wrong with the connection.', [
             '@fail_text' => $fail_text,
             '%endpoint' => $key_type->getEndpoint($key),

--- a/src/SDKConnector.php
+++ b/src/SDKConnector.php
@@ -276,6 +276,10 @@ class SDKConnector implements SDKConnectorInterface {
       $oc = new OrganizationController($client);
       /* @var \Apigee\Edge\Api\Management\Entity\Organization $org */
       $org = $oc->load($credentials->getKeyType()->getOrganization($credentials->getKey()));
+
+      // Calling an invalid endpoint under some circumstances might return an
+      // empty organization object, so we check if it indeed loaded an org.
+      // @see https://github.com/apigee/apigee-edge-drupal/issues/250
       if (empty($org->id())) {
         throw new InvalidArgumentException('Failed to load a valid organization.');
       }

--- a/src/SDKConnector.php
+++ b/src/SDKConnector.php
@@ -22,10 +22,10 @@ namespace Drupal\apigee_edge;
 use Apigee\Edge\Api\Management\Controller\OrganizationController;
 use Apigee\Edge\Client;
 use Apigee\Edge\ClientInterface;
-use Apigee\Edge\Exception\ApiException;
 use Apigee\Edge\HttpClient\Utility\Builder;
 use Drupal\apigee_edge\Exception\AuthenticationKeyException;
 use Drupal\apigee_edge\Exception\AuthenticationKeyNotFoundException;
+use Drupal\apigee_edge\Exception\InvalidArgumentException;
 use Drupal\apigee_edge\Plugin\EdgeKeyTypeInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -277,7 +277,7 @@ class SDKConnector implements SDKConnectorInterface {
       /* @var \Apigee\Edge\Api\Management\Entity\Organization $org */
       $org = $oc->load($credentials->getKeyType()->getOrganization($credentials->getKey()));
       if (empty($org->id())) {
-        throw new ApiException('Failed to load a valid organization.');
+        throw new InvalidArgumentException('Failed to load a valid organization.');
       }
     }
     catch (\Exception $e) {

--- a/src/SDKConnector.php
+++ b/src/SDKConnector.php
@@ -22,6 +22,7 @@ namespace Drupal\apigee_edge;
 use Apigee\Edge\Api\Management\Controller\OrganizationController;
 use Apigee\Edge\Client;
 use Apigee\Edge\ClientInterface;
+use Apigee\Edge\Exception\ApiException;
 use Apigee\Edge\HttpClient\Utility\Builder;
 use Drupal\apigee_edge\Exception\AuthenticationKeyException;
 use Drupal\apigee_edge\Exception\AuthenticationKeyNotFoundException;
@@ -273,7 +274,11 @@ class SDKConnector implements SDKConnectorInterface {
     try {
       // We use the original, non-decorated organization controller here.
       $oc = new OrganizationController($client);
-      $oc->load($credentials->getKeyType()->getOrganization($credentials->getKey()));
+      /* @var \Apigee\Edge\Api\Management\Entity\Organization $org */
+      $org = $oc->load($credentials->getKeyType()->getOrganization($credentials->getKey()));
+      if (empty($org->id())) {
+        throw new ApiException('Failed to load a valid organization.');
+      }
     }
     catch (\Exception $e) {
       throw $e;

--- a/tests/src/FunctionalJavascript/Form/AuthenticationFormJsTest.php
+++ b/tests/src/FunctionalJavascript/Form/AuthenticationFormJsTest.php
@@ -296,6 +296,16 @@ class AuthenticationFormJsTest extends ApigeeEdgeFunctionalJavascriptTestBase {
     $web_assert->fieldValueEquals('Apigee Edge endpoint', "http://{$invalid_domain}/");
     $page->fillField('Apigee Edge endpoint', '');
 
+    // Test another invalid endpoint scenario:
+    // This endpoint is not a Management API endpoint, but still returns
+    // HTTP 200 with a JSON response.
+    $invalid_endpoint = 'enterprise.apigee.com/platform/orgname';
+    $page->fillField('Apigee Edge endpoint', "https://{$invalid_endpoint}/");
+    $this->assertSendRequestMessage('.messages--error', "Failed to connect to Apigee Edge. The given endpoint (https://{$invalid_endpoint}/) is incorrect or something is wrong with the connection. Error message: ");
+    $web_assert->elementContains('css', 'textarea[data-drupal-selector="edit-debug-text"]', "\"endpoint\": \"https:\/\/{$invalid_endpoint}\/\"");
+    $web_assert->fieldValueEquals('Apigee Edge endpoint', "https://{$invalid_endpoint}/");
+    $page->fillField('Apigee Edge endpoint', '');
+
     // Test invalid authorization server.
     $this->cssSelect('select[data-drupal-selector="edit-key-input-settings-auth-type"]')[0]->setValue('oauth');
     $invalid_domain = "{$this->randomGenerator->word(16)}.example.com";


### PR DESCRIPTION
Fixes #250. It will check that the test connection returns a valid organization. This will need an additional test that mocks an invalid endpoint response, so a follow up issue will be needed after finalizing on a mocking test strategy.
Build: https://travis-ci.org/arlina-espinoza/apigee-edge-drupal/builds/569521122