### PR TITLE
[#262] Fix app analytics submit redirect

### DIFF
--- a/src/Form/AppAnalyticsFormBase.php
+++ b/src/Form/AppAnalyticsFormBase.php
@@ -452,7 +452,7 @@ abstract class AppAnalyticsFormBase extends FormBase {
         'until' => $form_state->getValue('until')->getTimeStamp(),
       ],
     ];
-    $form_state->setRedirect('<current>', [],  $options);
+    $form_state->setRedirect('<current>', [], $options);
   }
 
   /**

--- a/src/Form/AppAnalyticsFormBase.php
+++ b/src/Form/AppAnalyticsFormBase.php
@@ -445,14 +445,16 @@ abstract class AppAnalyticsFormBase extends FormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    $url = $this->urlGenerator->generateFromRoute('<current>', [], [
+    $route = \Drupal::routeMatch();
+    $parameters = $route->getRawParameters()->all();
+    $options = [
       'query' => [
         'metric' => $form_state->getValue('metrics'),
         'since' => $form_state->getValue('since')->getTimeStamp(),
         'until' => $form_state->getValue('until')->getTimeStamp(),
       ],
-    ]);
-    $form_state->setRedirectUrl(Url::fromUri('internal:' . $url));
+    ];
+    $form_state->setRedirect($route->getRouteName(), $parameters, $options);
   }
 
   /**

--- a/src/Form/AppAnalyticsFormBase.php
+++ b/src/Form/AppAnalyticsFormBase.php
@@ -445,8 +445,6 @@ abstract class AppAnalyticsFormBase extends FormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    $route = \Drupal::routeMatch();
-    $parameters = $route->getRawParameters()->all();
     $options = [
       'query' => [
         'metric' => $form_state->getValue('metrics'),
@@ -454,7 +452,7 @@ abstract class AppAnalyticsFormBase extends FormBase {
         'until' => $form_state->getValue('until')->getTimeStamp(),
       ],
     ];
-    $form_state->setRedirect($route->getRouteName(), $parameters, $options);
+    $form_state->setRedirect('<current>', [],  $options);
   }
 
   /**


### PR DESCRIPTION
Fixes #262 .

**Current bug**
When submitting an app analytics form (eg: _user/2/apps/test_app_1/analytics_), a redirect is issued that prepends the site's base path to the URL. If the site is installed under the root directory (like _example.com/_), then the redirect works, but if the site is under a subdirectory (like _/example.com/drupal/folder/_), then the redirect goes to a page not found _(example.com/drupal/folder/drupal/folder/user/2/apps/test_app_1/analytics)_.

**Expected behavior**
This PR fixes the redirect so it goes to the correct URL (ie, _example.com/drupal/folder/user/2/apps/test_app_1/analytics_).