### PR TITLE
With m10n module enabled, non monetized API products do not follow RBAC

### DIFF
--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -365,8 +365,9 @@ function apigee_edge_entity_view(array &$build, EntityInterface $entity, EntityV
  * for the API Product (entity) if the API product's access attribute value is
  * either one of the selected access attribute values OR if a developer
  * app is in association with the selected API product.
- * - If operation is "assign" then second part of the previous sentence does
- * not apply only access attribute's value matters.
+ * - If operation is "assign" then disallow access if the role is configured
+ * in the "Access by visibility" settings at the route
+ * apigee_edge.settings.developer.api_product_access.
  */
 function apigee_edge_api_product_access(EntityInterface $entity, $operation, AccountInterface $account) {
   /** @var \Drupal\apigee_edge\Entity\ApiProductInterface $entity */
@@ -386,12 +387,12 @@ function apigee_edge_api_product_access(EntityInterface $entity, $operation, Acc
     // access setting but we should still grant view access
     // if they have a developer app in association with this API product.
     if (empty(array_intersect($visible_to_roles, $account->getRoles()))) {
-      // We should not return allowed if the operation is "assign"
-      // just because a user has an app with the API product.
-      // Displaying these API products to a user should be solved on the
-      // form level always.
+
       if ($operation === 'assign') {
-        $result = AccessResult::neutral();
+        // If the apigee_edge.settings.developer.api_product_access settings
+        // limits access to this API product, do not allow user to assign it
+        // to an application.
+        $result = AccessResult::forbidden("User {$account->getEmail()} is does not have permissions to see API Product with visibility {$product_visibility}.");
       }
       else {
         $result = _apigee_edge_user_has_an_app_with_product($entity->id(), $account, TRUE);

--- a/tests/src/FunctionalJavascript/ApiProductAccessTest.php
+++ b/tests/src/FunctionalJavascript/ApiProductAccessTest.php
@@ -179,7 +179,7 @@ class ApiProductAccessTest extends ApigeeEdgeFunctionalJavascriptTestBase {
         ];
         $this->saveAccessSettings($settings);
         // We have to clear entity access control handler's static cache because
-        // otherwise access results comes from there instead of gets
+        // otherwise access results comes from there instead of getting
         // recalculated.
         $this->accessControlHandler->resetCache();
         foreach ($this->users as $userRole => $user) {


### PR DESCRIPTION
The Apigee M10n module’s hook_ENTITY_TYPE_access uses the Apigee Monetization API to determine an API Product ‘assign’ access by calling `/developers/{developer}/eligible-products`, which returns AccessResult::allowed for all API products.

This API returns all API Products
1. That are able to be assigned to an App because the developer purchased a Rate plan that contains the API product
2. All API products that are not monetized.

Due to #2, the Apigee Edge module hook_ENTITY_TYPE_access needs to return AccessResult::forbidden when the operation is ‘assign’ and the user does not have the correct role to assign an API product to an app.