### PR TITLE
#243 Default team member role help text and context

### DIFF
--- a/modules/apigee_edge_teams/apigee_edge_teams.module
+++ b/modules/apigee_edge_teams/apigee_edge_teams.module
@@ -20,6 +20,7 @@
  */
 
 use Drupal\apigee_edge\Exception\DeveloperDoesNotExistException;
+use Drupal\apigee_edge_teams\Entity\TeamRoleInterface;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Entity\EntityInterface;
@@ -29,6 +30,7 @@ use Drupal\Core\Link;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Url;
 
 /**
  * Implements hook_module_implements_alter().
@@ -224,4 +226,18 @@ function apigee_edge_teams_api_product_access(EntityInterface $entity, $operatio
 
   // $result is always defined.
   return $result;
+}
+
+/**
+ * Implements hook_help().
+ */
+function apigee_edge_teams_help($route_name, \Drupal\Core\Routing\RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    case 'entity.team_role.collection':
+      $member_role = \Drupal::entityTypeManager()->getStorage('team_role')->load(TeamRoleInterface::TEAM_MEMBER_ROLE);
+      return '<p>' . t('A role defines a group of users that have certain privileges. These privileges are defined on the <a href=":permissions">Permissions page</a>. Here you can define the names of the team roles on your site. Users who are part of a team have the :member team role, plus any other team roles granted to their user account.', [
+        ':permissions' => Url::fromRoute('apigee_edge_teams.settings.team.permissions')->toString(),
+        ':member' => $member_role->label(),
+      ]) . '</p>';
+  }
 }

--- a/modules/apigee_edge_teams/apigee_edge_teams.module
+++ b/modules/apigee_edge_teams/apigee_edge_teams.module
@@ -231,7 +231,7 @@ function apigee_edge_teams_api_product_access(EntityInterface $entity, $operatio
 /**
  * Implements hook_help().
  */
-function apigee_edge_teams_help($route_name, \Drupal\Core\Routing\RouteMatchInterface $route_match) {
+function apigee_edge_teams_help($route_name, RouteMatchInterface $route_match) {
   switch ($route_name) {
     case 'entity.team_role.collection':
       $member_role = \Drupal::entityTypeManager()->getStorage('team_role')->load(TeamRoleInterface::TEAM_MEMBER_ROLE);

--- a/modules/apigee_edge_teams/src/Form/AddTeamMembersForm.php
+++ b/modules/apigee_edge_teams/src/Form/AddTeamMembersForm.php
@@ -58,10 +58,10 @@ class AddTeamMembersForm extends TeamMembersFormBase {
    *   The entity type manager.
    */
   public function __construct(TeamMembershipManagerInterface $team_membership_manager, EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct($entity_type_manager);
+
     $this->teamMembershipManager = $team_membership_manager;
     $this->userStorage = $entity_type_manager->getStorage('user');
-    $this->teamRoleStorage = $entity_type_manager->getStorage('team_role');
-    $this->teamMemberRoleStorage = $entity_type_manager->getStorage('team_member_role');
   }
 
   /**

--- a/modules/apigee_edge_teams/src/Form/AddTeamMembersForm.php
+++ b/modules/apigee_edge_teams/src/Form/AddTeamMembersForm.php
@@ -134,13 +134,14 @@ class AddTeamMembersForm extends FormBase {
       '#options' => $role_options,
       '#multiple' => TRUE,
       '#required' => FALSE,
-      TeamRoleInterface::TEAM_MEMBER_ROLE => [
-        '#disabled' => TRUE,
-      ],
-      '#default_value' => [
-        TeamRoleInterface::TEAM_MEMBER_ROLE,
-      ],
     ];
+
+    // Special handling for the inevitable team member role.
+    $form['team_roles'][TeamRoleInterface::TEAM_MEMBER_ROLE] = [
+      '#default_value' => TRUE,
+      '#disabled' => TRUE,
+    ];
+
     $form['team_roles']['description'] = [
       '#markup' => $this->t('Assign one or more roles to <em>all developers</em> that you selected in %team_label @team.', ['%team_label' => $this->team->label(), '@team' => $this->team->getEntityType()->getLowercaseLabel()]),
     ];

--- a/modules/apigee_edge_teams/src/Form/EditTeamMemberForm.php
+++ b/modules/apigee_edge_teams/src/Form/EditTeamMemberForm.php
@@ -118,10 +118,14 @@ class EditTeamMemberForm extends FormBase {
       '#default_value' => $current_role_options,
       '#multiple' => TRUE,
       '#required' => FALSE,
-      TeamRoleInterface::TEAM_MEMBER_ROLE => [
-        '#disabled' => TRUE,
-      ],
     ];
+
+    // Special handling for the inevitable team member role.
+    $form['team_roles'][TeamRoleInterface::TEAM_MEMBER_ROLE] = [
+      '#default_value' => TRUE,
+      '#disabled' => TRUE,
+    ];
+
     $form['team_roles']['description'] = [
       '#markup' => $this->t('Modify roles of %developer in the %team_label @team.', [
         '%developer' => $this->developer->getOwner()->label(),

--- a/modules/apigee_edge_teams/src/Form/EditTeamMemberForm.php
+++ b/modules/apigee_edge_teams/src/Form/EditTeamMemberForm.php
@@ -23,10 +23,8 @@ namespace Drupal\apigee_edge_teams\Form;
 use Drupal\apigee_edge\Entity\DeveloperInterface;
 use Drupal\apigee_edge_teams\Entity\TeamInterface;
 use Drupal\apigee_edge_teams\Entity\TeamRoleInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Utility\Error;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Edit team member form.
@@ -39,26 +37,6 @@ class EditTeamMemberForm extends TeamMembersFormBase {
    * @var \Drupal\apigee_edge\Entity\DeveloperInterface
    */
   protected $developer;
-
-  /**
-   * EditTeamMemberForm constructor.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->teamRoleStorage = $entity_type_manager->getStorage('team_role');
-    $this->teamMemberRoleStorage = $entity_type_manager->getStorage('team_member_role');
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('entity_type.manager')
-    );
-  }
 
   /**
    * {@inheritdoc}

--- a/modules/apigee_edge_teams/src/Form/TeamMembersFormBase.php
+++ b/modules/apigee_edge_teams/src/Form/TeamMembersFormBase.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_edge_teams\Form;
+
+use Drupal\apigee_edge_teams\Entity\TeamRoleInterface;
+use Drupal\Core\Form\FormBase;
+
+/**
+ * Base team members form.
+ */
+abstract class TeamMembersFormBase extends FormBase {
+
+  /**
+   * The team from the route.
+   *
+   * @var \Drupal\apigee_edge_teams\Entity\TeamInterface
+   */
+  protected $team;
+
+  /**
+   * Team role storage.
+   *
+   * @var \Drupal\apigee_edge_teams\Entity\Storage\TeamRoleStorageInterface
+   */
+  protected $teamRoleStorage;
+
+  /**
+   * Team member role storage.
+   *
+   * @var \Drupal\apigee_edge_teams\Entity\Storage\TeamMemberRoleStorage
+   */
+  protected $teamMemberRoleStorage;
+
+  /**
+   * Returns an array of team role options keyed by team role id.
+   *
+   * @return array
+   *   Role options.
+   */
+  protected function getRoleOptions() {
+    $role_options = array_reduce($this->teamRoleStorage->loadMultiple(), function (array $carry, TeamRoleInterface $role) {
+      $carry[$role->id()] = $role->label();
+      return $carry;
+    }, []);
+
+    return $role_options;
+  }
+
+  /**
+   * Helper function to filter the value of a team roles checkboxes element.
+   *
+   * It will only leave selected items, and also remove the TEAM_MEMBER_ROLE,
+   * as it is granted implicitly.
+   *
+   * @param array $team_roles_value
+   *   The checkboxes element values.
+   *
+   * @return array
+   *   The filtered result.
+   */
+  protected function filterSelectedRoles(array $team_roles_value) {
+    $selected_roles = array_filter($team_roles_value, function ($role) {
+      return $role && $role != TeamRoleInterface::TEAM_MEMBER_ROLE;
+    });
+
+    return $selected_roles;
+  }
+
+}

--- a/modules/apigee_edge_teams/src/Form/TeamMembersFormBase.php
+++ b/modules/apigee_edge_teams/src/Form/TeamMembersFormBase.php
@@ -21,7 +21,9 @@
 namespace Drupal\apigee_edge_teams\Form;
 
 use Drupal\apigee_edge_teams\Entity\TeamRoleInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Base team members form.
@@ -48,6 +50,26 @@ abstract class TeamMembersFormBase extends FormBase {
    * @var \Drupal\apigee_edge_teams\Entity\Storage\TeamMemberRoleStorage
    */
   protected $teamMemberRoleStorage;
+
+  /**
+   * TeamMembersFormBase constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->teamRoleStorage = $entity_type_manager->getStorage('team_role');
+    $this->teamMemberRoleStorage = $entity_type_manager->getStorage('team_member_role');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
 
   /**
    * Returns an array of team role options keyed by team role id.


### PR DESCRIPTION
Fixes #243 . It adds help text to the team roles configuration page _(/admin/config/apigee-edge/team-settings/team_role)_:
![image](https://user-images.githubusercontent.com/4062676/62899340-67308100-bd0c-11e9-8a98-2e3f0959dcaf.png)

It also adds a checkbox to the add/edit member form that will show the member role as checked and disabled:
![image](https://user-images.githubusercontent.com/4062676/62899371-7ca5ab00-bd0c-11e9-88fc-78282cf578d4.png)

