### PR TITLE
[#365] Switch functional DeveloperAppAnalyticsTest: use mock client.

### DIFF
--- a/tests/modules/apigee_mock_api_client/tests/response-templates/app-analytics.json.twig
+++ b/tests/modules/apigee_mock_api_client/tests/response-templates/app-analytics.json.twig
@@ -1,0 +1,18 @@
+  {#
+  /**
+   * @file
+   *   App analytics.
+   *
+   * Variables: none.
+   */
+  #}
+{
+  "Response" : {
+    "TimeUnit" : [ ],
+    "metaData" : {
+      "errors" : [ ],
+      "notices" : [ "Source:Postgres", "Table used: edge.api.faxgroupusenondn012.agg_app", "query served by:31c31eba-a1b8-4796-a17c-e64a82d2610c", "PG Host:uap-trial-us-central1-1:us-central1:rgce1uappg02s" ]
+    },
+    "resultTruncated" : false
+  }
+}

--- a/tests/modules/apigee_mock_api_client/tests/response-templates/developer-app.json.twig
+++ b/tests/modules/apigee_mock_api_client/tests/response-templates/developer-app.json.twig
@@ -1,0 +1,35 @@
+{#
+/**
+ * @file
+ *   Developer App include file.
+ *
+ * Usage:
+ *   @code {% include 'developer-app.json.twig' %} @endcode
+ *
+ * Variables: An "app" with the following properties or keys.
+ *   - appId:          AppId.
+ *   - displayName:   User-friendly display name of the Developer App.
+ *   - name:          Machine name of the Developer App.
+ *   - developerId:   ID of the developer/app owner.
+ *   - status:        The Developer App status.
+ */
+#}
+{
+  "appFamily": "default",
+  "appId": "{{ app.appId }}",
+  "attributes": [
+    {
+      "name": "DisplayName",
+      "value": "{{ app.displayName }}"
+    }
+  ],
+  "developerId": "{{ app.developerId }}",
+  "name": "{{ app.name }}",
+  "status":  "{{ app.status|default('approved') }}",
+  "createdAt" : 1540110813284,
+  "createdBy" : "{{ app.createdBy|default('foo@example.com') }}",
+  "lastModifiedAt" : 1540110813284,
+  "lastModifiedBy" : "{{ app.lastModifiedBy|default('foo@example.com') }}",
+  "scopes" : [ ],
+  "credentials" : [ ]
+}

--- a/tests/modules/apigee_mock_api_client/tests/response-templates/get-developer-app.json.twig
+++ b/tests/modules/apigee_mock_api_client/tests/response-templates/get-developer-app.json.twig
@@ -1,0 +1,12 @@
+{#
+/**
+ * @file
+ *   GET /v1/organizations/{org_name}/developers/{developer_email_or_id}/apps/{app_name}
+ *
+ * Variables:
+ * - org_name:              The name of the org.
+ * - developer_email_or_id: The developer email or id.
+ * - app_name:              The machine name of the app.
+ */
+#}
+{% include 'developer-app.json.twig' %}

--- a/tests/modules/apigee_mock_api_client/tests/src/Traits/ApigeeMockApiClientHelperTrait.php
+++ b/tests/modules/apigee_mock_api_client/tests/src/Traits/ApigeeMockApiClientHelperTrait.php
@@ -238,7 +238,7 @@ trait ApigeeMockApiClientHelperTrait {
           'appId' => $app->getAppId() ?: $this->randomMachineName(),
           'name' => $app->getName(),
           'status' => $app->getStatus(),
-          'displayName' => $app->getStatus(),
+          'displayName' => $app->getDisplayName(),
           'developerId' => $app->getDeveloperId(),
         ],
       ],

--- a/tests/modules/apigee_mock_api_client/tests/src/Traits/ApigeeMockApiClientHelperTrait.php
+++ b/tests/modules/apigee_mock_api_client/tests/src/Traits/ApigeeMockApiClientHelperTrait.php
@@ -23,6 +23,7 @@ use Apigee\Edge\Api\Management\Entity\Company;
 use Apigee\Edge\Api\Management\Entity\Organization;
 use Apigee\MockClient\Generator\ApigeeSdkEntitySource;
 use Drupal\apigee_edge\Entity\Developer;
+use Drupal\apigee_edge\Entity\DeveloperAppInterface;
 use Drupal\apigee_edge\Entity\DeveloperInterface;
 use Drupal\Tests\apigee_edge\Traits\ApigeeEdgeUtilTestTrait;
 use Drupal\user\UserInterface;
@@ -219,6 +220,29 @@ trait ApigeeMockApiClientHelperTrait {
     $context['developers'] = $developers;
 
     $this->stack->queueMockResponse(['developers_in_company' => $context]);
+  }
+
+  /**
+   * Add an app analytics mock response to the stack.
+   *
+   * @param \Drupal\apigee_edge\Entity\DeveloperAppInterface $app
+   *   The app.
+   * @param int $response_code
+   *   Response code, defaults to 200.
+   */
+  protected function queueDeveloperAppResponse(DeveloperAppInterface $app, $response_code = 200) {
+    $this->stack->queueMockResponse([
+      'get_developer_app' => [
+        'status_code' => $response_code,
+        'app' => [
+          'appId' => $app->getAppId() ?: $this->randomMachineName(),
+          'name' => $app->getName(),
+          'status' => $app->getStatus(),
+          'displayName' => $app->getStatus(),
+          'developerId' => $app->getDeveloperId(),
+        ],
+      ],
+    ]);
   }
 
   /**

--- a/tests/src/Functional/DeveloperAppAnalyticsTest.php
+++ b/tests/src/Functional/DeveloperAppAnalyticsTest.php
@@ -22,7 +22,6 @@ namespace Drupal\Tests\apigee_edge\Functional;
 use Apigee\Edge\Api\Management\Entity\App;
 use Drupal\apigee_edge\Entity\Developer;
 use Drupal\apigee_edge\Entity\DeveloperApp;
-use Drupal\apigee_edge\Entity\DeveloperAppInterface;
 use Drupal\Component\Utility\Crypt;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Url;
@@ -254,29 +253,6 @@ class DeveloperAppAnalyticsTest extends ApigeeEdgeFunctionalTestBase {
   protected function queueAppAnalyticsStackedResponse() {
     $this->stack->queueMockResponse([
       'app_analytics' => [],
-    ]);
-  }
-
-  /**
-   * Add an app analytics mock response to the stack.
-   *
-   * @param \Drupal\apigee_edge\Entity\DeveloperAppInterface $app
-   *   The app.
-   * @param int $response_code
-   *   Response code, defaults to 200.
-   */
-  protected function queueDeveloperAppResponse(DeveloperAppInterface $app, $response_code = 200) {
-    $this->stack->queueMockResponse([
-      'get_developer_app' => [
-        'status_code' => $response_code,
-        'app' => [
-          'appId' => $app->getAppId() ?: $this->randomMachineName(),
-          'name' => $app->getName(),
-          'status' => $app->getStatus(),
-          'displayName' => $app->getStatus(),
-          'developerId' => $app->getDeveloperId(),
-        ],
-      ],
     ]);
   }
 


### PR DESCRIPTION
Refactors the test to use the sdk connector's client, and apigee_mock_api_client.
It reuses some of the mock templates that would be added by #360 , so this PR will need a touch up after that one gets merged.