### PR TITLE
#350 Switch to mocks for kernel UserCreateTest

### DIFF
--- a/tests/src/Kernel/UserCreateTest.php
+++ b/tests/src/Kernel/UserCreateTest.php
@@ -20,6 +20,7 @@
 namespace Drupal\Tests\apigee_edge\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\apigee_mock_api_client\Traits\ApigeeMockApiClientHelperTrait;
 use Drupal\user\Entity\User;
 
 /**
@@ -29,6 +30,9 @@ use Drupal\user\Entity\User;
  * @group apigee_edge_kernel
  */
 class UserCreateTest extends KernelTestBase {
+
+  use ApigeeMockApiClientHelperTrait;
+
   /**
    * {@inheritdoc}
    */
@@ -37,7 +41,15 @@ class UserCreateTest extends KernelTestBase {
     'system',
     'apigee_edge',
     'key',
+    'apigee_mock_api_client',
   ];
+
+  /**
+   * Indicates this test class is mock API client ready.
+   *
+   * @var bool
+   */
+  protected static $mock_api_client_ready = TRUE;
 
   /**
    * {@inheritdoc}
@@ -48,6 +60,8 @@ class UserCreateTest extends KernelTestBase {
     $this->installSchema('system', ['sequences']);
     $this->installSchema('user', ['users_data']);
     $this->installEntitySchema('user');
+
+    $this->apigeeTestHelperSetup();
   }
 
   /**
@@ -60,6 +74,8 @@ class UserCreateTest extends KernelTestBase {
       'first_name' => $this->randomMachineName(64),
       'last_name' => $this->randomMachineName(64),
     ]);
+
+    $this->queueDeveloperResponse($user, 200);
 
     $this->assertEquals(SAVED_NEW, $user->save());
   }

--- a/tests/src/Kernel/UserCreateTest.php
+++ b/tests/src/Kernel/UserCreateTest.php
@@ -103,7 +103,7 @@ class UserCreateTest extends KernelTestBase {
       'last_name' => $this->randomMachineName(64),
     ]);
 
-    $this->queueDeveloperResponse($this->account, 200);
+    $this->queueDeveloperResponse($this->account, 201);
 
     $this->assertEquals(SAVED_NEW, $this->account->save());
   }

--- a/tests/src/Kernel/UserCreateTest.php
+++ b/tests/src/Kernel/UserCreateTest.php
@@ -34,6 +34,13 @@ class UserCreateTest extends KernelTestBase {
   use ApigeeMockApiClientHelperTrait;
 
   /**
+   * A Drupal user.
+   *
+   * @var \Drupal\user\Entity\User
+   */
+  protected $account;
+
+  /**
    * {@inheritdoc}
    */
   protected static $modules = [
@@ -65,19 +72,40 @@ class UserCreateTest extends KernelTestBase {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  protected function tearDown() {
+    $this->stack->reset();
+    try {
+      if ($this->account) {
+        $this->queueDeveloperResponse($this->account);
+        $developer = \Drupal::entityTypeManager()
+          ->getStorage('developer')
+          ->create([
+            'email' => $this->account->getEmail(),
+          ]);
+        $developer->delete();
+      }
+    }
+    catch (\Exception $exception) {
+      $this->logException($exception);
+    }
+  }
+
+  /**
    * Test user create.
    */
   public function testUserCreate() {
-    $user = User::create([
+    $this->account = User::create([
       'mail' => $this->randomMachineName() . '@example.com',
       'name' => $this->randomMachineName(),
       'first_name' => $this->randomMachineName(64),
       'last_name' => $this->randomMachineName(64),
     ]);
 
-    $this->queueDeveloperResponse($user, 200);
+    $this->queueDeveloperResponse($this->account, 200);
 
-    $this->assertEquals(SAVED_NEW, $user->save());
+    $this->assertEquals(SAVED_NEW, $this->account->save());
   }
 
 }


### PR DESCRIPTION
Refactors the test to use the sdk connector's client, and apigee_mock_api_client.