### PR TITLE
#346 Switch to mocks for kernel EntityControllerCacheTest

### DIFF
--- a/tests/modules/apigee_mock_api_client/README.md
+++ b/tests/modules/apigee_mock_api_client/README.md
@@ -31,6 +31,11 @@ client. All that is needed is overriding and setting the following property to "
   - Use `Drupal\Tests\apigee_mock_api_client\Traits\ApigeeMockApiClientHelperTrait` in the test class. It provides
   helper methods to initialize and use the mock API client.
   - Call `$this->apigeeTestHelperSetup()` to set the client up.
+  - To make it easier to know that a kernel test is compatible with the mock client, add the following property:
+
+  ```
+    protected static $mock_api_client_ready = TRUE;
+  ```
 
 ### Mock responses
 

--- a/tests/src/Kernel/EntityControllerCacheTest.php
+++ b/tests/src/Kernel/EntityControllerCacheTest.php
@@ -36,6 +36,13 @@ class EntityControllerCacheTest extends KernelTestBase {
   use EntityControllerCacheUtilsTrait;
 
   /**
+   * Indicates this test class is mock API client ready.
+   *
+   * @var bool
+   */
+  protected static $mock_api_client_ready = TRUE;
+
+  /**
    * {@inheritdoc}
    */
   protected static $modules = [


### PR DESCRIPTION
This test didn't need refactoring, as no API calls are made. Just marking it as compatible/ready witth the mock client.