### PR TITLE
[#291] Highlight "D8P" solution for hybrid being in alpha.

### DIFF
--- a/apigee_edge.install
+++ b/apigee_edge.install
@@ -23,6 +23,7 @@
  * Install, update and uninstall functions for Apigee Edge.
  */
 
+use Apigee\Edge\Utility\OrganizationFeatures;
 use Drupal\apigee_edge\OauthTokenFileStorage;
 use Drupal\Core\Url;
 use Drupal\user\RoleInterface;
@@ -32,6 +33,7 @@ use Drupal\user\RoleInterface;
  */
 function apigee_edge_requirements($phase) {
   $requirements = [];
+  $hybrid_support_message = t('Support for Apigee hybrid in the Apigee modules is in Alpha. Connecting to a hybrid organization is appropriate for evaluation and testing purposes during this pre-production stage.');
 
   if ($phase === 'install') {
     // This should be checked only if Drupal is installed.
@@ -48,12 +50,26 @@ function apigee_edge_requirements($phase) {
         ];
       }
     }
+
+    \Drupal::messenger()->addWarning($hybrid_support_message);
   }
   elseif ($phase === 'runtime') {
     /** @var \Drupal\apigee_edge\SDKConnectorInterface $sdk_connector */
     $sdk_connector = \Drupal::service('apigee_edge.sdk_connector');
     try {
       $sdk_connector->testConnection();
+
+      // Hybrid support warning.
+      $org_controller = \Drupal::service('apigee_edge.controller.organization');
+      /* @var \Apigee\Edge\Api\Management\Entity\Organization $organization */
+      $organization = $org_controller->load($sdk_connector->getOrganization());
+      if ($organization && OrganizationFeatures::isHybridEnabled($organization)) {
+        $requirements['apigee_edge_hybrid_support'] = [
+          'title' => t('Apigee Edge'),
+          'description' => $hybrid_support_message,
+          'severity' => REQUIREMENT_WARNING,
+        ];
+      }
     }
     catch (\Exception $exception) {
       $requirements['apigee_edge_connection_error'] = [

--- a/src/Plugin/KeyInput/ApigeeAuthKeyInput.php
+++ b/src/Plugin/KeyInput/ApigeeAuthKeyInput.php
@@ -88,6 +88,15 @@ class ApigeeAuthKeyInput extends KeyInputBase {
       ],
       '#default_value' => $values['instance_type'] ?? 'public',
     ];
+    $form['hybrid_support_info'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Support for Apigee hybrid'),
+      '#description' => $this->t('Support for Apigee hybrid in the Apigee modules is in Alpha. Connecting to a hybrid organization is appropriate for evaluation and testing purposes during this pre-production stage.'),
+
+      '#states' => [
+        'visible' => $state_for_hybrid,
+      ],
+    ];
     $form['auth_type'] = [
       '#type' => 'select',
       '#title' => $this->t('Authentication type'),


### PR DESCRIPTION
Fixes #291 . This PR adds the following:

- A message when the `apigee_edge` module is installed:
![image](https://user-images.githubusercontent.com/4062676/69376106-8ff6d980-0c5e-11ea-8ce3-43b464712a4d.png)

- A message on the Edge connection configuration form when "Hybrid" is selected:
![image](https://user-images.githubusercontent.com/4062676/69376168-a9982100-0c5e-11ea-8109-c3974268159b.png)

- A warning message on Drupal's status report page only when the connection has been configured to a hybrid org:
![image](https://user-images.githubusercontent.com/4062676/69376292-e5cb8180-0c5e-11ea-8c72-05297e442a1f.png)


