### PR TITLE
[#279] Allow disabling username override w/ first name + last name

### DIFF
--- a/apigee_edge.install
+++ b/apigee_edge.install
@@ -178,3 +178,14 @@ function apigee_edge_update_8002() {
     }
   }
 }
+
+/**
+ * Initialize new developer_settings.override_usernames configuration.
+ */
+function apigee_edge_update_8003() {
+  $config_factory = \Drupal::configFactory();
+
+  $developer_settings = $config_factory->getEditable('apigee_edge.developer_settings');
+  $developer_settings->set('override_usernames', TRUE)
+    ->save(TRUE);
+}

--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -138,8 +138,12 @@ function apigee_edge_theme() {
  * Implements hook_user_format_name_alter().
  */
 function apigee_edge_user_format_name_alter(&$name, AccountInterface $account) {
-  // Ignore Anonymous user.
-  if ($account instanceof UserInterface && !$account->isAnonymous()) {
+  $config = \Drupal::config('apigee_edge.developer_settings');
+  if (!$config->get('override_usernames') || $account->isAnonymous()) {
+    return;
+  }
+
+  if ($account instanceof UserInterface) {
     $first_name_last_name = trim($account->get('first_name')->value) . ' ' . trim($account->get('last_name')->value);
     // If both fields were empty this string still could be empty.
     $first_name_last_name = trim($first_name_last_name);

--- a/config/install/apigee_edge.developer_settings.yml
+++ b/config/install/apigee_edge.developer_settings.yml
@@ -1,4 +1,5 @@
 langcode: en
+override_usernames: true
 verification_action: verify_email
 display_only_error_message_content:
   value: 'This email address already exists in our system. Contact us if you have any questions.'

--- a/config/schema/apigee_edge.schema.yml
+++ b/config/schema/apigee_edge.schema.yml
@@ -110,6 +110,8 @@ apigee_edge.developer_settings:
   type: config_object
   label: 'Developer settings'
   mapping:
+    override_usernames:
+      type: boolean
     verification_action:
       type: string
     display_only_error_message_content:

--- a/src/Form/DeveloperSettingsForm.php
+++ b/src/Form/DeveloperSettingsForm.php
@@ -61,6 +61,13 @@ class DeveloperSettingsForm extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config('apigee_edge.developer_settings');
 
+    $form['override_usernames'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Override usernames'),
+      '#description' => $this->t('Display first name and last name instead of username.'),
+      '#default_value' => $config->get('override_usernames'),
+    ];
+
     $form['email_verification_on_registration'] = [
       '#type' => 'fieldset',
       '#title' => $this->t('When a new user registers and the developer email address is already taken on Apigee Edge but not in Drupal'),
@@ -192,6 +199,7 @@ class DeveloperSettingsForm extends ConfigFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->configFactory->getEditable('apigee_edge.developer_settings')
+      ->set('override_usernames', $form_state->getValue('override_usernames'))
       ->set('verification_action', $form_state->getValue('verification_action'))
       ->set('display_only_error_message_content.value', $form_state->getValue(['display_only_error_message_content', 'value']))
       ->set('display_only_error_message_content.format', $form_state->getValue(['display_only_error_message_content', 'format']))


### PR DESCRIPTION
Possible additional configuration options that could be implemented
* only override if the first name and last name fields are actually set by the user (IOW, their values are not the default "Firstname" and "Lastname"). This could generate mixed results on the admin/people page that could be confusing.
* Add username to the formatted username, ex.: "John Doe" => "John Doe (superjohn)". The result would look better on the admin/people page, but other UIs where the username is displayed should be also considered.

Closes: #279 #280 #281 