### PR TITLE
[#313] [POC] Hybrid app cache handling

### DIFF
--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -1559,6 +1559,21 @@ function apigee_edge_developer_app_storage_load(array $entities) {
 }
 
 /**
+ * Implements hook_entity_insert().
+ */
+function apigee_edge_entity_insert(EntityInterface $entity) {
+  $user = Drupal::currentUser();
+  if ($entity instanceof AppInterface) {
+    $store = Drupal::keyValue("apigee_edge.local_entities.{$entity->getEntityTypeId()}");
+
+    // Save the inserted app to the key value store.
+    $value = $store->get($user->getEmail(), []);
+    $value[$entity->id()] = $entity->getDisplayName();
+    $store->set($user->getEmail(), $value);
+  }
+}
+
+/**
  * Checks whether a user has a developer app with an API product.
  *
  * We did not add static caching to this function because there could be

--- a/src/Entity/ListBuilder/AppListBuilder.php
+++ b/src/Entity/ListBuilder/AppListBuilder.php
@@ -209,7 +209,7 @@ class AppListBuilder extends EdgeEntityListBuilder {
     array_pop($entities);
 
     $local_entities = \Drupal::keyValue("apigee_edge.local_entities.{$this->entityTypeId}")
-      ->get(Drupal::currentUser()->getEmail());
+      ->get(\Drupal::currentUser()->getEmail());
     $unsynced_entities = array_diff_key($local_entities, $entities);
 
     // Show a message if there are app created locally but not persisted yet.


### PR DESCRIPTION
@cnovak @arlina-espinoza This is proof of concept (as we discussed on the call) for handling app creation and server delay.

How it works:

1. When an `app` is inserted, insert a record to the key value store.
2. On the `AppListBuilder`, compare cached app entities and entities from the key value store. 
3. Display an info message if there are apps that were saved locally (here save is the app create form was successfully submitted) but not persisted on the remote server yet.

![Apps___Apigee](https://user-images.githubusercontent.com/124599/81162986-1bf78600-8f9f-11ea-86d0-5780641e5b62.jpg)

Note: I'm forcing some missing entities since I could not reproduce the delay on our hybrid instance. 

This is wip and needs implementation (example handling team apps..etc). 

Let's gather some feedback.