### PR TITLE
[#336] Add Apigee entities display settings

### DIFF
--- a/apigee_edge.links.task.yml
+++ b/apigee_edge.links.task.yml
@@ -35,6 +35,12 @@ apigee_edge.settings.developer_app.alias:
   base_route: apigee_edge.settings.developer_app
   weight: -10
 
+apigee_edge.settings.developer_app.display_settings:
+  route_name: apigee_edge.display_settings.developer_app
+  title: 'Display settings'
+  base_route: apigee_edge.settings.developer_app
+  weight: -9
+
 apigee_edge.settings.developer_app.credentials:
   route_name: apigee_edge.settings.developer_app.credentials
   title: 'Credentials'

--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -118,6 +118,9 @@ function apigee_edge_theme() {
     'apigee_entity' => [
       'render element' => 'elements',
     ],
+    'apigee_entity_list' => [
+      'render element' => 'elements',
+    ],
     'apigee_entity__app' => [
       'render element' => 'elements',
       'base hook' => 'apigee_entity',
@@ -177,6 +180,36 @@ function apigee_edge_theme_suggestions_apigee_entity(array $variables) {
 
   $suggestions[] = 'apigee_entity__' . $entity->getEntityTypeId();
   $suggestions[] = 'apigee_entity__' . $entity->getEntityTypeId() . '__' . $sanitized_view_mode;
+
+  return $suggestions;
+}
+
+/**
+ * Prepares variables for Apigee entity list templates.
+ *
+ * Default template: apigee-entity-list.html.twig.
+ */
+function template_preprocess_apigee_entity_list(array &$variables) {
+  $variables['view_mode'] = $variables['elements']['#view_mode'];
+  $variables['entity_type_id'] = $variables['elements']['#entity_type']->id();
+
+  $variables += ['content' => []];
+  foreach (Element::children($variables['elements']) as $key) {
+    $variables['content'][$key] = $variables['elements'][$key];
+  }
+}
+
+/**
+ * Implements hook_theme_suggestions_HOOK().
+ */
+function apigee_edge_theme_suggestions_apigee_entity_list(array $variables) {
+  $suggestions = [];
+  $view_mode = $variables['elements']['#view_mode'];
+  $entity_type_id = $variables['elements']['#entity_type']->id();
+
+  // Add a suggestion based on the entity type and on the view mode.
+  $suggestions[] = 'apigee_entity_list__' . $entity_type_id;
+  $suggestions[] = 'apigee_entity_list__' . $entity_type_id . '__' . $view_mode;
 
   return $suggestions;
 }

--- a/apigee_edge.routing.yml
+++ b/apigee_edge.routing.yml
@@ -134,6 +134,15 @@ apigee_edge.settings.developer_app:
   requirements:
     _permission: 'administer apigee edge'
 
+apigee_edge.display_settings.developer_app:
+  path: '/admin/config/apigee-edge/app-settings/developer-apps/display-settings'
+  defaults:
+    _form: '\Drupal\apigee_edge\Form\EdgeEntityDisplaySettingsForm'
+    _title: 'Display settings'
+    entity_type_id: 'developer_app'
+  requirements:
+    _permission: 'administer apigee edge'
+
 apigee_edge.settings.developer_app.credentials:
   path: '/admin/config/apigee-edge/app-settings/developer-apps/credentials'
   defaults:

--- a/config/schema/apigee_edge.schema.yml
+++ b/config/schema/apigee_edge.schema.yml
@@ -91,10 +91,10 @@ apigee_edge.display_settings.*:
   label: 'Display settings'
   mapping:
     display_type:
-      type: String
+      type: string
       label: 'Display type'
     view_mode:
-      type: String
+      type: string
       label: 'View mode'
 
 field.widget.settings.app_callback_url:

--- a/config/schema/apigee_edge.schema.yml
+++ b/config/schema/apigee_edge.schema.yml
@@ -86,6 +86,17 @@ apigee_edge.developer_app_settings:
     credential_lifetime:
       type: integer
 
+apigee_edge.display_settings.*:
+  type: config_object
+  label: 'Display settings'
+  mapping:
+    display_type:
+      type: String
+      label: 'Display type'
+    view_mode:
+      type: String
+      label: 'View mode'
+
 field.widget.settings.app_callback_url:
   type: mapping
   label: 'Callback URL widget settings'

--- a/modules/apigee_edge_teams/apigee_edge_teams.links.task.yml
+++ b/modules/apigee_edge_teams/apigee_edge_teams.links.task.yml
@@ -4,6 +4,12 @@ apigee_edge_teams.settings.team:
   base_route: apigee_edge_teams.settings.team
   weight: -10
 
+apigee_edge.settings.team.display_settings:
+  route_name: apigee_edge.display_settings.team
+  title: 'Display settings'
+  base_route: apigee_edge_teams.settings.team
+  weight: -9
+
 apigee_edge_teams.settings.team.roles:
   route_name: entity.team_role.collection
   title: 'Roles'

--- a/modules/apigee_edge_teams/apigee_edge_teams.links.task.yml
+++ b/modules/apigee_edge_teams/apigee_edge_teams.links.task.yml
@@ -24,6 +24,12 @@ apigee_edge_teams.settings.team_app.alias:
   title: 'Alias'
   base_route: apigee_edge_teams.settings.team_app
 
+apigee_edge.settings.team_app.display_settings:
+  route_name: apigee_edge.display_settings.team_app
+  title: 'Display settings'
+  base_route: apigee_edge_teams.settings.team_app
+  weight: -9
+
 apigee_edge_teams.settings.team_app.credentials:
   route_name: apigee_edge_teams.settings.team_app.credentials
   title: 'Credentials'

--- a/modules/apigee_edge_teams/apigee_edge_teams.routing.yml
+++ b/modules/apigee_edge_teams/apigee_edge_teams.routing.yml
@@ -6,6 +6,15 @@ apigee_edge_teams.settings.team:
   requirements:
     _permission: 'administer team'
 
+apigee_edge.display_settings.team:
+  path: '/admin/config/apigee-edge/team-settings/display-settings'
+  defaults:
+    _form: '\Drupal\apigee_edge\Form\EdgeEntityDisplaySettingsForm'
+    _title: 'Display settings'
+    entity_type_id: 'team'
+  requirements:
+    _permission: 'administer team'
+
 apigee_edge_teams.settings.team.cache:
   path: '/admin/config/apigee-edge/team-settings/caching'
   defaults:

--- a/modules/apigee_edge_teams/apigee_edge_teams.routing.yml
+++ b/modules/apigee_edge_teams/apigee_edge_teams.routing.yml
@@ -30,6 +30,15 @@ apigee_edge_teams.settings.team_app:
   requirements:
     _permission: 'administer team'
 
+apigee_edge.display_settings.team_app:
+  path: '/admin/config/apigee-edge/app-settings/team-apps/display-settings'
+  defaults:
+    _form: '\Drupal\apigee_edge\Form\EdgeEntityDisplaySettingsForm'
+    _title: 'Display settings'
+    entity_type_id: 'team_app'
+  requirements:
+    _permission: 'administer team'
+
 apigee_edge_teams.settings.team_app.credentials:
   path: '/admin/config/apigee-edge/app-settings/team-apps/credentials'
   defaults:

--- a/modules/apigee_edge_teams/src/Entity/ListBuilder/TeamAppListByTeam.php
+++ b/modules/apigee_edge_teams/src/Entity/ListBuilder/TeamAppListByTeam.php
@@ -52,8 +52,6 @@ class TeamAppListByTeam extends AppListBuilder implements ContainerInjectionInte
    *   The entity type.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The config factory.
    * @param \Drupal\Core\Render\RendererInterface $render
    *   The render.
    * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
@@ -62,9 +60,15 @@ class TeamAppListByTeam extends AppListBuilder implements ContainerInjectionInte
    *   The time service.
    * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
    *   The route match object.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
    */
-  public function __construct(EntityTypeInterface $entity_type, EntityTypeManagerInterface $entity_type_manager, ConfigFactoryInterface $config_factory, RendererInterface $render, RequestStack $request_stack, TimeInterface $time, RouteMatchInterface $route_match) {
-    parent::__construct($entity_type, $entity_type_manager, $config_factory, $render, $request_stack, $time);
+  public function __construct(EntityTypeInterface $entity_type, EntityTypeManagerInterface $entity_type_manager, RendererInterface $render, RequestStack $request_stack, TimeInterface $time, RouteMatchInterface $route_match, ConfigFactoryInterface $config_factory = NULL) {
+    if (!$config_factory) {
+      $config_factory = \Drupal::service('config.factory');
+    }
+
+    parent::__construct($entity_type, $entity_type_manager, $render, $request_stack, $time, $config_factory);
     $this->routeMatch = $route_match;
   }
 
@@ -75,11 +79,11 @@ class TeamAppListByTeam extends AppListBuilder implements ContainerInjectionInte
     return new static(
       $entity_type,
       $container->get('entity_type.manager'),
-      $container->get('config.factory'),
       $container->get('renderer'),
       $container->get('request_stack'),
       $container->get('datetime.time'),
-      $container->get('current_route_match')
+      $container->get('current_route_match'),
+      $container->get('config.factory')
     );
   }
 

--- a/modules/apigee_edge_teams/src/Entity/ListBuilder/TeamAppListByTeam.php
+++ b/modules/apigee_edge_teams/src/Entity/ListBuilder/TeamAppListByTeam.php
@@ -103,6 +103,22 @@ class TeamAppListByTeam extends AppListBuilder implements ContainerInjectionInte
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function render() {
+    $build = parent::render();
+
+    // Update the empty text for table views.
+    if (!empty($build['table'])) {
+      $build['table']['#empty'] = t('There are no @label yet.', [
+        '@label' => $this->entityType->getPluralLabel(),
+      ]);
+    }
+
+    return $build;
+  }
+
+  /**
    * Returns the title of the "team app list by team" page.
    *
    * @return \Drupal\Core\StringTranslation\TranslatableMarkup

--- a/modules/apigee_edge_teams/src/Entity/ListBuilder/TeamAppListByTeam.php
+++ b/modules/apigee_edge_teams/src/Entity/ListBuilder/TeamAppListByTeam.php
@@ -22,6 +22,7 @@ namespace Drupal\apigee_edge_teams\Entity\ListBuilder;
 
 use Drupal\apigee_edge\Entity\ListBuilder\AppListBuilder;
 use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -51,6 +52,8 @@ class TeamAppListByTeam extends AppListBuilder implements ContainerInjectionInte
    *   The entity type.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
    * @param \Drupal\Core\Render\RendererInterface $render
    *   The render.
    * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
@@ -60,8 +63,8 @@ class TeamAppListByTeam extends AppListBuilder implements ContainerInjectionInte
    * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
    *   The route match object.
    */
-  public function __construct(EntityTypeInterface $entity_type, EntityTypeManagerInterface $entity_type_manager, RendererInterface $render, RequestStack $request_stack, TimeInterface $time, RouteMatchInterface $route_match) {
-    parent::__construct($entity_type, $entity_type_manager, $render, $request_stack, $time);
+  public function __construct(EntityTypeInterface $entity_type, EntityTypeManagerInterface $entity_type_manager, ConfigFactoryInterface $config_factory, RendererInterface $render, RequestStack $request_stack, TimeInterface $time, RouteMatchInterface $route_match) {
+    parent::__construct($entity_type, $entity_type_manager, $config_factory, $render, $request_stack, $time);
     $this->routeMatch = $route_match;
   }
 
@@ -72,6 +75,7 @@ class TeamAppListByTeam extends AppListBuilder implements ContainerInjectionInte
     return new static(
       $entity_type,
       $container->get('entity_type.manager'),
+      $container->get('config.factory'),
       $container->get('renderer'),
       $container->get('request_stack'),
       $container->get('datetime.time'),

--- a/src/Element/ApigeeEntityListElement.php
+++ b/src/Element/ApigeeEntityListElement.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Copyright 2020 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_edge\Element;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Render\Element\RenderElement;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides an element for listing Apigee entities.
+ *
+ * @RenderElement("apigee_entity_list")
+ */
+class ApigeeEntityListElement extends RenderElement implements ContainerFactoryPluginInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * ApigeeEntityListElement constructor.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param array $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(array $configuration, $plugin_id, array $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getInfo() {
+    return [
+      '#entities' => NULL,
+      '#entity_type' => NULL,
+      '#view_mode' => NULL,
+      '#theme' => 'apigee_entity_list',
+      '#pre_render' => [
+        [$this, 'preRender'],
+      ],
+    ];
+  }
+
+  /**
+   * Pre-render callback.
+   */
+  public function preRender($element) {
+    $element['items'] = $this->entityTypeManager->getViewBuilder($element['#entity_type']->id())
+      ->viewMultiple($element['#entities'], $element['#view_mode']);
+
+    return $element;
+  }
+
+}

--- a/src/Entity/ListBuilder/AppListBuilder.php
+++ b/src/Entity/ListBuilder/AppListBuilder.php
@@ -77,16 +77,20 @@ class AppListBuilder extends EdgeEntityListBuilder {
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
    *   The time service.
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The config factory.
    * @param \Drupal\Core\Render\RendererInterface $renderer
    *   The renderer service.
    * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
    *   The request stack object.
    * @param \Drupal\Component\Datetime\TimeInterface $time
    *   The time service.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
    */
-  public function __construct(EntityTypeInterface $entity_type, EntityTypeManagerInterface $entity_type_manager, ConfigFactoryInterface $config_factory, RendererInterface $renderer, RequestStack $request_stack, TimeInterface $time) {
+  public function __construct(EntityTypeInterface $entity_type, EntityTypeManagerInterface $entity_type_manager, RendererInterface $renderer, RequestStack $request_stack, TimeInterface $time, ConfigFactoryInterface $config_factory = NULL) {
+    if (!$config_factory) {
+      $config_factory = \Drupal::service('config.factory');
+    }
+
     parent::__construct($entity_type, $entity_type_manager, $config_factory);
     $this->renderer = $renderer;
     $this->entityTypeManager = $entity_type_manager;
@@ -101,10 +105,10 @@ class AppListBuilder extends EdgeEntityListBuilder {
     return new static(
       $entity_type,
       $container->get('entity_type.manager'),
-      $container->get('config.factory'),
       $container->get('renderer'),
       $container->get('request_stack'),
-      $container->get('datetime.time')
+      $container->get('datetime.time'),
+      $container->get('config.factory')
     );
   }
 

--- a/src/Entity/ListBuilder/AppListBuilder.php
+++ b/src/Entity/ListBuilder/AppListBuilder.php
@@ -37,7 +37,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
- * General app list builder for developer- and team apps.
+ * General app list builder for developer and team apps.
  */
 class AppListBuilder extends EdgeEntityListBuilder {
 

--- a/src/Entity/ListBuilder/AppListBuilder.php
+++ b/src/Entity/ListBuilder/AppListBuilder.php
@@ -26,6 +26,7 @@ use Drupal\apigee_edge\Entity\AppInterface;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Component\Utility\Html;
 use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -62,12 +63,22 @@ class AppListBuilder extends EdgeEntityListBuilder {
   protected $time;
 
   /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
    * AppListBuilder constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
    *   The entity type definition.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
+   *   The time service.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
    * @param \Drupal\Core\Render\RendererInterface $renderer
    *   The renderer service.
    * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
@@ -75,8 +86,8 @@ class AppListBuilder extends EdgeEntityListBuilder {
    * @param \Drupal\Component\Datetime\TimeInterface $time
    *   The time service.
    */
-  public function __construct(EntityTypeInterface $entity_type, EntityTypeManagerInterface $entity_type_manager, RendererInterface $renderer, RequestStack $request_stack, TimeInterface $time) {
-    parent::__construct($entity_type, $entity_type_manager);
+  public function __construct(EntityTypeInterface $entity_type, EntityTypeManagerInterface $entity_type_manager, ConfigFactoryInterface $config_factory, RendererInterface $renderer, RequestStack $request_stack, TimeInterface $time) {
+    parent::__construct($entity_type, $entity_type_manager, $config_factory);
     $this->renderer = $renderer;
     $this->entityTypeManager = $entity_type_manager;
     $this->requestStack = $request_stack;
@@ -90,6 +101,7 @@ class AppListBuilder extends EdgeEntityListBuilder {
     return new static(
       $entity_type,
       $container->get('entity_type.manager'),
+      $container->get('config.factory'),
       $container->get('renderer'),
       $container->get('request_stack'),
       $container->get('datetime.time')
@@ -184,9 +196,14 @@ class AppListBuilder extends EdgeEntityListBuilder {
    */
   public function render() {
     $build = parent::render();
-    $build['table']['#attributes']['class'][] = 'table--app-list';
+    if ($this->usingDisplayType(static::VIEW_MODE_DISPLAY_TYPE)) {
+      return $build;
+    }
 
-    // Parent couldn't build row(s) for entities, let's build them now.
+    $build['table']['#attributes']['class'][] = 'table--app-list';
+    $build['table']['#rows'] = [];
+    $build['table']['#empty'] = $this->t('Looks like you do not have any apps. Get started by adding one.');
+
     foreach ($this->load() as $entity) {
       $rows = [];
       $this->buildInfoRow($entity, $rows);
@@ -195,6 +212,7 @@ class AppListBuilder extends EdgeEntityListBuilder {
     }
 
     $build['#attached']['library'][] = 'apigee_edge/apigee_edge.app_listing';
+
     return $build;
   }
 

--- a/src/Entity/ListBuilder/DeveloperAppListBuilderForDeveloper.php
+++ b/src/Entity/ListBuilder/DeveloperAppListBuilderForDeveloper.php
@@ -73,8 +73,6 @@ class DeveloperAppListBuilderForDeveloper extends AppListBuilder implements Cont
    *   The entity type.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The config factory.
    * @param \Drupal\Core\Render\RendererInterface $render
    *   The render.
    * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
@@ -85,9 +83,15 @@ class DeveloperAppListBuilderForDeveloper extends AppListBuilder implements Cont
    *   Currently logged-in user.
    * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
    *   The route match object.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
    */
-  public function __construct(EntityTypeInterface $entity_type, EntityTypeManagerInterface $entity_type_manager, ConfigFactoryInterface $config_factory, RendererInterface $render, RequestStack $request_stack, TimeInterface $time, AccountInterface $current_user, RouteMatchInterface $route_match) {
-    parent::__construct($entity_type, $entity_type_manager, $config_factory, $render, $request_stack, $time);
+  public function __construct(EntityTypeInterface $entity_type, EntityTypeManagerInterface $entity_type_manager, RendererInterface $render, RequestStack $request_stack, TimeInterface $time, AccountInterface $current_user, RouteMatchInterface $route_match, ConfigFactoryInterface $config_factory = NULL) {
+    if (!$config_factory) {
+      $config_factory = \Drupal::service('config.factory');
+    }
+
+    parent::__construct($entity_type, $entity_type_manager, $render, $request_stack, $time, $config_factory);
     $this->currentUser = $current_user;
     $this->routeMatch = $route_match;
   }
@@ -99,12 +103,12 @@ class DeveloperAppListBuilderForDeveloper extends AppListBuilder implements Cont
     return new static(
       $entity_type,
       $container->get('entity_type.manager'),
-      $container->get('config.factory'),
       $container->get('renderer'),
       $container->get('request_stack'),
       $container->get('datetime.time'),
       $container->get('current_user'),
-      $container->get('current_route_match')
+      $container->get('current_route_match'),
+      $container->get('config.factory')
     );
   }
 

--- a/src/Entity/ListBuilder/DeveloperAppListBuilderForDeveloper.php
+++ b/src/Entity/ListBuilder/DeveloperAppListBuilderForDeveloper.php
@@ -24,6 +24,7 @@ use Drupal\apigee_edge\Entity\AppInterface;
 use Drupal\apigee_edge\Exception\DeveloperDoesNotExistException;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Component\Utility\Html;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
@@ -72,6 +73,8 @@ class DeveloperAppListBuilderForDeveloper extends AppListBuilder implements Cont
    *   The entity type.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
    * @param \Drupal\Core\Render\RendererInterface $render
    *   The render.
    * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
@@ -83,8 +86,8 @@ class DeveloperAppListBuilderForDeveloper extends AppListBuilder implements Cont
    * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
    *   The route match object.
    */
-  public function __construct(EntityTypeInterface $entity_type, EntityTypeManagerInterface $entity_type_manager, RendererInterface $render, RequestStack $request_stack, TimeInterface $time, AccountInterface $current_user, RouteMatchInterface $route_match) {
-    parent::__construct($entity_type, $entity_type_manager, $render, $request_stack, $time);
+  public function __construct(EntityTypeInterface $entity_type, EntityTypeManagerInterface $entity_type_manager, ConfigFactoryInterface $config_factory, RendererInterface $render, RequestStack $request_stack, TimeInterface $time, AccountInterface $current_user, RouteMatchInterface $route_match) {
+    parent::__construct($entity_type, $entity_type_manager, $config_factory, $render, $request_stack, $time);
     $this->currentUser = $current_user;
     $this->routeMatch = $route_match;
   }
@@ -96,6 +99,7 @@ class DeveloperAppListBuilderForDeveloper extends AppListBuilder implements Cont
     return new static(
       $entity_type,
       $container->get('entity_type.manager'),
+      $container->get('config.factory'),
       $container->get('renderer'),
       $container->get('request_stack'),
       $container->get('datetime.time'),
@@ -169,15 +173,6 @@ class DeveloperAppListBuilderForDeveloper extends AppListBuilder implements Cont
       return $app->toLink(NULL, 'canonical-by-developer')->toRenderable();
     }
     return parent::renderAppName($app);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function render() {
-    $build = parent::render();
-    $build['table']['#empty'] = $this->t('Looks like you do not have any apps. Get started by adding one.');
-    return $build;
   }
 
   /**

--- a/src/Entity/ListBuilder/EdgeEntityListBuilder.php
+++ b/src/Entity/ListBuilder/EdgeEntityListBuilder.php
@@ -69,9 +69,14 @@ class EdgeEntityListBuilder extends EntityListBuilder {
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  public function __construct(EntityTypeInterface $entity_type, EntityTypeManagerInterface $entity_type_manager, ConfigFactoryInterface $config_factory) {
+  public function __construct(EntityTypeInterface $entity_type, EntityTypeManagerInterface $entity_type_manager, ConfigFactoryInterface $config_factory = NULL) {
     parent::__construct($entity_type, $entity_type_manager->getStorage($entity_type->id()));
     $this->entityTypeManager = $entity_type_manager;
+
+    if (!$config_factory) {
+      $config_factory = \Drupal::service('config.factory');
+    }
+
     $this->configFactory = $config_factory;
     // Disable pager for now for all Apigee Edge entities.
     $this->limit = 0;

--- a/src/Entity/ListBuilder/EdgeEntityListBuilder.php
+++ b/src/Entity/ListBuilder/EdgeEntityListBuilder.php
@@ -20,6 +20,7 @@
 
 namespace Drupal\apigee_edge\Entity\ListBuilder;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityListBuilder;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -32,11 +33,28 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class EdgeEntityListBuilder extends EntityListBuilder {
 
   /**
+   * The default display type.
+   */
+  const DEFAULT_DISPLAY_TYPE = 'default';
+
+  /**
+   * The view mode display type.
+   */
+  const VIEW_MODE_DISPLAY_TYPE = 'view_mode';
+
+  /**
    * The entity type manager service.
    *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
 
   /**
    * EdgeEntityListBuilder constructor.
@@ -45,10 +63,16 @@ class EdgeEntityListBuilder extends EntityListBuilder {
    *   The entity type definition.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  public function __construct(EntityTypeInterface $entity_type, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(EntityTypeInterface $entity_type, EntityTypeManagerInterface $entity_type_manager, ConfigFactoryInterface $config_factory) {
     parent::__construct($entity_type, $entity_type_manager->getStorage($entity_type->id()));
     $this->entityTypeManager = $entity_type_manager;
+    $this->configFactory = $config_factory;
     // Disable pager for now for all Apigee Edge entities.
     $this->limit = 0;
   }
@@ -59,7 +83,8 @@ class EdgeEntityListBuilder extends EntityListBuilder {
   public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
     return new static(
       $entity_type,
-      $container->get('entity.manager')
+      $container->get('entity.manager'),
+      $container->get('config.factory')
     );
   }
 
@@ -88,6 +113,71 @@ class EdgeEntityListBuilder extends EntityListBuilder {
       $query->pager($this->limit);
     }
     return $query;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render() {
+    $settings = $this->getDisplaySettings();
+    if ($this->usingDisplayType(static::VIEW_MODE_DISPLAY_TYPE)) {
+      return $this->renderUsingViewMode($settings['view_mode']);
+    }
+
+    return parent::render();
+  }
+
+  /**
+   * Renders a list of entities using the provided view mode.
+   *
+   * @param string $view_mode
+   *   The view mode.
+   *
+   * @return array
+   *   A renderable array.
+   */
+  protected function renderUsingViewMode($view_mode): array {
+    return [
+      '#type' => 'apigee_entity_list',
+      '#entities' => $this->load(),
+      '#entity_type' => $this->entityType,
+      '#view_mode' => $view_mode,
+      '#cache' => [
+        'contexts' => $this->entityType->getListCacheContexts(),
+        'tags' => $this->entityType->getListCacheTags(),
+      ]
+    ];
+  }
+
+  /**
+   * Returns TRUE if entity type is configure to use provided display type.
+   *
+   * @param string $display_type
+   *   The display type.
+   *
+   * @return bool
+   *   TRUE if using provided display type. FALSE otherwise.
+   */
+  protected function usingDisplayType($display_type): bool {
+    $settings = $this->getDisplaySettings();
+
+    if (empty($settings['display_type'])) {
+      return FALSE;
+    }
+
+    return $settings['display_type'] === $display_type;
+  }
+
+  /**
+   * Returns the display settings.
+   *
+   * @return array
+   *   An array of display settings.
+   */
+  protected function getDisplaySettings(): array {
+    return $this->configFactory
+      ->get("apigee_edge.display_settings.{$this->entityTypeId}")
+      ->getRawData();
   }
 
 }

--- a/src/Form/EdgeEntityDisplaySettingsForm.php
+++ b/src/Form/EdgeEntityDisplaySettingsForm.php
@@ -1,0 +1,223 @@
+<?php
+
+/**
+ * Copyright 2020 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_edge\Form;
+
+use Drupal\apigee_edge\Entity\ListBuilder\EdgeEntityListBuilder;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Form\BaseFormIdInterface;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Configuration form for Apigee entities display settings.
+ */
+class EdgeEntityDisplaySettingsForm extends ConfigFormBase implements BaseFormIdInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * The entity display repository.
+   *
+   * @var \Drupal\Core\Entity\EntityDisplayRepositoryInterface
+   */
+  protected $entityDisplayRepository;
+
+  /**
+   * The entity type ID.
+   *
+   * @var string
+   */
+  protected $entityTypeId;
+
+  /**
+   * The route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * AppDisplaySettingsForm constructor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Entity\EntityDisplayRepositoryInterface $entity_display_repository
+   *   The entity display repository.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The route match.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entity_type_manager, EntityDisplayRepositoryInterface $entity_display_repository, ModuleHandlerInterface $module_handler, RouteMatchInterface $route_match) {
+    parent::__construct($config_factory);
+    $this->entityTypeManager = $entity_type_manager;
+    $this->moduleHandler = $module_handler;
+    $this->entityDisplayRepository = $entity_display_repository;
+    $this->routeMatch = $route_match;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('entity_type.manager'),
+      $container->get('entity_display.repository'),
+      $container->get('module_handler'),
+      $container->get('current_route_match')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getBaseFormId() {
+    return 'apigee_edge_display_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    $entity_type_id = $this->routeMatch->getParameter('entity_type_id');
+    return "apigee_edge_display_settings_form.{$entity_type_id}";
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'apigee_edge.display_settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, $entity_type_id = NULL) {
+    $this->entityTypeId = $entity_type_id;
+
+    /** @var \Drupal\Core\Entity\EntityTypeInterface $entity_type */
+    $entity_type = $this->entityTypeManager->getDefinition($entity_type_id);
+    $config = $this->configFactory()->get("apigee_edge.display_settings.{$entity_type_id}");
+
+    $form['display_settings'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Configure the display for @label listing page.', [
+        '@label' => $entity_type->getPluralLabel(),
+      ]),
+      '#collapsible' => FALSE,
+    ];
+
+    $form['display_settings']['display_type'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Type'),
+      '#default_value' => $config->get('display_type'),
+      '#required' => TRUE,
+      '#description' => $this->t('Select <em>Display mode</em> to configure a custom display.'),
+      '#options' => [
+        EdgeEntityListBuilder::DEFAULT_DISPLAY_TYPE => $this->t('Default'),
+        EdgeEntityListBuilder::VIEW_MODE_DISPLAY_TYPE => $this->t('Display mode'),
+      ],
+    ];
+
+    $form['display_settings']['display_mode_container'] = [
+      '#type' => 'container',
+      '#states' => [
+        'visible' => [
+          ':input[name="display_type"]' => ['value' => 'view_mode'],
+        ],
+      ],
+    ];
+
+    $display_modes = [
+      'default' => $this->t('Default')
+    ];
+    foreach ($this->entityDisplayRepository->getViewModes($entity_type->id()) as $name => $view_mode) {
+      $display_modes[$name] = $view_mode['label'];
+    }
+
+    $form['display_settings']['display_mode_container']['view_mode'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Display mode'),
+      '#default_value' => $config->get('view_mode'),
+      '#description' => $this->t('Select the display mode.', [
+        ':uri' => '#',
+      ]),
+      '#options' => $display_modes,
+    ];
+
+    if ($this->moduleHandler->moduleExists('field_ui')) {
+      $form['display_settings']['display_mode_container']['display_mode_help'] = [
+        '#theme' => 'item_list',
+        '#items' => [
+          [
+            '#markup' => $this->t('<a href=":uri">Click here</a> to configure the display.', [
+              ':uri' => Url::fromRoute("entity.entity_view_display.{$entity_type->id()}.default")->toString(),
+            ])
+          ],
+          [
+            '#markup' => $this->t('<a href=":uri">Click here</a> to add a new display mode.', [
+              ':uri' => Url::fromRoute('entity.entity_view_mode.collection')->toString(),
+            ])
+          ]
+        ],
+      ];
+    }
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->configFactory()->getEditable("apigee_edge.display_settings.{$this->entityTypeId}")
+      ->set('display_type', $form_state->getValue('display_type'))
+      ->set('view_mode', $form_state->getValue('view_mode'))
+      ->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/src/Form/EdgeEntityDisplaySettingsForm.php
+++ b/src/Form/EdgeEntityDisplaySettingsForm.php
@@ -154,7 +154,7 @@ class EdgeEntityDisplaySettingsForm extends ConfigFormBase implements BaseFormId
       '#title' => $this->t('Type'),
       '#default_value' => $config->get('display_type'),
       '#required' => TRUE,
-      '#description' => $this->t('Select <em>Display mode</em> to configure a custom display.'),
+      '#description' => $this->t('Select the <em>Default</em> type to display a table of entities with links to entity operations. Select <em>Display mode</em> to configure a custom display.'),
       '#options' => [
         EdgeEntityListBuilder::DEFAULT_DISPLAY_TYPE => $this->t('Default'),
         EdgeEntityListBuilder::VIEW_MODE_DISPLAY_TYPE => $this->t('Display mode'),

--- a/templates/apigee-entity-list.html.twig
+++ b/templates/apigee-entity-list.html.twig
@@ -1,0 +1,24 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a list of Apigee entities.
+ *
+ * Available variables:
+ * - content: List of apigee entities.
+ * - view_mode: The view mode for the entities.
+ * - entity_type_id: The entity type id.
+ *
+ * @see template_preprocess_apigee_entities_list()
+ *
+ * @ingroup themeable
+ */
+#}
+{% set classes = [
+  'apigee-entity-list',
+  'apigee-entity-list--' ~ entity_type_id|clean_class,
+  'apigee-entity-list--' ~ view_mode|clean_class,
+] %}
+
+<div {{ attributes.addClass(classes) }}>
+  {{ content }}
+</div>

--- a/tests/modules/apigee_mock_api_client/tests/src/Traits/ApigeeMockApiClientHelperTrait.php
+++ b/tests/modules/apigee_mock_api_client/tests/src/Traits/ApigeeMockApiClientHelperTrait.php
@@ -235,9 +235,12 @@ trait ApigeeMockApiClientHelperTrait {
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
   protected function createDeveloperApp(): DeveloperAppInterface {
+    static $appId;
+    $appId = $appId ? $appId++ : 1;
+
     /** @var \Drupal\apigee_edge\Entity\DeveloperAppInterface $entity */
     $entity = DeveloperApp::create([
-      'appId' => 1,
+      'appId' => $this->integration_enabled ? NULL : $appId,
       'name' => $this->randomMachineName(),
       'status' => App::STATUS_APPROVED,
       'displayName' => $this->randomMachineName(),

--- a/tests/src/Kernel/Entity/ListBuilder/EntityListBuilderTest.php
+++ b/tests/src/Kernel/Entity/ListBuilder/EntityListBuilderTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * Copyright 2020 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\Tests\apigee_edge\Kernel\Entity\ListBuilder;
+
+use Drupal\Core\Entity\Entity\EntityViewMode;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\apigee_mock_api_client\Traits\ApigeeMockApiClientHelperTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use Drupal\user\Entity\User;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Tests for EntityListBuilder.
+ *
+ * @group apigee_edge
+ * @group apigee_edge_kernel
+ */
+class EntityListBuilderTest extends KernelTestBase {
+
+  use ApigeeMockApiClientHelperTrait, UserCreationTrait;
+
+  /**
+   * Indicates this test class is mock API client ready.
+   *
+   * @var bool
+   */
+  protected static $mock_api_client_ready = TRUE;
+
+  /**
+   * The entity type to test.
+   */
+  const ENTITY_TYPE = 'developer_app';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'apigee_edge',
+    'apigee_mock_api_client',
+    'key',
+    'user',
+    'options'
+  ];
+
+  /**
+   * The user account.
+   *
+   * @var \Drupal\user\Entity\User
+   */
+  protected $account;
+
+  /**
+   * {@inheritdoc}
+   *
+   * @throws \Exception
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installSchema('system', ['sequences']);
+    $this->installConfig(['apigee_edge']);
+
+    $this->apigeeTestHelperSetup();
+
+    $this->account = User::create([
+      'mail' => $this->randomMachineName() . '@example.com',
+      'name' => $this->randomMachineName(),
+      'first_name' => $this->getRandomGenerator()->word(16),
+      'last_name' => $this->getRandomGenerator()->word(16),
+    ]);
+    $this->account->save();
+    $this->queueDeveloperResponse($this->account, Response::HTTP_CREATED);
+  }
+
+  /**
+   * Tests display settings for list builder.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function testDisplaySettings() {
+    /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager */
+    $entity_type_manager = $this->container->get('entity_type.manager');
+    $this->queueDeveloperResponse($this->account);
+    $developer_app = $this->createDeveloperApp();
+
+    $this->queueDeveloperResponse($this->account);
+    $this->stack->queueMockResponse([
+      'get_developer_apps' => [
+        'apps' => [$developer_app]
+      ],
+    ]);
+
+    // Using default.
+    $build = $entity_type_manager->getListBuilder(static::ENTITY_TYPE)->render();
+    static::assertTrue(isset($build['table']));
+
+    // Add view mode.
+    EntityViewMode::create([
+      'id' => static::ENTITY_TYPE . '.foo',
+      'targetEntityType' => static::ENTITY_TYPE,
+      'label' => 'Foo',
+      'status' => TRUE,
+    ])->save();
+
+    $config = $this->config('apigee_edge.display_settings.' . static::ENTITY_TYPE);
+    $config->set('display_type', 'view_mode')
+      ->set('view_mode', 'foo')
+      ->save();
+
+    // Using view mode.
+    $build = $entity_type_manager->getListBuilder(static::ENTITY_TYPE)->render();
+    static::assertSame('apigee_entity_list', $build['#type']);
+    static::assertSame('foo', $build['#view_mode']);
+  }
+
+}

--- a/tests/src/Kernel/Entity/ListBuilder/EntityListBuilderTest.php
+++ b/tests/src/Kernel/Entity/ListBuilder/EntityListBuilderTest.php
@@ -69,6 +69,13 @@ class EntityListBuilderTest extends KernelTestBase {
   protected $account;
 
   /**
+   * A DeveloperApp entity.
+   *
+   * @var \Drupal\apigee_edge\Entity\DeveloperAppInterface
+   */
+  protected $app;
+
+  /**
    * {@inheritdoc}
    *
    * @throws \Exception
@@ -93,6 +100,33 @@ class EntityListBuilderTest extends KernelTestBase {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  protected function tearDown() {
+    $this->stack->reset();
+    try {
+      if ($this->account) {
+        $this->queueDeveloperResponse($this->account);
+        $developer = \Drupal::entityTypeManager()
+          ->getStorage('developer')
+          ->create([
+            'email' => $this->account->getEmail(),
+          ]);
+        $developer->delete();
+      }
+
+      if ($this->app) {
+        $this->app->delete();
+      }
+    }
+    catch (\Exception $exception) {
+      $this->logException($exception);
+    }
+
+    parent::tearDown();
+  }
+
+  /**
    * Tests display settings for list builder.
    *
    * @throws \Drupal\Core\Entity\EntityStorageException
@@ -101,12 +135,12 @@ class EntityListBuilderTest extends KernelTestBase {
     /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager */
     $entity_type_manager = $this->container->get('entity_type.manager');
     $this->queueDeveloperResponse($this->account);
-    $developer_app = $this->createDeveloperApp();
+    $this->app = $this->createDeveloperApp();
 
     $this->queueDeveloperResponse($this->account);
     $this->stack->queueMockResponse([
       'get_developer_apps' => [
-        'apps' => [$developer_app]
+        'apps' => [$this->app]
       ],
     ]);
 

--- a/tests/src/Kernel/Form/EdgeEntityDisplaySettingsFormTest.php
+++ b/tests/src/Kernel/Form/EdgeEntityDisplaySettingsFormTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * Copyright 2020 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\Tests\apigee_edge\Kernel\Form;
+
+use Drupal\apigee_edge\Form\EdgeEntityDisplaySettingsForm;
+use Drupal\Core\Entity\Entity\EntityViewMode;
+use Drupal\Core\Form\FormState;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests for EdgeEntityDisplaySettingsForm.
+ *
+ * @group apigee_edge
+ * @group apigee_edge_kernel
+ */
+class EdgeEntityDisplaySettingsFormTest extends KernelTestBase {
+
+  /**
+   * The entity type to test.
+   */
+  const ENTITY_TYPE = 'developer_app';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'apigee_edge',
+    'key',
+  ];
+
+  /**
+   * Tests the config form.
+   */
+  public function testForm() {
+    $builder = $this->container->get('form_builder');
+    $form = $builder->getForm(EdgeEntityDisplaySettingsForm::class, static::ENTITY_TYPE);
+
+    $display_type_options = $form['display_settings']['display_type']['#options'];
+    static::assertCount(3, $display_type_options);
+    static::assertSame('Default', (string) $display_type_options['default']);
+    static::assertSame('Display mode', (string) $display_type_options['view_mode']);
+
+    $view_mode_options = $form['display_settings']['display_mode_container']['view_mode']['#options'];
+    static::assertCount(1, $view_mode_options);
+    static::assertSame('Default', (string) $view_mode_options['default']);
+
+    // Add view mode.
+    EntityViewMode::create([
+      'id' => static::ENTITY_TYPE . '.foo',
+      'targetEntityType' => static::ENTITY_TYPE,
+      'label' => 'Foo',
+      'status' => TRUE,
+    ])->save();
+
+    // Check if new view mode appears on form.
+    $builder = $this->container->get('form_builder');
+    $form = $builder->getForm(EdgeEntityDisplaySettingsForm::class, static::ENTITY_TYPE);
+    $view_mode_options = $form['display_settings']['display_mode_container']['view_mode']['#options'];
+    static::assertCount(2, $view_mode_options);
+    static::assertSame('Default', (string) $view_mode_options['default']);
+    static::assertSame('Foo', (string) $view_mode_options['foo']);
+
+    // Submit form and test config.
+    $form_state = new FormState();
+    $form_state->setValue('display_type', 'view_mode');
+    $form_state->setValue('view_mode', 'foo');
+    $this->container->get('form_builder')->submitForm(EdgeEntityDisplaySettingsForm::class, $form_state, static::ENTITY_TYPE);
+
+    $config = $this->config('apigee_edge.display_settings.' . static::ENTITY_TYPE);
+    static::assertSame('view_mode', $config->get('display_type'));
+    static::assertSame('foo', $config->get('view_mode'));
+  }
+
+}


### PR DESCRIPTION
Fixes #336 

This PR adds `apigee_edge.display_settings.*` config that any Apigee entity type can extend.

It provides a config form `apigee_edge.display_settings.*` that lets an admin configure the display type for an Apigee edge display. 

Example: the display type for the apps on the `/apps` page.

![Display_settings___Apigee](https://user-images.githubusercontent.com/124599/80201020-8c63e600-8634-11ea-9337-23bf41c3f634.jpg)

This can be extended by any entity type that implements `EntityListBuilder`, i.e all the entity displays such as App, Team Apps, Teams can use this. This also eliminates custom implementation for Rate plans displays in m10n.

## Implementation

```yml
apigee_edge.display_settings.developer_app:
  path: '/admin/config/apigee-edge/app-settings/developer-apps/display-settings'
  defaults:
    _form: '\Drupal\apigee_edge\Form\EdgeEntityDisplaySettingsForm'
    _title: 'Display settings'
    entity_type_id: 'developer_app'
  requirements:
    _permission: 'administer apigee edge'
```

## Theming

When using the display settings, the following templates are available for theming.

`apigee-entity-list.html.twig`
`apigee-entity-list--ENTITY-TYPE.html.twig`
`apigee-entity-list--ENTITY-TYPE--VIEW-MODE.html.twig`

Example:

`apigee-entity-list.html.twig`
`apigee-entity-list--developer-app.html.twig`
`apigee-entity-list--developer-app--collapsible-card.html.twig`

~~This is WIP and still needs tests.~~ ✅ Tests added

