### PR TITLE
[#413] Remove experimental status off the apigee_edge_teams submodule.

### DIFF
--- a/modules/apigee_edge_teams/apigee_edge_teams.info.yml
+++ b/modules/apigee_edge_teams/apigee_edge_teams.info.yml
@@ -1,6 +1,6 @@
 name: Apigee Edge Teams
 description: Provides shared app functionality by allowing developers to be organised into teams.
-package: Apigee (Experimental)
+package: Apigee
 
 type: module
 core_version_requirement: ^8 || ^9


### PR DESCRIPTION
Remove the _experimental_ status off the `apigee_edge_teams` submodule. 