### PR TITLE
Sync: prevent exception if username is too long

### DIFF
--- a/src/Job/UserCreate.php
+++ b/src/Job/UserCreate.php
@@ -19,35 +19,12 @@
 
 namespace Drupal\apigee_edge\Job;
 
-use Drupal\apigee_edge\Exception\DeveloperToUserConversationInvalidValueException;
 use Drupal\apigee_edge\Structure\DeveloperToUserConversionResult;
-use Drupal\user\Plugin\Validation\Constraint\UserNameUnique;
-use Symfony\Component\Validator\ConstraintViolation;
 
 /**
  * A job to create a Drupal user from an Apigee Edge developer.
  */
 class UserCreate extends UserCreateUpdate {
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function beforeUserSave(DeveloperToUserConversionResult $result): void {
-    // Abort the operation if any of these special problems occurred
-    // meanwhile the conversation.
-    foreach ($result->getProblems() as $problem) {
-      if ($problem instanceof DeveloperToUserConversationInvalidValueException) {
-        $violation = $problem->getViolation();
-        // Skip user creation if username is already taken here instead
-        // of getting a database exception in a lower layer.
-        // (Username is not unique in Apigee Edge.)
-        if ($problem->getTarget() === 'name' && $violation instanceof ConstraintViolation && $violation->getConstraint() instanceof UserNameUnique) {
-          throw $problem;
-        }
-      }
-    }
-    parent::beforeUserSave($result);
-  }
 
   /**
    * {@inheritdoc}

--- a/src/Job/UserUpdate.php
+++ b/src/Job/UserUpdate.php
@@ -52,7 +52,7 @@ class UserUpdate extends UserCreateUpdate {
       /** @var \Drupal\user\UserInterface $original_user */
       foreach ($result->getProblems() as $problem) {
         // Do not apply rollback on base fields.
-        if ($problem instanceof DeveloperToUserConversationInvalidValueException && !in_array($problem->getTarget(), $this->userDeveloperConverter()::DEVELOPER_PROP_USER_BASE_FIELD_MAP)) {
+        if ($problem instanceof DeveloperToUserConversationInvalidValueException && !in_array($problem->getTarget(), $this->userDeveloperConverter()::DEVELOPER_PROP_USER_BASE_FIELD_MAP, TRUE)) {
           $result->getUser()->set($problem->getTarget(), $original_user->get($problem->getTarget())->getValue());
         }
       }


### PR DESCRIPTION
Developer sync does not handle properly if the username coming from Apigee Edge is longer than the default accepted length by Drupal (60 charachters as per [UserNameConstraintValidator](https://github.com/drupal/core/blob/8.8.x/modules/user/src/Plugin/Validation/Constraint/UserNameConstraintValidator.php#L56) and [UserInterface](https://github.com/drupal/core/blob/8.8.x/modules/user/src/UserInterface.php#L21)).

Before:
![before](https://user-images.githubusercontent.com/1755573/79754871-785c7380-8318-11ea-90b1-62dd4309cf68.png)

After:
![after](https://user-images.githubusercontent.com/1755573/79754887-7f838180-8318-11ea-98f0-eb576586c702.png)

