### PR TITLE
#347 Switch to mocks for Kernel MockIntegrationToggleKernelTest

### DIFF
--- a/tests/src/Kernel/MockIntegrationToggleKernelTest.php
+++ b/tests/src/Kernel/MockIntegrationToggleKernelTest.php
@@ -32,6 +32,13 @@ use GuzzleHttp\HandlerStack;
 class MockIntegrationToggleKernelTest extends KernelTestBase {
 
   /**
+   * Indicates this test class is mock API client ready.
+   *
+   * @var bool
+   */
+  protected static $mock_api_client_ready = TRUE;
+
+  /**
    * {@inheritdoc}
    */
   protected static $modules = [


### PR DESCRIPTION
This test didn't need refactoring, as no API calls are made. Just marking it as compatible/ready witth the mock client.