### PR TITLE
[#396] Add a target bundle to first and last name user fields.

### DIFF
--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -280,6 +280,13 @@ function apigee_edge_entity_base_field_info_alter(&$fields, EntityTypeInterface 
     $mail = $fields['mail'];
     $mail->setRequired(TRUE);
     $mail->addConstraint('DeveloperMailUnique');
+
+    // Add a bundle to these fields to allow other modules to display them
+    // as configurable (fields added through the UI or configuration do have a
+    // target bundle set).
+    // @see https://github.com/apigee/apigee-edge-drupal/issues/396
+    $fields['first_name']->setTargetBundle('user');
+    $fields['last_name']->setTargetBundle('user');
   }
 }
 


### PR DESCRIPTION
At least one module seems to think that user fields that should be exposed for other configuration should have a target bundle set, as a way to distinguish the fields from other internal fields (such as uuid, roles, etc). This is at least the case with the_CAS Attributes_ module that allows setting remote attributes mapping to user fields. 
This PR adds the bundle to the first/last name fields.
As a note, fields added through the UI and saved into configuration do have the bundle set to "user", however, fields added through `hook_entity_base_field_info_alter()` do not (even if using `->setTargetBundle('user')`), I think that because by definition base fields apply to all bundles of an entity type.