### PR TITLE
[#398] Add Drupal 9 readiness checks to CI.

### DIFF
--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -55,12 +55,15 @@ class RoboFile extends \Robo\Tasks
       ->mkdir('artifacts/phpcs')
       ->mkdir('artifacts/phpmd')
       ->mkdir('artifacts/phpmetrics')
+      ->mkdir('artifacts/d9')
       ->mkdir('/tmp/artifacts/phpunit')
       ->mkdir('/tmp/artifacts/phpmd')
       ->run();
 
     $this->taskFilesystemStack()
       ->chown('/tmp/artifacts', 'www-data', TRUE)
+      ->copy('modules/apigee_edge/.circleci/d9.sh', '/var/www/html/d9.sh')
+      ->chmod('/var/www/html/d9.sh', 0777)
       ->run();
   }
 

--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -414,6 +414,11 @@ class RoboFile extends \Robo\Tasks
    */
   public function drupalVersion($drupalCoreVersion)
   {
+    // Remove all core files.
+    $this->taskFilesystemStack()
+      ->taskDeleteDir('core')
+      ->run();
+
     $config = json_decode(file_get_contents('composer.json'));
     unset($config->require->{"drupal/core"});
 

--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -47,6 +47,7 @@ class RoboFile extends \Robo\Tasks
     $config = json_decode(file_get_contents('composer.json'));
     $config->extra->{"enable-patching"} = 'true';
     $config->extra->{"patches"} = new \stdClass();
+    unset($config->scripts->{"post-package-install"});
     file_put_contents('composer.json', json_encode($config));
 
     // Create a directory for our artifacts.

--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -183,10 +183,7 @@ class RoboFile extends \Robo\Tasks
       ->optimizeAutoloader()
       ->run();
 
-    // Preserve composer.lock as an artifact for future debugging - remove token.
-    $config = json_decode(file_get_contents('composer.json'));
-    unset($config->config->{"github-oauth"});
-    file_put_contents('composer.json', json_encode($config, JSON_PRETTY_PRINT));
+    // Preserve composer.lock as an artifact for future debugging.
     $this->taskFilesystemStack()
       ->copy('composer.json', '/tmp/artifacts/composer.json')
       ->copy('composer.lock', '/tmp/artifacts/composer.lock')
@@ -425,15 +422,9 @@ class RoboFile extends \Robo\Tasks
         $config->require->{"drupal/core-recommended"} = '^9@beta';
         $config->require->{"drupal/core-dev"} = '^9@beta';
 
-        // We require Drupal drush for some tests.
-        $config->require->{"drush/drush"} = "^10";
 
-        // Fork of drupal/key D9 compatible.
-        $config->repositories[] = [
-          'type' => 'vcs',
-          'url' => 'https://github.com/arlina-espinoza/drupal-key.git',
-        ];
-        $config->require->{"drupal/key"} = "dev-d9 as 1.x-dev";
+        // Use drupal/key D9 compatible.
+        $config->require->{"drupal/key"} = "1.x-dev";
 
         break;
 
@@ -446,10 +437,6 @@ class RoboFile extends \Robo\Tasks
 
         // We require Drupal drush and console for some tests.
         $config->require->{"drupal/console"} = "~1.0";
-        $config->require->{"drush/drush"} = "^9.7";
-
-        # Hack to avoid installing drupal/console in D9.
-        $config->replace->{"drupal/console"} = '*';
 
       default:
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,11 @@ defaults: &defaults
   # https://discuss.circleci.com/t/bug-circleci-build-command-ignores-checkout-path-config/13004
   working_directory: /var/www/html/modules/apigee_edge
 
+  parameters:
+    core-version:
+      type: integer
+      default: 8
+
 # YAML does not support merging of lists. That means we can't have a default
 # 'steps' configuration, though we can have defaults for individual step
 # properties.
@@ -55,7 +60,11 @@ save_cache: &save_cache
 # Install composer dependencies into the workspace to share with all jobs.
 update_dependencies: &update_dependencies
   <<: *defaults
+
   steps:
+    - print:
+        message: Using Drupal core version << parameters.core-version >>
+
     - checkout
 
     - restore_cache: *restore_cache
@@ -64,7 +73,7 @@ update_dependencies: &update_dependencies
         working_directory: /var/www/html
         command: |
           cp ./modules/apigee_edge/.circleci/update-dependencies.sh /var/www/html
-          ./update-dependencies.sh apigee_edge 9
+          ./update-dependencies.sh apigee_edge << parameters.core-version >>
 
     - save_cache: *save_cache
 
@@ -194,7 +203,14 @@ d9_check: &d9_check
         path: /var/www/html/artifacts/d9
 
 # Declare all of the jobs we should run.
-version: 2
+version: 2.1
+commands:
+  print:
+    parameters:
+      message:
+        type: string
+    steps:
+      - run: echo << parameters.message >>
 jobs:
   update-dependencies:
      <<: *update_dependencies
@@ -218,22 +234,40 @@ workflows:
   # Functional JS tests need to run after functional due to a conflict in apigee_edge_apiproduct_rbac tests.
   test_and_lint:
     jobs:
-      - update-dependencies
-      - run-unit-kernel-tests:
-          requires:
-            - update-dependencies
-      - run-functional-tests:
-          requires:
-            - update-dependencies
-      - run-functional-js-tests:
-          requires:
-            - update-dependencies
-      - run-code-sniffer:
-          requires:
-            - update-dependencies
-      - run-d9-check:
-          requires:
-            - update-dependencies
+      - update-dependencies:
+          name: update-dependencies-<< matrix.core-version >>
+          matrix:
+            parameters:
+              core-version: [8, 9]
+#          name: update-dependencies-<< matrix.core-version >>
+#          core-version: 8
+#      - run-unit-kernel-tests:
+#          name: run-unit-kernel-tests-<< matrix.version >>
+#          matrix:
+#            parameters:
+#              version: [8, 9]
+#          requires:
+#            - update-dependencies-<< matrix.version >>
+#      - run-functional-tests:
+#          name: run-functional-tests-<< matrix.version >>
+#          matrix:
+#            parameters:
+#              version: [8, 9]
+#          requires:
+#            - update-dependencies-<< matrix.version >>
+#      - run-functional-js-tests:
+#          name: run-functional-js-tests-<< matrix.version >>
+#          matrix:
+#            parameters:
+#              version: [8, 9]
+#          requires:
+#            - update-dependencies-<< matrix.version >>
+#      - run-code-sniffer:
+#          requires:
+#            - update-dependencies-8
+#      - run-d9-check:
+#          requires:
+#            - update-dependencies-8
 #      - run-code-coverage:
 #          requires:
 #            - update-dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@
 defaults: &defaults
   docker:
     # specify the version you desire here (avoid latest except for testing)
-    - image: andrewberry/drupal_tests:0.4.0
+    - image: quay.io/deviantintegral/drupal_tests:0.5.0-drupal87
 
     - image: selenium/standalone-chrome-debug:3.141.59-neon
 
@@ -64,7 +64,7 @@ update_dependencies: &update_dependencies
         working_directory: /var/www/html
         command: |
           cp ./modules/apigee_edge/.circleci/update-dependencies.sh /var/www/html
-          ./update-dependencies.sh apigee_edge
+          ./update-dependencies.sh apigee_edge 9
 
     - save_cache: *save_cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,25 @@ code_coverage: &code_coverage
     - store_artifacts:
         path: /var/www/html/artifacts
 
+# Run D9 deprecation checks.
+d9_check: &d9_check
+  <<: *defaults
+  steps:
+    - attach_workspace:
+        at: /var/www/html
+
+    - checkout
+
+    - run:
+        working_directory: /var/www/html
+        command: |
+          ./d9.sh modules/apigee_edge
+
+    - store_test_results:
+        path: /var/www/html/artifacts/d9
+    - store_artifacts:
+        path: /var/www/html/artifacts/d9
+
 # Declare all of the jobs we should run.
 version: 2
 jobs:
@@ -189,6 +208,8 @@ jobs:
      <<: *code_sniffer
   run-code-coverage:
      <<: *code_coverage
+  run-d9-check:
+     <<: *d9_check
 
 workflows:
   version: 2
@@ -208,6 +229,9 @@ workflows:
           requires:
             - update-dependencies
       - run-code-sniffer:
+          requires:
+            - update-dependencies
+      - run-d9-check:
           requires:
             - update-dependencies
 #      - run-code-coverage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,7 +248,6 @@ workflows:
               core-version: [8, 9]
           requires:
             - update-dependencies-<< matrix.core-version >>
-            - run-d9-check
       - run-functional-tests:
           name: run-functional-tests-<< matrix.core-version >>
           matrix:
@@ -256,7 +255,6 @@ workflows:
               core-version: [8, 9]
           requires:
             - update-dependencies-<< matrix.core-version >>
-            - run-d9-check
       - run-functional-js-tests:
           name: run-functional-js-tests-<< matrix.core-version >>
           matrix:
@@ -264,7 +262,6 @@ workflows:
               core-version: [8, 9]
           requires:
             - update-dependencies-<< matrix.core-version >>
-            - run-d9-check
       - run-code-sniffer:
           requires:
             - update-dependencies-8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,6 +247,12 @@ workflows:
           matrix:
             parameters:
               core-version: [8]
+      - run-code-sniffer:
+          requires:
+            - update-dependencies-8
+      - run-d9-check:
+          requires:
+            - update-dependencies-8
       - run-unit-kernel-tests:
           name: run-unit-kernel-tests-<< matrix.core-version >>
           matrix:
@@ -268,12 +274,6 @@ workflows:
 #              core-version: [8, 9]
 #          requires:
 #            - update-dependencies-<< matrix.core-version >>
-#      - run-code-sniffer:
-#          requires:
-#            - update-dependencies-8
-#      - run-d9-check:
-#          requires:
-#            - update-dependencies-8
 #      - run-code-coverage:
 #          requires:
 #            - update-dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ update_dependencies: &update_dependencies
 unit_kernel_tests: &unit_kernel_tests
   <<: *defaults
   steps:
-    - run: rm -rf /var/www/html
+    - run: rm -rf /var/www/html/core
 
     - attach_workspace:
         at: /var/www/html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ unit_kernel_tests: &unit_kernel_tests
         working_directory: /var/www/html
         command: |
           cp ./modules/apigee_edge/.circleci/test.sh /var/www/html
-          ./test.sh apigee_edge
+          ./test.sh apigee_edge << parameters.core-version >>
 
     - store_test_results:
         path: /tmp/artifacts/phpunit
@@ -122,7 +122,7 @@ functional_tests: &functional_tests
         working_directory: /var/www/html
         command: |
           cp ./modules/apigee_edge/.circleci/test-functional.sh /var/www/html
-          ./test-functional.sh apigee_edge
+          ./test-functional.sh apigee_edge << parameters.core-version >>
 
     - store_test_results:
         path: /tmp/artifacts/phpunit
@@ -142,7 +142,7 @@ functional_js_tests: &functional_js_tests
         working_directory: /var/www/html
         command: |
           cp ./modules/apigee_edge/.circleci/test-functional-js.sh /var/www/html
-          ./test-functional-js.sh apigee_edge
+          ./test-functional-js.sh apigee_edge << parameters.core-version >>
 
     - store_test_results:
         path: /tmp/artifacts/phpunit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,8 @@ unit_kernel_tests: &unit_kernel_tests
 functional_tests: &functional_tests
   <<: *defaults
   steps:
+    - run: rm -rf /var/www/html/core
+
     - attach_workspace:
         at: /var/www/html
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,13 +267,13 @@ workflows:
               core-version: [8]
           requires:
             - update-dependencies-<< matrix.core-version >>
-#      - run-functional-js-tests:
-#          name: run-functional-js-tests-<< matrix.core-version >>
-#          matrix:
-#            parameters:
-#              core-version: [8, 9]
-#          requires:
-#            - update-dependencies-<< matrix.core-version >>
+      - run-functional-js-tests:
+          name: run-functional-js-tests-<< matrix.core-version >>
+          matrix:
+            parameters:
+              core-version: [8]
+          requires:
+            - update-dependencies-<< matrix.core-version >>
 #      - run-code-coverage:
 #          requires:
 #            - update-dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,8 @@ update_dependencies: &update_dependencies
 unit_kernel_tests: &unit_kernel_tests
   <<: *defaults
   steps:
+    - run: rm -rf /var/www/html
+
     - attach_workspace:
         at: /var/www/html
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,34 +240,34 @@ workflows:
           name: update-dependencies-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [8, 9]
+              core-version: [9]
       - run-unit-kernel-tests:
           name: run-unit-kernel-tests-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [8, 9]
+              core-version: [9]
           requires:
             - update-dependencies-<< matrix.core-version >>
       - run-functional-tests:
           name: run-functional-tests-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [8, 9]
+              core-version: [9]
           requires:
             - update-dependencies-<< matrix.core-version >>
-      - run-functional-js-tests:
-          name: run-functional-js-tests-<< matrix.core-version >>
-          matrix:
-            parameters:
-              core-version: [8, 9]
-          requires:
-            - update-dependencies-<< matrix.core-version >>
-      - run-code-sniffer:
-          requires:
-            - update-dependencies-8
-      - run-d9-check:
-          requires:
-            - update-dependencies-8
+#      - run-functional-js-tests:
+#          name: run-functional-js-tests-<< matrix.core-version >>
+#          matrix:
+#            parameters:
+#              core-version: [8, 9]
+#          requires:
+#            - update-dependencies-<< matrix.core-version >>
+#      - run-code-sniffer:
+#          requires:
+#            - update-dependencies-8
+#      - run-d9-check:
+#          requires:
+#            - update-dependencies-8
 #      - run-code-coverage:
 #          requires:
 #            - update-dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,19 +246,19 @@ workflows:
           name: update-dependencies-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [9]
+              core-version: [8]
       - run-unit-kernel-tests:
           name: run-unit-kernel-tests-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [9]
+              core-version: [8]
           requires:
             - update-dependencies-<< matrix.core-version >>
       - run-functional-tests:
           name: run-functional-tests-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [9]
+              core-version: [8]
           requires:
             - update-dependencies-<< matrix.core-version >>
 #      - run-functional-js-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,8 @@
 # Check https://circleci.com/docs/2.0/language-php/ for more details
 #
 
+version: 2.1
+
 defaults: &defaults
   docker:
     # specify the version you desire here (avoid latest except for testing)
@@ -202,8 +204,6 @@ d9_check: &d9_check
     - store_artifacts:
         path: /var/www/html/artifacts/d9
 
-# Declare all of the jobs we should run.
-version: 2.1
 commands:
   print:
     parameters:
@@ -211,6 +211,8 @@ commands:
         type: string
     steps:
       - run: echo << parameters.message >>
+
+# Declare all of the jobs we should run.
 jobs:
   update-dependencies:
      <<: *update_dependencies
@@ -239,35 +241,36 @@ workflows:
           matrix:
             parameters:
               core-version: [8, 9]
-#          name: update-dependencies-<< matrix.core-version >>
-#          core-version: 8
-#      - run-unit-kernel-tests:
-#          name: run-unit-kernel-tests-<< matrix.version >>
-#          matrix:
-#            parameters:
-#              version: [8, 9]
-#          requires:
-#            - update-dependencies-<< matrix.version >>
-#      - run-functional-tests:
-#          name: run-functional-tests-<< matrix.version >>
-#          matrix:
-#            parameters:
-#              version: [8, 9]
-#          requires:
-#            - update-dependencies-<< matrix.version >>
-#      - run-functional-js-tests:
-#          name: run-functional-js-tests-<< matrix.version >>
-#          matrix:
-#            parameters:
-#              version: [8, 9]
-#          requires:
-#            - update-dependencies-<< matrix.version >>
-#      - run-code-sniffer:
-#          requires:
-#            - update-dependencies-8
-#      - run-d9-check:
-#          requires:
-#            - update-dependencies-8
+      - run-unit-kernel-tests:
+          name: run-unit-kernel-tests-<< matrix.core-version >>
+          matrix:
+            parameters:
+              core-version: [8, 9]
+          requires:
+            - update-dependencies-<< matrix.core-version >>
+            - run-d9-check
+      - run-functional-tests:
+          name: run-functional-tests-<< matrix.core-version >>
+          matrix:
+            parameters:
+              core-version: [8, 9]
+          requires:
+            - update-dependencies-<< matrix.core-version >>
+            - run-d9-check
+      - run-functional-js-tests:
+          name: run-functional-js-tests-<< matrix.core-version >>
+          matrix:
+            parameters:
+              core-version: [8, 9]
+          requires:
+            - update-dependencies-<< matrix.core-version >>
+            - run-d9-check
+      - run-code-sniffer:
+          requires:
+            - update-dependencies-8
+      - run-d9-check:
+          requires:
+            - update-dependencies-8
 #      - run-code-coverage:
 #          requires:
 #            - update-dependencies

--- a/.circleci/d9.sh
+++ b/.circleci/d9.sh
@@ -7,6 +7,3 @@ fi
 
 vendor/bin/drupal-check --no-progress --memory-limit=1000M --format=junit $1 > /var/www/html/artifacts/d9/d9check.xml
 
-# to-do: Remove when PR gets merged into mglaman/drupal-check:
-# https://github.com/mglaman/drupal-check/pull/155
-sed -i '/%/d' /var/www/html/artifacts/d9/d9check.xml

--- a/.circleci/d9.sh
+++ b/.circleci/d9.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -ex
+
+if [ ! -f dependencies_updated ]
+then
+  ./update-dependencies.sh $1
+fi
+
+vendor/bin/drupal-check --no-progress --memory-limit=1000M --format=junit $1 > /var/www/html/artifacts/d9/d9check.xml
+
+# to-do: Remove when PR gets merged into mglaman/drupal-check:
+# https://github.com/mglaman/drupal-check/pull/155
+sed -i '/%/d' /var/www/html/artifacts/d9/d9check.xml

--- a/.circleci/test-functional-js.sh
+++ b/.circleci/test-functional-js.sh
@@ -16,5 +16,6 @@ fi
 apache2-foreground&
 
 robo override:phpunit-config $1
+robo do:extra $2
 
 sudo -E -u www-data vendor/bin/phpunit -c core --group $1 --testsuite functional-javascript --debug --verbose --log-junit /tmp/artifacts/phpunit/phpunit.xml

--- a/.circleci/test-functional-js.sh
+++ b/.circleci/test-functional-js.sh
@@ -9,7 +9,7 @@ export MINK_DRIVER_ARGS_WEBDRIVER='["chrome", null, "http://localhost:4444/wd/hu
 
 if [ ! -f dependencies_updated ]
 then
-  ./update-dependencies.sh $1
+  ./update-dependencies.sh $1 $2
 fi
 
 # This is the command used by the base image to serve Drupal.

--- a/.circleci/test-functional.sh
+++ b/.circleci/test-functional.sh
@@ -8,7 +8,7 @@ export BROWSERTEST_OUTPUT_DIRECTORY="/var/www/html/sites/simpletest"
 
 if [ ! -f dependencies_updated ]
 then
-  ./update-dependencies.sh $1
+  ./update-dependencies.sh $1 $2
 fi
 
 # This is the command used by the base image to serve Drupal.

--- a/.circleci/test-functional.sh
+++ b/.circleci/test-functional.sh
@@ -15,5 +15,6 @@ fi
 apache2-foreground&
 
 robo override:phpunit-config $1
+robo do:extra $2
 
 sudo -E -u www-data vendor/bin/phpunit -c core --group $1 --testsuite functional --debug --verbose --log-junit /tmp/artifacts/phpunit/phpunit.xml

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -8,7 +8,7 @@ export BROWSERTEST_OUTPUT_DIRECTORY="/var/www/html/sites/simpletest"
 
 if [ ! -f dependencies_updated ]
 then
-  ./update-dependencies.sh $1
+  ./update-dependencies.sh $1 $2
 fi
 
 # This is the command used by the base image to serve Drupal.

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -15,5 +15,6 @@ fi
 apache2-foreground&
 
 robo override:phpunit-config $1
+composer show
 
 sudo -E -u www-data vendor/bin/phpunit -c core --group $1 --testsuite unit,kernel --debug --verbose --log-junit /tmp/artifacts/phpunit/phpunit.xml

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -15,6 +15,7 @@ fi
 apache2-foreground&
 
 robo override:phpunit-config $1
+robo do:extra $2
 composer show
 
 sudo -E -u www-data vendor/bin/phpunit -c core --group $1 --testsuite unit,kernel --debug --verbose --log-junit /tmp/artifacts/phpunit/phpunit.xml

--- a/.circleci/update-dependencies.sh
+++ b/.circleci/update-dependencies.sh
@@ -4,7 +4,9 @@
 cp modules/apigee_edge/.circleci/RoboFile.php ./
 
 robo setup:skeleton
+robo github:token "35654eccb82e092e2d496a5466b46b12f76710b3"
 robo add:modules $1
+robo drupal:version $2
 robo configure:module-dependencies
 robo update:dependencies
 

--- a/.circleci/update-dependencies.sh
+++ b/.circleci/update-dependencies.sh
@@ -4,7 +4,6 @@
 cp modules/apigee_edge/.circleci/RoboFile.php ./
 
 robo setup:skeleton
-robo github:token "35654eccb82e092e2d496a5466b46b12f76710b3"
 robo add:modules $1
 robo drupal:version $2
 robo configure:module-dependencies

--- a/.circleci/update-dependencies.sh
+++ b/.circleci/update-dependencies.sh
@@ -8,6 +8,7 @@ robo add:modules $1
 robo drupal:version $2
 robo configure:module-dependencies
 robo update:dependencies
+robo do:extra $2
 
 # Touch a flag so we know dependencies have been set. Otherwise, there is no
 # easy way to know this step needs to be done when running circleci locally since

--- a/apigee_edge.services.yml
+++ b/apigee_edge.services.yml
@@ -116,12 +116,12 @@ services:
   apigee_edge.exception_subscriber:
     class: Drupal\apigee_edge\EventSubscriber\EdgeExceptionSubscriber
     arguments:
-      - '@http_kernel'
       - '@logger.channel.apigee_edge'
-      - '@redirect.destination'
-      - '@router.no_access_checks'
       - '@config.factory'
       - '@messenger'
+      - '@class_resolver'
+      - '@current_route_match'
+      - '%main_content_renderers%'
     tags:
       - { name: event_subscriber }
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "phpmd/phpmd": "^2.8",
         "phpmetrics/phpmetrics": "^2.5",
         "phpunit/phpunit": "^6.5",
-        "drupal/console": "~1.0"
+        "drupal/console": "~1.0",
+        "mglaman/drupal-check": "^1.1"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,6 @@
         "phpmetrics/phpmetrics": "^2.5",
         "mglaman/drupal-check": "dev-master"
     },
-    "conflict": {
-        "drupal/coder": ">8.3.8"
-    },
     "suggest": {
         "drupal/console": "Needed only to run tests in Drupal 8."
     },

--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,14 @@
     },
     "require-dev": {
         "apigee/apigee-mock-client-php": "^1.0",
-        "behat/mink-extension": "v2.2",
+        "behat/mink-extension": "^2.0",
         "bex/behat-screenshot": "^1.2",
         "cweagans/composer-patches": "^1.6",
         "drupal/core-dev": "^8.7 || ^9",
         "drupal/drupal-extension": "master-dev",
-        "drush/drush": "^9.0",
         "phpmd/phpmd": "^2.8",
         "phpmetrics/phpmetrics": "^2.5",
-        "mglaman/drupal-check": "dev-master",
-        "drupal/console": "~1.0"
+        "mglaman/drupal-check": "dev-master"
     },
     "conflict": {
         "drupal/coder": ">8.3.8"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "phpmetrics/phpmetrics": "^2.5",
         "phpunit/phpunit": "^6.5",
         "drupal/console": "~1.0",
-        "mglaman/drupal-check": "^1.1"
+        "mglaman/drupal-check": "dev-master"
     },
     "conflict": {
         "drupal/coder": ">8.3.8"

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,16 @@
         "cweagans/composer-patches": "^1.6",
         "drupal/core-dev": "^8.7 || ^9",
         "drupal/drupal-extension": "master-dev",
+        "drush/drush": "^9.0 || ^10.0",
         "phpmd/phpmd": "^2.8",
         "phpmetrics/phpmetrics": "^2.5",
         "mglaman/drupal-check": "dev-master"
     },
     "conflict": {
         "drupal/coder": ">8.3.8"
+    },
+    "suggest": {
+        "drupal/console": "Needed only to run tests in Drupal 8."
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "drush/drush": "^9.0 || ^10.0",
         "phpmd/phpmd": "^2.8",
         "phpmetrics/phpmetrics": "^2.5",
-        "mglaman/drupal-check": "dev-master"
+        "mglaman/drupal-check": "^1.1"
     },
     "suggest": {
         "drupal/console": "Needed only to run tests in Drupal 8."

--- a/src/Entity/App.php
+++ b/src/Entity/App.php
@@ -114,7 +114,10 @@ abstract class App extends AttributesAwareFieldableEdgeEntityBase implements App
    * {@inheritdoc}
    */
   public function getCreatedBy(): ?string {
-    return $this->decorated->getCreatedBy();
+    return method_exists($this->decorated, 'getCreatedBy') ?
+      /* @phpstan-ignore-next-line */
+      $this->decorated->getCreatedBy() :
+      '';
   }
 
   /**
@@ -181,7 +184,10 @@ abstract class App extends AttributesAwareFieldableEdgeEntityBase implements App
    * {@inheritdoc}
    */
   public function getLastModifiedBy(): ?string {
-    return $this->decorated->getLastModifiedBy();
+    return method_exists($this->decorated, 'getLastModifiedBy') ?
+      /* @phpstan-ignore-next-line */
+      $this->decorated->getLastModifiedBy() :
+      '';
   }
 
   /**

--- a/src/EventSubscriber/EdgeExceptionSubscriber.php
+++ b/src/EventSubscriber/EdgeExceptionSubscriber.php
@@ -20,16 +20,18 @@
 namespace Drupal\apigee_edge\EventSubscriber;
 
 use Apigee\Edge\Exception\ApiException;
+use Drupal\apigee_edge\Controller\ErrorPageController;
 use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\EventSubscriber\DefaultExceptionHtmlSubscriber;
+use Drupal\Core\DependencyInjection\ClassResolverInterface;
 use Drupal\Core\Messenger\MessengerInterface;
-use Drupal\Core\Routing\RedirectDestinationInterface;
+use Drupal\Core\Routing\RouteMatch;
+use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Utility\Error;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\Route;
 
 /**
  * Handles uncaught ApiExceptions.
@@ -37,7 +39,14 @@ use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
  * Redirects the user to the Edge error page if an uncaught
  * SDK-level ApiException event appears in the HttpKernel component.
  */
-final class EdgeExceptionSubscriber extends DefaultExceptionHtmlSubscriber {
+final class EdgeExceptionSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The logger instance.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $logger;
 
   /**
    * The messenger service.
@@ -54,25 +63,49 @@ final class EdgeExceptionSubscriber extends DefaultExceptionHtmlSubscriber {
   protected $configFactory;
 
   /**
+   * Class Resolver service.
+   *
+   * @var \Drupal\Core\DependencyInjection\ClassResolverInterface
+   */
+  protected $classResolver;
+
+  /**
+   * The current route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * The available main content renderer services, keyed per format.
+   *
+   * @var array
+   */
+  protected $mainContentRenderers;
+
+  /**
    * EdgeExceptionSubscriber constructor.
    *
-   * @param \Symfony\Component\HttpKernel\HttpKernelInterface $http_kernel
-   *   The HTTP kernel.
    * @param \Psr\Log\LoggerInterface $logger
    *   The logger service.
-   * @param \Drupal\Core\Routing\RedirectDestinationInterface $redirect_destination
-   *   The redirect destination service.
-   * @param \Symfony\Component\Routing\Matcher\UrlMatcherInterface $access_unaware_router
-   *   A router implementation which does not check access.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The config factory service.
    * @param \Drupal\Core\Messenger\MessengerInterface $messenger
    *   The messenger service.
+   * @param \Drupal\Core\DependencyInjection\ClassResolverInterface $class_resolver
+   *   The class resolver service.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The current route match.
+   * @param array $main_content_renderers
+   *   The available main content renderer service IDs, keyed by format.
    */
-  public function __construct(HttpKernelInterface $http_kernel, LoggerInterface $logger, RedirectDestinationInterface $redirect_destination, UrlMatcherInterface $access_unaware_router, ConfigFactoryInterface $config_factory, MessengerInterface $messenger) {
-    parent::__construct($http_kernel, $logger, $redirect_destination, $access_unaware_router);
-    $this->messenger = $messenger;
+  public function __construct(LoggerInterface $logger, ConfigFactoryInterface $config_factory, MessengerInterface $messenger, ClassResolverInterface $class_resolver, RouteMatchInterface $route_match, array $main_content_renderers) {
+    $this->logger = $logger;
     $this->configFactory = $config_factory;
+    $this->messenger = $messenger;
+    $this->classResolver = $class_resolver;
+    $this->routeMatch = $route_match;
+    $this->mainContentRenderers = $main_content_renderers;
   }
 
   /**
@@ -85,20 +118,40 @@ final class EdgeExceptionSubscriber extends DefaultExceptionHtmlSubscriber {
   /**
    * Displays the Edge connection error page.
    *
-   * @param \Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent $event
+   * @param \Symfony\Component\HttpKernel\Event\ExceptionEvent|\Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent $event
    *   The exception event.
    */
-  public function onException(GetResponseForExceptionEvent $event) {
-    if ($event->getException() instanceof ApiException || $event->getException()->getPrevious() instanceof ApiException) {
-      $context = Error::decodeException($event->getException());
+  public function onException($event) {
+    $exception = ($event instanceof ExceptionEvent) ? $event->getThrowable() : $event->getException();
+    if ($exception instanceof ApiException || $exception->getPrevious() instanceof ApiException) {
+      $context = Error::decodeException($exception);
       $this->logger->critical('@message %function (line %line of %file). <pre>@backtrace_string</pre>', $context);
-      $this->makeSubrequest($event, '/api-communication-error', Response::HTTP_SERVICE_UNAVAILABLE);
+
+      $controller = $this->classResolver->getInstanceFromDefinition(ErrorPageController::class);
+      $content = [
+        '#title' => $controller->getPageTitle(),
+        'content' => $controller->render(),
+      ];
+
+      $routeMatch = new RouteMatch('apigee_edge.error_page', new Route('/api-communication-error'));
+      $renderer = $this->classResolver->getInstanceFromDefinition($this->mainContentRenderers['html']);
+      $response = $renderer->renderResponse($content, $event->getRequest(), $routeMatch);
 
       // Display additional debug messages.
       if ($this->configFactory->get('apigee_edge.error_page')->get('error_page_debug_messages')) {
-        $this->messenger->addError($event->getException()->getMessage());
+        $this->messenger->addError($exception->getMessage());
       }
+
+      $event->setResponse($response);
     }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[KernelEvents::EXCEPTION][] = ['onException', static::getPriority()];
+    return $events;
   }
 
 }

--- a/src/EventSubscriber/EdgeExceptionSubscriber.php
+++ b/src/EventSubscriber/EdgeExceptionSubscriber.php
@@ -135,7 +135,10 @@ final class EdgeExceptionSubscriber implements EventSubscriberInterface {
 
       $routeMatch = new RouteMatch('apigee_edge.error_page', new Route('/api-communication-error'));
       $renderer = $this->classResolver->getInstanceFromDefinition($this->mainContentRenderers['html']);
+
+      /* @var \Symfony\Component\HttpFoundation\Response $response */
       $response = $renderer->renderResponse($content, $event->getRequest(), $routeMatch);
+      $response->setStatusCode(503);
 
       // Display additional debug messages.
       if ($this->configFactory->get('apigee_edge.error_page')->get('error_page_debug_messages')) {

--- a/src/Plugin/EdgeKeyTypeBase.php
+++ b/src/Plugin/EdgeKeyTypeBase.php
@@ -78,9 +78,11 @@ abstract class EdgeKeyTypeBase extends KeyTypeBase implements EdgeKeyTypeInterfa
    */
   public function getEndpointType(KeyInterface $key): string {
     if ($this->getInstanceType($key) === EdgeKeyTypeInterface::INSTANCE_TYPE_PUBLIC) {
+      /* @phpstan-ignore-next-line */
       return EdgeKeyTypeInterface::EDGE_ENDPOINT_TYPE_DEFAULT;
     }
 
+    /* @phpstan-ignore-next-line */
     return EdgeKeyTypeInterface::EDGE_ENDPOINT_TYPE_CUSTOM;
   }
 

--- a/src/Plugin/EdgeKeyTypeInterface.php
+++ b/src/Plugin/EdgeKeyTypeInterface.php
@@ -73,7 +73,7 @@ interface EdgeKeyTypeInterface extends KeyTypeMultivalueInterface, KeyTypeAuthen
    *
    * @var string
    *
-   * @deprecated Deprecated in apigee_edge:8.x-1.2 and is removed from
+   * @deprecated in apigee_edge:8.x-1.2 and is removed from
    * apigee_edge:8.x-2.0. Check for endpoint type instead.
    *
    * @see EdgeKeyTypeInterface::getEndpointType().
@@ -85,7 +85,7 @@ interface EdgeKeyTypeInterface extends KeyTypeMultivalueInterface, KeyTypeAuthen
    *
    * @var string
    *
-   * @deprecated Deprecated in apigee_edge:8.x-1.2 and is removed from
+   * @deprecated in apigee_edge:8.x-1.2 and is removed from
    * apigee_edge:8.x-2.0. Check for endpoint type instead.
    *
    * @see EdgeKeyTypeInterface::getEndpointType().
@@ -136,7 +136,7 @@ interface EdgeKeyTypeInterface extends KeyTypeMultivalueInterface, KeyTypeAuthen
    * @return string
    *   The API endpoint type.
    *
-   * @deprecated Deprecated in apigee_edge:8.x-1.2 and is removed from
+   * @deprecated in apigee_edge:8.x-1.2 and is removed from
    * apigee_edge:8.x-2.0. Use getInstanceType() instead.
    *
    * @see https://github.com/apigee/apigee-edge-drupal/issues/268

--- a/tests/src/Functional/ApigeeEdgeFunctionalTestBase.php
+++ b/tests/src/Functional/ApigeeEdgeFunctionalTestBase.php
@@ -30,6 +30,13 @@ abstract class ApigeeEdgeFunctionalTestBase extends BrowserTestBase {
   use ApigeeEdgeFunctionalTestTrait;
 
   /**
+   * For tests relying on no markup at all or at least no core markup.
+   *
+   * @var string
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp() {

--- a/tests/src/Functional/DeveloperAppUITestTrait.php
+++ b/tests/src/Functional/DeveloperAppUITestTrait.php
@@ -357,7 +357,7 @@ trait DeveloperAppUITestTrait {
    *   Array of breadcrumb links.
    */
   protected function getBreadcrumbLinks(): array {
-    return $this->xpath('//nav[@class="breadcrumb"]/ol/li/a');
+    return $this->xpath('//nav[@role="navigation"]/ol/li/a');
   }
 
 }

--- a/tests/src/Traits/ApigeeEdgeFunctionalTestTrait.php
+++ b/tests/src/Traits/ApigeeEdgeFunctionalTestTrait.php
@@ -93,7 +93,7 @@ trait ApigeeEdgeFunctionalTestTrait {
     $rid = NULL;
     if ($permissions) {
       $rid = $this->createRole($permissions);
-      $this->assertTrue($rid, 'Role created');
+      static::assertNotFalse($rid, 'Role created');
     }
 
     $edit = [
@@ -116,7 +116,7 @@ trait ApigeeEdgeFunctionalTestTrait {
     $account = User::create($edit);
     $account->save();
 
-    $this->assertTrue($account->id(), 'User created.');
+    static::assertNotFalse($account->id(), 'User created.');
     if (!$account->id()) {
       return NULL;
     }

--- a/tests/src/Unit/EventSubscriber/EdgeExceptionSubscriberTest.php
+++ b/tests/src/Unit/EventSubscriber/EdgeExceptionSubscriberTest.php
@@ -34,7 +34,6 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
-use Symfony\Component\Routing\RequestContext;
 
 /**
  * Test EdgeExceptionSubscriber.
@@ -107,17 +106,7 @@ class EdgeExceptionSubscriberTest extends UnitTestCase {
 
     $this->exception = new ApiException("API response error message.");
 
-//    $this->httpKernel = $this->prophesize(HttpKernelInterface::class);
-//    $this->httpKernel->handle(Argument::any(), Argument::any())->willReturn(new Response());
     $this->logger = $this->prophesize(LoggerInterface::class);
-//    $this->redirectDestination = $this->prophesize(RedirectDestinationInterface::class);
-//    $this->redirectDestination->getAsArray()->willReturn([]);
-
-    $request = $this->prophesize(RequestContext::class);
-//    $this->accessUnawareRouter = $this->prophesize(UrlMatcherInterface::class);
-//    $this->accessUnawareRouter->getContext(Argument::any())->willReturn($request->reveal());
-//    $this->accessUnawareRouter->setContext(Argument::any())->willReturn();
-//    $this->accessUnawareRouter->match(Argument::any())->willReturn([]);
 
     $this->messenger = $this->prophesize(MessengerInterface::class);
 


### PR DESCRIPTION
- Adds [mglaman/drupal-check](https://github.com/mglaman/drupal-check) as another step for CI.
- Fixes deprecations.
- Prepares CircleCI config file to run in a matrix against D8 and D9 (although D9 tests aren't executed yet).