### PR TITLE
[Bug][High priority] Do not try to update read-only API keys

### DIFF
--- a/apigee_edge.install
+++ b/apigee_edge.install
@@ -27,6 +27,7 @@ use Drupal\apigee_edge\Plugin\KeyType\ApigeeAuthKeyType;
 use Drupal\apigee_edge\OauthTokenFileStorage;
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Url;
+use Drupal\key\Plugin\KeyProviderSettableValueInterface;
 use Drupal\user\RoleInterface;
 
 /**
@@ -168,7 +169,7 @@ function apigee_edge_update_8002() {
   $keys = \Drupal::service('key.repository')->getKeys();
   foreach ($keys as $key) {
     /* @var \Drupal\key\Entity\Key $key */
-    if ($key->getKeyType() instanceof ApigeeAuthKeyType) {
+    if ($key->getKeyType() instanceof ApigeeAuthKeyType && $key->getKeyProvider() instanceof KeyProviderSettableValueInterface) {
       $values = $key->getKeyValues();
       $values['endpoint_type'] = $values['endpoint'] ? 'custom' : 'default';
       $values['authorization_server_type'] = $values['authorization_server'] ? 'custom' : 'default';


### PR DESCRIPTION
The `apigee_edge_update_8002()` is broken if the environment credential storage is being used as an Apigee Edge credential storage. That storage is read-only, so calling `$key->save()` operation on the key throws a `KeyValueNotSetException` exception: `The selected key provider does not support setting a key value.` See: `\Drupal\key\Entity\Key::preSave()`

I am also referring to my original question on a related PR about whether these changes around the key field types are working properly if the environment credential storage is being used: https://github.com/apigee/apigee-edge-drupal/pull/263#discussion_r328165113

Please perform extra testing to verify the newly introduced functionality in 8.x-1.1 works properly with the environmental credential storage as well. For example, connect to a "special" org that accepts usernames instead of email address for authentication and verify the displayed error messages and suggestions on the Connection setting form are valid when you are trying to connect with:
* an invalid username
* with an invalid username that is an email address
