### PR TITLE
Validate field level constraints on form save

### DIFF
--- a/src/Entity/Form/FieldableEdgeEntityForm.php
+++ b/src/Entity/Form/FieldableEdgeEntityForm.php
@@ -120,7 +120,7 @@ abstract class FieldableEdgeEntityForm extends EntityForm implements FieldableEd
    * @return string[]
    *   An array of field names.
    *
-   * TODO Add missing return type-hint in 2.x.
+   * @todo Add missing return type-hint in 2.x.
    */
   protected function getEditedFieldNames(FormStateInterface $form_state) {
     return array_keys($this->getFormDisplay($form_state)->getComponents());
@@ -147,7 +147,7 @@ abstract class FieldableEdgeEntityForm extends EntityForm implements FieldableEd
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    *   The current state of the form.
    *
-   * TODO Add missing return type-hint in 2.x.
+   * @todo Add missing return type-hint in 2.x.
    */
   protected function flagViolations(EntityConstraintViolationListInterface $violations, array $form, FormStateInterface $form_state) {
     // Flag entity level violations.

--- a/src/Entity/Form/FieldableEdgeEntityForm.php
+++ b/src/Entity/Form/FieldableEdgeEntityForm.php
@@ -21,6 +21,7 @@ namespace Drupal\apigee_edge\Entity\Form;
 
 use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
 use Drupal\Core\Entity\Entity\EntityFormDisplay;
+use Drupal\Core\Entity\EntityConstraintViolationListInterface;
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -64,16 +65,98 @@ abstract class FieldableEdgeEntityForm extends EntityForm implements FieldableEd
   /**
    * {@inheritdoc}
    *
-   * @see \Drupal\Core\Entity\ContentEntityForm::buildEntity()
+   * TODO Add missing return type-hint in 2.x.
    */
-  public function buildEntity(array $form, FormStateInterface $form_state) {
-    /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
-    $entity = parent::buildEntity($form, $form_state);
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    parent::validateForm($form, $form_state);
+    /** @var \Drupal\apigee_edge\Entity\FieldableEdgeEntityInterface $entity */
+    $entity = $this->buildEntity($form, $form_state);
 
-    // Mark the entity as requiring validation.
-    $entity->setValidationRequired(!$form_state->getTemporaryValue('entity_validated'));
+    $violations = $entity->validate();
+
+    // Remove violations of inaccessible fields.
+    $violations->filterByFieldAccess($this->currentUser());
+
+    // In case a field-level submit button is clicked, for example the 'Add
+    // another item' button for multi-value fields or the 'Upload' button for a
+    // File or an Image field, make sure that we only keep violations for that
+    // specific field.
+    $edited_fields = [];
+    if ($limit_validation_errors = $form_state->getLimitValidationErrors()) {
+      foreach ($limit_validation_errors as $section) {
+        $field_name = reset($section);
+        if ($entity->hasField($field_name)) {
+          $edited_fields[] = $field_name;
+        }
+      }
+      $edited_fields = array_unique($edited_fields);
+    }
+    else {
+      $edited_fields = $this->getEditedFieldNames($form_state);
+    }
+
+    // Remove violations for fields that are not edited.
+    $violations->filterByFields(array_diff(array_keys($entity->getFieldDefinitions()), $edited_fields));
+
+    $this->flagViolations($violations, $form, $form_state);
+
+    // The entity was validated.
+    $entity->setValidationRequired(FALSE);
+    $form_state->setTemporaryValue('entity_validated', TRUE);
 
     return $entity;
+  }
+
+  /**
+   * Gets the names of all fields edited in the form.
+   *
+   * If the entity form customly adds some fields to the form (i.e. without
+   * using the form display), it needs to add its fields here and override
+   * flagViolations() for displaying the violations.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   *
+   * @return string[]
+   *   An array of field names.
+   *
+   * TODO Add missing return type-hint in 2.x.
+   */
+  protected function getEditedFieldNames(FormStateInterface $form_state) {
+    return array_keys($this->getFormDisplay($form_state)->getComponents());
+  }
+
+  /**
+   * Flags violations for the current form.
+   *
+   * If the entity form customly adds some fields to the form (i.e. without
+   * using the form display), it needs to add its fields to array returned by
+   * getEditedFieldNames() and overwrite this method in order to show any
+   * violations for those fields; e.g.:
+   * @code
+   * foreach ($violations->getByField('name') as $violation) {
+   *   $form_state->setErrorByName('name', $violation->getMessage());
+   * }
+   * parent::flagViolations($violations, $form, $form_state);
+   * @endcode
+   *
+   * @param \Drupal\Core\Entity\EntityConstraintViolationListInterface $violations
+   *   The violations to flag.
+   * @param array $form
+   *   A nested array of form elements comprising the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   *
+   * TODO Add missing return type-hint in 2.x.
+   */
+  protected function flagViolations(EntityConstraintViolationListInterface $violations, array $form, FormStateInterface $form_state) {
+    // Flag entity level violations.
+    foreach ($violations->getEntityViolations() as $violation) {
+      /** @var \Symfony\Component\Validator\ConstraintViolationInterface $violation */
+      $form_state->setErrorByName(str_replace('.', '][', $violation->getPropertyPath()), $violation->getMessage());
+    }
+    // Let the form display flag violations of its fields.
+    $this->getFormDisplay($form_state)->flagWidgetsErrorsFromViolations($violations, $form, $form_state);
   }
 
   /**

--- a/tests/modules/apigee_edge_test/apigee_edge_test.module
+++ b/tests/modules/apigee_edge_test/apigee_edge_test.module
@@ -33,7 +33,7 @@ use Drupal\apigee_edge_test\Entity\Storage\DeveloperAppStorage;
  */
 function apigee_edge_test_entity_type_alter(array &$entity_types) {
   /* @var $entity_types \Drupal\Core\Entity\EntityTypeInterface[] */
-  foreach (_apigee_edge_entity_class_mapping() as $entity_type => $entity_class) {
+  foreach (_apigee_edge_test_entity_class_mapping() as $entity_type => $entity_class) {
     if (isset($entity_types[$entity_type])) {
       $entity_types[$entity_type]->setClass($entity_class);
     }
@@ -48,7 +48,7 @@ function apigee_edge_test_entity_type_alter(array &$entity_types) {
  * @return array
  *   Override map.
  */
-function _apigee_edge_entity_class_mapping(): array {
+function _apigee_edge_test_entity_class_mapping(): array {
   return [
     'developer' => OverriddenDeveloper::class,
     'developer_app' => OverriddenDeveloperApp::class,

--- a/tests/modules/apigee_edge_test/src/Entity/OverriddenDeveloperApp.php
+++ b/tests/modules/apigee_edge_test/src/Entity/OverriddenDeveloperApp.php
@@ -20,8 +20,29 @@
 namespace Drupal\apigee_edge_test\Entity;
 
 use Drupal\apigee_edge\Entity\DeveloperApp;
+use Drupal\Core\Entity\EntityTypeInterface;
 
 /**
  * Class OverriddenDeveloperApp.
  */
-final class OverriddenDeveloperApp extends DeveloperApp {}
+final class OverriddenDeveloperApp extends DeveloperApp {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function baseFieldDefinitions(EntityTypeInterface $entity_type): array {
+    /** @var \Drupal\Core\Field\BaseFieldDefinition[] $definitions */
+    $definitions = parent::baseFieldDefinitions($entity_type);
+
+    // Set a length limit on app name that we can use in tests.
+    $definitions['displayName']->setPropertyConstraints('value', [
+      'Length' => [
+        'min' => 1,
+        'max' => 30,
+      ],
+    ]);
+
+    return $definitions;
+  }
+
+}

--- a/tests/src/Functional/DeveloperAppUITest.php
+++ b/tests/src/Functional/DeveloperAppUITest.php
@@ -178,6 +178,23 @@ class DeveloperAppUITest extends ApigeeEdgeFunctionalTestBase {
   }
 
   /**
+   * Tests that field validation constraints are executed on form save.
+   *
+   * @covers \Drupal\apigee_edge\Entity\Form\FieldableEdgeEntityForm::validateForm
+   */
+  public function testFieldValidationConstraints() {
+    /* @see \Drupal\apigee_edge_test\Entity\OverriddenDeveloperApp::baseFieldDefinitions() */
+    $name = strtolower($this->randomMachineName(31));
+
+    $this->postCreateAppForm([
+      'name' => $name,
+      'displayName[0][value]' => $name,
+      "api_products[{$this->products[0]->getName()}]" => $this->products[0]->getName(),
+    ]);
+    $this->assertSession()->pageTextContains('This value is too long. It should have 30 characters or less.');
+  }
+
+  /**
    * Tests creating two apps with the same name but different developers.
    */
   public function testSameAppNameDifferentUser() {

--- a/tests/src/Functional/OverriddenEntityClassTest.php
+++ b/tests/src/Functional/OverriddenEntityClassTest.php
@@ -32,7 +32,7 @@ class OverriddenEntityClassTest extends ApigeeEdgeFunctionalTestBase {
   public function testClassOverride() {
     /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $manager */
     $manager = $this->container->get('entity_type.manager');
-    foreach (_apigee_edge_entity_class_mapping() as $entity_type => $entity_class) {
+    foreach (_apigee_edge_test_entity_class_mapping() as $entity_type => $entity_class) {
       $entity = $manager->getStorage($entity_type)->create();
       $this->assertInstanceOf($entity_class, $entity);
     }


### PR DESCRIPTION
Field level constraints are not validated when an instance of a FieldableEdgeEntityForm gets submitted. As FieldableEdgeEntityForm if a fine-tuned copy of ContentEntityForm without being tied to an SQL entity storage, I copied the missing logic from the ContentEntityForm.

Also added a test coverage to the Developer App UI test because by default, this is the only entity with CU UI in the Apigee Edge module (submodules not included) and until this time all "fieldable edge entity" base classes were valided as part of its subclasses' tests, therefore there are no dedicated tests for "fieldable edge entity" base classes.