### PR TITLE
[#244] Add team member form searches by email

### DIFF
--- a/modules/apigee_edge_teams/src/Form/AddTeamMembersForm.php
+++ b/modules/apigee_edge_teams/src/Form/AddTeamMembersForm.php
@@ -118,7 +118,7 @@ class AddTeamMembersForm extends FormBase {
 
     $form['developers'] = [
       '#title' => $this->t('Developers'),
-      '#description' => $this->t('Add one or more developers to the @team.', ['@team' => $this->team->getEntityType()->getLowercaseLabel()]),
+      '#description' => $this->t('Enter the email of one or more developers to add them to the @team.', ['@team' => $this->team->getEntityType()->getLowercaseLabel()]),
       '#type' => 'entity_autocomplete',
       '#target_type' => 'user',
       '#tags' => TRUE,

--- a/modules/apigee_edge_teams/src/Plugin/EntityReferenceSelection/TeamMembersSelection.php
+++ b/modules/apigee_edge_teams/src/Plugin/EntityReferenceSelection/TeamMembersSelection.php
@@ -22,7 +22,6 @@ namespace Drupal\apigee_edge_teams\Plugin\EntityReferenceSelection;
 
 use Drupal\apigee_edge\Entity\Controller\DeveloperControllerInterface;
 use Drupal\apigee_edge_teams\TeamMembershipManagerInterface;
-use Drupal\Component\Utility\Html;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;


### PR DESCRIPTION
Fixes #244 . It makes the _"add team member"_ form _(teams/{team}/add-members)_ search by email, and display emails in the autocomplete dropdown.