### PR TITLE
[#299] Teams not supported on Hybrid orgs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Apigee Edge for Drupal.",
     "require": {
         "php": ">=7.1",
-        "apigee/apigee-client-php": "^2.0.1",
+        "apigee/apigee-client-php": "dev-2.x-hybrid",
         "cweagans/composer-patches": "^1.6.5",
         "drupal/core": "~8.7.0",
         "drupal/entity": "^1.0",

--- a/modules/apigee_edge_teams/apigee_edge_teams.install
+++ b/modules/apigee_edge_teams/apigee_edge_teams.install
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @file
+ * Copyright 2019 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+use Apigee\Edge\Utility\OrganizationFeatures;
+
+/**
+ * @file
+ * Install, update and uninstall functions for Apigee Edge Teams.
+ */
+
+/**
+ * Implements hook_requirements().
+ */
+function apigee_edge_teams_requirements($phase) {
+  $requirements = [];
+
+  if ($phase == 'install' || $phase == 'runtime') {
+    try {
+      /** @var \Drupal\apigee_edge\SDKConnectorInterface $sdk_connector */
+      $sdk_connector = \Drupal::service('apigee_edge.sdk_connector');
+      $org_controller = \Drupal::service('apigee_edge.controller.organization');
+      /* @var \Apigee\Edge\Api\Management\Entity\Organization $organization */
+      $organization = $org_controller->load($sdk_connector->getOrganization());
+      if ($organization && !OrganizationFeatures::isCompaniesFeatureAvailable($organization)) {
+        $requirements['apigee_edge_teams_not_supported'] = [
+          'title' => t('Apigee Edge Teams'),
+          'description' => t('Teams are not supported for your Apigee Edge organization.'),
+          'severity' => REQUIREMENT_ERROR,
+        ];
+      }
+    }
+    catch (\Exception $exception) {
+      // Do nothing if connection to Edge is not available.
+    }
+  }
+
+  return $requirements;
+}

--- a/modules/apigee_edge_teams/apigee_edge_teams.install
+++ b/modules/apigee_edge_teams/apigee_edge_teams.install
@@ -41,7 +41,7 @@ function apigee_edge_teams_requirements($phase) {
       if ($organization && !OrganizationFeatures::isCompaniesFeatureAvailable($organization)) {
         $requirements['apigee_edge_teams_not_supported'] = [
           'title' => t('Apigee Edge Teams'),
-          'description' => t('Teams are not supported for your Apigee Edge organization.'),
+          'description' => t('Teams are not available for your org because <a href=':url' target='_blank'>Edge company APIs are not supported in Apigee hybrid orgs</a>.', [':url' => 'https://docs.apigee.com/hybrid/compare-hybrid-edge#unsupported-apis'] ),
           'severity' => REQUIREMENT_ERROR,
         ];
       }

--- a/modules/apigee_edge_teams/apigee_edge_teams.install
+++ b/modules/apigee_edge_teams/apigee_edge_teams.install
@@ -39,9 +39,15 @@ function apigee_edge_teams_requirements($phase) {
       /* @var \Apigee\Edge\Api\Management\Entity\Organization $organization */
       $organization = $org_controller->load($sdk_connector->getOrganization());
       if ($organization && !OrganizationFeatures::isCompaniesFeatureAvailable($organization)) {
+        $url = [
+          ':url' => 'https://docs.apigee.com/hybrid/compare-hybrid-edge#unsupported-apis',
+        ];
+        $message = ($phase == 'runtime') ?
+          t("The Apigee Edge Teams module functionality is not available for your org and should be uninstalled, because <a href=':url' target='_blank'>Edge company APIs are not supported in Apigee hybrid orgs</a>.", $url) :
+          t("The Apigee Edge Teams module functionality is not available for your org because <a href=':url' target='_blank'>Edge company APIs are not supported in Apigee hybrid orgs</a>.", $url);
         $requirements['apigee_edge_teams_not_supported'] = [
           'title' => t('Apigee Edge Teams'),
-          'description' => t('Teams are not available for your org because <a href=':url' target='_blank'>Edge company APIs are not supported in Apigee hybrid orgs</a>.', [':url' => 'https://docs.apigee.com/hybrid/compare-hybrid-edge#unsupported-apis'] ),
+          'description' => $message,
           'severity' => REQUIREMENT_ERROR,
         ];
       }


### PR DESCRIPTION
Fixes #299 . PR adds an install/runtime requirements check to `apigee_edge_teams` module that verifies if the configured Edge connection is to a Hybrid org, and if so, throws a requirements error. How this works:

- If the Edge connection has already been configured when trying to enable the teams module, and it is connecting to a Hybrid org, it will prevent installing the module and display an error: _Teams are not supported for your Apigee Edge organization._
- If the Edge connection still hasn't been setup when enabling the teams module, installation will proceed. When the connection to a Hybrid org has been configured, an error will be shown on Drupal's status report page: _Teams are not supported for your Apigee Edge organization._

NOTE: Requires https://github.com/apigee/apigee-client-php/pull/93 on the PHP client.
