### PR TITLE
#349 Switch to mocks for kernel TestFrameworkKernelTest

### DIFF
--- a/tests/src/Kernel/TestFrameworkKernelTest.php
+++ b/tests/src/Kernel/TestFrameworkKernelTest.php
@@ -39,6 +39,13 @@ class TestFrameworkKernelTest extends KernelTestBase {
   use UserCreationTrait;
 
   /**
+   * Indicates this test class is mock API client ready.
+   *
+   * @var bool
+   */
+  protected static $mock_api_client_ready = TRUE;
+
+  /**
    * {@inheritdoc}
    */
   protected static $modules = [


### PR DESCRIPTION
This test didn't need refactoring, as it was already compatible. Just marking it as compatible/ready with the mock client.