### PR TITLE
[#261] Allow authentication using a username

### DIFF
--- a/apigee_edge.services.yml
+++ b/apigee_edge.services.yml
@@ -19,7 +19,7 @@ services:
 
   apigee_edge.key_entity_form_enhancer:
     class: Drupal\apigee_edge\KeyEntityFormEnhancer
-    arguments: ['@apigee_edge.sdk_connector', '@apigee_edge.authentication.oauth_token_storage', '@entity_type.manager', '@config.factory']
+    arguments: ['@apigee_edge.sdk_connector', '@apigee_edge.authentication.oauth_token_storage', '@entity_type.manager', '@config.factory', '@email.validator']
     calls:
       - [setMessenger, ['@messenger']]
       - [setStringTranslation, ['@string_translation']]

--- a/src/KeyEntityFormEnhancer.php
+++ b/src/KeyEntityFormEnhancer.php
@@ -94,7 +94,7 @@ final class KeyEntityFormEnhancer {
    *
    * @var \Drupal\Component\Utility\EmailValidatorInterface
    */
-  protected $emailValidator;
+  private $emailValidator;
 
   /**
    * KeyEntityFormEnhancer constructor.
@@ -512,7 +512,7 @@ final class KeyEntityFormEnhancer {
 
         // If on public cloud (using the default endpoint), the username should
         // be an email.
-        if ($key_type->getEndpointType($key) == 'default' && !$this->emailValidator->isValid($key_type->getUsername($key))) {
+        if ($key_type->getEndpointType($key) === EdgeKeyTypeInterface::EDGE_ENDPOINT_TYPE_DEFAULT && !$this->emailValidator->isValid($key_type->getUsername($key))) {
           $suggestion = $this->t('@fail_text The organization username should be a valid email.', [
             '@fail_text' => $fail_text,
           ]);

--- a/src/Plugin/EdgeKeyTypeBase.php
+++ b/src/Plugin/EdgeKeyTypeBase.php
@@ -65,6 +65,13 @@ abstract class EdgeKeyTypeBase extends KeyTypeBase implements EdgeKeyTypeInterfa
   /**
    * {@inheritdoc}
    */
+  public function getEndpointType(KeyInterface $key): string {
+    return $key->getKeyValues()['endpoint_type'] ?? 'default';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getOrganization(KeyInterface $key): string {
     if (!isset($key->getKeyValues()['organization'])) {
       throw new AuthenticationKeyValueMalformedException('organization');

--- a/src/Plugin/EdgeKeyTypeBase.php
+++ b/src/Plugin/EdgeKeyTypeBase.php
@@ -66,7 +66,7 @@ abstract class EdgeKeyTypeBase extends KeyTypeBase implements EdgeKeyTypeInterfa
    * {@inheritdoc}
    */
   public function getEndpointType(KeyInterface $key): string {
-    return $key->getKeyValues()['endpoint_type'] ?? 'default';
+    return $key->getKeyValues()['endpoint_type'] ?? EdgeKeyTypeInterface::EDGE_ENDPOINT_TYPE_DEFAULT;
   }
 
   /**

--- a/src/Plugin/EdgeKeyTypeBase.php
+++ b/src/Plugin/EdgeKeyTypeBase.php
@@ -66,7 +66,15 @@ abstract class EdgeKeyTypeBase extends KeyTypeBase implements EdgeKeyTypeInterfa
    * {@inheritdoc}
    */
   public function getEndpointType(KeyInterface $key): string {
-    return $key->getKeyValues()['endpoint_type'] ?? EdgeKeyTypeInterface::EDGE_ENDPOINT_TYPE_DEFAULT;
+    if (isset($key->getKeyValues()['endpoint_type'])) {
+      return $key->getKeyValues()['endpoint_type'];
+    }
+
+    if (empty($key->getKeyValues()['endpoint']) || $key->getKeyValues()['endpoint'] === Client::DEFAULT_ENDPOINT) {
+      return EdgeKeyTypeInterface::EDGE_ENDPOINT_TYPE_DEFAULT;
+    }
+
+    return EdgeKeyTypeInterface::EDGE_ENDPOINT_TYPE_CUSTOM;
   }
 
   /**

--- a/src/Plugin/EdgeKeyTypeInterface.php
+++ b/src/Plugin/EdgeKeyTypeInterface.php
@@ -64,6 +64,17 @@ interface EdgeKeyTypeInterface extends KeyTypeMultivalueInterface, KeyTypeAuthen
   public function getEndpoint(KeyInterface $key): string;
 
   /**
+   * Gets the API endpoint type (default or custom).
+   *
+   * @param \Drupal\key\KeyInterface $key
+   *   The key entity.
+   *
+   * @return string
+   *   The API endpoint type.
+   */
+  public function getEndpointType(KeyInterface $key): string;
+
+  /**
    * Gets the API organization.
    *
    * @param \Drupal\key\KeyInterface $key

--- a/src/Plugin/EdgeKeyTypeInterface.php
+++ b/src/Plugin/EdgeKeyTypeInterface.php
@@ -42,6 +42,20 @@ interface EdgeKeyTypeInterface extends KeyTypeMultivalueInterface, KeyTypeAuthen
   const EDGE_AUTH_TYPE_OAUTH = 'oauth';
 
   /**
+   * The endpoint type for default.
+   *
+   * @var string
+   */
+  const EDGE_ENDPOINT_TYPE_DEFAULT = 'default';
+
+  /**
+   * The endpoint type for custom.
+   *
+   * @var string
+   */
+  const EDGE_ENDPOINT_TYPE_CUSTOM = 'custom';
+
+  /**
    * Gets the authentication type.
    *
    * @param \Drupal\key\KeyInterface $key

--- a/src/Plugin/EdgeKeyTypeInterface.php
+++ b/src/Plugin/EdgeKeyTypeInterface.php
@@ -80,6 +80,9 @@ interface EdgeKeyTypeInterface extends KeyTypeMultivalueInterface, KeyTypeAuthen
   /**
    * Gets the API endpoint type (default or custom).
    *
+   * If the "endpoint_type" property is empty, it returns "default" if the
+   * "endpoint" is empty or the same as the default endpoint.
+   *
    * @param \Drupal\key\KeyInterface $key
    *   The key entity.
    *

--- a/src/Plugin/KeyInput/ApigeeAuthKeyInput.php
+++ b/src/Plugin/KeyInput/ApigeeAuthKeyInput.php
@@ -87,9 +87,9 @@ class ApigeeAuthKeyInput extends KeyInputBase {
       '#attributes' => ['autocomplete' => 'off'],
     ];
     $form['username'] = [
-      '#type' => 'email',
+      '#type' => 'textfield',
       '#title' => $this->t('Username'),
-      '#description' => $this->t("Organization user's email address that is used for authenticating with the endpoint."),
+      '#description' => $this->t("Organization username that is used for authenticating with the endpoint."),
       '#required' => TRUE,
       '#default_value' => $values['username'] ?? '',
       '#attributes' => ['autocomplete' => 'off'],

--- a/src/Plugin/KeyInput/ApigeeAuthKeyInput.php
+++ b/src/Plugin/KeyInput/ApigeeAuthKeyInput.php
@@ -89,7 +89,7 @@ class ApigeeAuthKeyInput extends KeyInputBase {
     $form['username'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Username'),
-      '#description' => $this->t("Organization username that is used for authenticating with the endpoint."),
+      '#description' => $this->t("Apigee user's email address or identity provider username that is used for authenticating with the endpoint."),
       '#required' => TRUE,
       '#default_value' => $values['username'] ?? '',
       '#attributes' => ['autocomplete' => 'off'],

--- a/src/Plugin/KeyInput/ApigeeAuthKeyInput.php
+++ b/src/Plugin/KeyInput/ApigeeAuthKeyInput.php
@@ -63,7 +63,7 @@ class ApigeeAuthKeyInput extends KeyInputBase {
 
     // Could be an empty array.
     $values = Json::decode($key_value);
-    $values['endpoint_type'] = empty($values['endpoint']) ? 'default' : 'custom';
+    $values['endpoint_type'] = empty($values['endpoint']) ? EdgeKeyTypeInterface::EDGE_ENDPOINT_TYPE_DEFAULT : EdgeKeyTypeInterface::EDGE_ENDPOINT_TYPE_CUSTOM;
     $values['authorization_server_type'] = empty($values['authorization_server']) ? 'default' : 'custom';
 
     $form['auth_type'] = [
@@ -109,10 +109,10 @@ class ApigeeAuthKeyInput extends KeyInputBase {
       '#title' => $this->t('Apigee Edge endpoint'),
       '#type' => 'radios',
       '#required' => TRUE,
-      '#default_value' => $values['endpoint_type'] ?? 'default',
+      '#default_value' => $values['endpoint_type'],
       '#options' => [
-        'default' => $this->t('Default'),
-        'custom' => $this->t('Custom'),
+        EdgeKeyTypeInterface::EDGE_ENDPOINT_TYPE_DEFAULT => $this->t('Default'),
+        EdgeKeyTypeInterface::EDGE_ENDPOINT_TYPE_CUSTOM => $this->t('Custom'),
       ],
       '#description' => $this->t('Apigee Edge endpoint where the API calls are being sent. Use the default (%endpoint) when pointing to an organization on <a href="@link" target="_blank">Public Cloud</a>, or custom when using <a href="@link" target="_blank">Private Cloud</a>.', [
         '%endpoint' => ClientInterface::DEFAULT_ENDPOINT,
@@ -218,7 +218,7 @@ class ApigeeAuthKeyInput extends KeyInputBase {
     $input_values = $form_state->getValues();
 
     // Make sure the endpoint defaults are not overridden by other values.
-    if (empty($input_values['endpoint_type']) || $input_values['endpoint_type'] == 'default') {
+    if (empty($input_values['endpoint_type']) || $input_values['endpoint_type'] == EdgeKeyTypeInterface::EDGE_ENDPOINT_TYPE_DEFAULT) {
       $input_values['endpoint'] = '';
     }
     if (empty($input_values['authorization_server_type']) || $input_values['authorization_server_type'] == 'default') {

--- a/tests/src/FunctionalJavascript/Form/AuthenticationFormJsTest.php
+++ b/tests/src/FunctionalJavascript/Form/AuthenticationFormJsTest.php
@@ -282,6 +282,12 @@ class AuthenticationFormJsTest extends ApigeeEdgeFunctionalJavascriptTestBase {
     $web_assert->elementNotContains('css', 'textarea[data-drupal-selector="edit-debug-text"]', $random_pass);
     $page->fillField('Password', $this->password);
 
+    // Test invalid username when using default endpoint.
+    $page->selectFieldOption('key_input_settings[endpoint_type]', 'default');
+    $page->fillField('Username', $this->randomMachineName());
+    $this->assertSendRequestMessage('.messages--error', "Failed to connect to Apigee Edge. The organization username should be a valid email. Error message: ");
+    $page->fillField('Username', $this->username);
+
     // Test invalid organization.
     $random_org = $this->randomGenerator->word(16);
     $page->fillField('Organization', $random_org);


### PR DESCRIPTION
Fixes #261 . It changes the username field to a textfield, and does email validation only if using the default endpoint (for public cloud).