### PR TITLE
#348 Switch to mocks for kernel OauthTokenFileStorageTest 

### DIFF
--- a/tests/src/Kernel/OauthTokenFileStorageTest.php
+++ b/tests/src/Kernel/OauthTokenFileStorageTest.php
@@ -32,6 +32,13 @@ use Drupal\KernelTests\KernelTestBase;
  */
 class OauthTokenFileStorageTest extends KernelTestBase {
 
+  /**
+   * Indicates this test class is mock API client ready.
+   *
+   * @var bool
+   */
+  protected static $mock_api_client_ready = TRUE;
+
   private const CUSTOM_TOKEN_DIR = 'oauth/token/dir';
 
   /**


### PR DESCRIPTION
This test didn't need refactoring, as no API calls are made. Just marking it as compatible/ready witth the mock client.