### PR TITLE
Workaround a composer bug documented at drupal.org/project/coder/issu…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,9 @@
         "phpunit/phpunit": "^6.5",
         "drupal/console": "~1.0"
     },
+    "conflict": {
+        "drupal/coder": ">8.3.8"
+    },
     "config": {
         "sort-packages": true
     },


### PR DESCRIPTION
Builds are failing on CircleCI because code sniffer can't run:
 
```
+ vendor/bin/phpcs --config-set installed_paths vendor/drupal/coder/coder_sniffer
./code-sniffer.sh: line 11: vendor/bin/phpcs: No such file or directory
```

After inspection, the package `squizlabs/php_codesniffer` isn't getting installed, and it should because it's a dependency of `drupal/coder` (and that is required by `drupal/core-dev` on the module's composer.json).
This seems to be a bug with Drupal's infrastructure, and it's documented at: https://www.drupal.org/project/coder/issues/3134853
This PR marks a conflict with `"drupal/coder": ">8.3.8"` while it gets sorted out on the Drupal infrastructure side. 

Note: an [example failed build](https://app.circleci.com/pipelines/github/apigee/apigee-edge-drupal/92/workflows/02ff977c-2dcb-4ec6-ae57-ef353e8a170e/jobs/319).