### PR TITLE
[#321] Increase max_length for first_name and last_name fields

### DIFF
--- a/apigee_edge.install
+++ b/apigee_edge.install
@@ -186,7 +186,7 @@ function apigee_edge_update_8002() {
 /**
  * Increase the max_length for first_name and last_name fields.
  */
-function apigee_edge_update_8003() {
+function apigee_edge_update_8101() {
   $entity_type_id = 'user';
   $fields = ['first_name', 'last_name'];
   $field_length = 64;

--- a/apigee_edge.install
+++ b/apigee_edge.install
@@ -182,3 +182,57 @@ function apigee_edge_update_8002() {
   // Empty.
   // Removed because Hybrid support makes this update hook unneeded.
 }
+
+/**
+ * Increase the max_length for first_name and last_name fields.
+ */
+function apigee_edge_update_8003() {
+  $entity_type_id = 'user';
+  $fields = ['first_name', 'last_name'];
+  $field_length = 64;
+
+  $definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+  $last_installed_schema_repository = \Drupal::service('entity.last_installed_schema.repository');
+
+  /** @var \Drupal\Core\Field\FieldStorageDefinitionInterface[] $field_storage_definitions */
+  $field_storage_definitions = $last_installed_schema_repository->getLastInstalledFieldStorageDefinitions($entity_type_id);
+  $entity_type = $definition_update_manager->getEntityType($entity_type_id);
+
+  $definition = \Drupal::entityTypeManager()->getDefinition($entity_type_id);
+  $data_table = $definition->getDataTable();
+  $revision_data_table = $definition->getRevisionDataTable();
+  $entity_storage_schema_sql = \Drupal::keyValue('entity.storage_schema.sql');
+
+  $schema = \Drupal::database()->schema();
+
+  // Update the field storage definition.
+  foreach ($fields as $field_name) {
+    $field_storage_definitions[$field_name]->setSetting('max_length', $field_length);
+  }
+
+  $definition_update_manager->updateFieldableEntityType($entity_type, $field_storage_definitions, $sandbox);
+
+  // Update table schema.
+  foreach ($fields as $field_name) {
+    $schema_key = "$entity_type_id.field_schema_data.$field_name";
+    if ($field_schema_data = $entity_storage_schema_sql->get($schema_key)) {
+      // Update storage schema for data table.
+      $field_schema_data[$data_table]['fields'][$field_name]['length'] = $field_length;
+
+      // Update storage schema for the revision table.
+      if ($revision_data_table) {
+        $field_schema_data[$revision_data_table]['fields'][$field_name]['length'] = $field_length;
+      }
+
+      $entity_storage_schema_sql->set($schema_key, $field_schema_data);
+
+      // Update the base database field.
+      $schema->changeField($data_table, $field_name, $field_name, $field_schema_data[$data_table]['fields'][$field_name]);
+
+      // Update schema for the revision table.
+      if ($revision_data_table) {
+        $schema->changeField($revision_data_table, $field_name, $field_name, $field_schema_data[$revision_data_table]['fields'][$field_name]);
+      }
+    }
+  }
+}

--- a/apigee_edge.install
+++ b/apigee_edge.install
@@ -210,7 +210,7 @@ function apigee_edge_update_8101() {
     $field_storage_definitions[$field_name]->setSetting('max_length', $field_length);
   }
 
-  $definition_update_manager->updateFieldableEntityType($entity_type, $field_storage_definitions, $sandbox);
+  $definition_update_manager->updateFieldableEntityType($entity_type, $field_storage_definitions);
 
   // Update table schema.
   foreach ($fields as $field_name) {

--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -248,7 +248,7 @@ function apigee_edge_entity_base_field_info(EntityTypeInterface $entity_type) {
     $fields['first_name'] = BaseFieldDefinition::create('string')
       ->setLabel(t('First name'))
       ->setDescription(t('Your first name.'))
-      ->setSetting('max_length', 32)
+      ->setSetting('max_length', 64)
       ->setRequired(TRUE)
       ->setInitialValue('Firstname')
       ->setDisplayOptions('form', [
@@ -263,7 +263,7 @@ function apigee_edge_entity_base_field_info(EntityTypeInterface $entity_type) {
     $fields['last_name'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Last name'))
       ->setDescription(t('Your last name.'))
-      ->setSetting('max_length', 32)
+      ->setSetting('max_length', 64)
       ->setRequired(TRUE)
       ->setInitialValue('Lastname')
       ->setDisplayOptions('form', [

--- a/tests/src/Functional/DeveloperSyncTest.php
+++ b/tests/src/Functional/DeveloperSyncTest.php
@@ -151,8 +151,8 @@ class DeveloperSyncTest extends ApigeeEdgeFunctionalTestBase {
       $this->edgeDevelopers[$mail] = Developer::create([
         'email' => $mail,
         'userName' => $this->randomMachineName(),
-        'firstName' => $this->randomMachineName(),
-        'lastName' => $this->randomMachineName(),
+        'firstName' => $this->randomMachineName(64),
+        'lastName' => $this->randomMachineName(64),
       ]);
       foreach ($this->fields as $field_type => $data) {
         $formatter = $this->formatManager->lookupPluginForFieldType($field_type);

--- a/tests/src/Kernel/UserCreateTest.php
+++ b/tests/src/Kernel/UserCreateTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Copyright 2020 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\Tests\apigee_edge\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\user\Entity\User;
+
+/**
+ * Test create operations for User entity type.
+ *
+ * @group apigee_edge
+ * @group apigee_edge_kernel
+ */
+class UserCreateTest extends KernelTestBase {
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'user',
+    'system',
+    'apigee_edge',
+    'key',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installSchema('system', ['sequences']);
+    $this->installSchema('user', ['users_data']);
+    $this->installEntitySchema('user');
+  }
+
+  /**
+   * Test user create.
+   */
+  public function testUserCreate() {
+    $user = User::create([
+      'mail' => $this->randomMachineName() . '@example.com',
+      'name' => $this->randomMachineName(),
+      'first_name' => $this->randomMachineName(64),
+      'last_name' => $this->randomMachineName(64),
+    ]);
+
+    $this->assertEquals(SAVED_NEW, $user->save());
+  }
+
+}


### PR DESCRIPTION
Fixes #321 

This PR increases the `max_length` for `first_name` and `last_name` fields to 64.

Note: 

I searched the docs but did not find this limit (64) documented anywhere. I manually tested this and it started failing at 65. (The D7 module is using the max value (255) for the fields)

https://docs.apigee.com/api-platform/reference/naming-guidelines
https://docs.apigee.com/api-platform/publish/drupal/add-and-manage-user-accounts.html