### PR TITLE
Lock rules version to 3.0.0-alpha5

### DIFF
--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -412,7 +412,7 @@ class RoboFile extends \Robo\Tasks
     $config->require->{"drupal/core-recommended"} = "~8.8";
 
     // Add rules for testing apigee_edge_actions.
-    $config->require->{"drupal/rules"} = "^3.0@alpha";
+    $config->require->{"drupal/rules"} = "3.0.0-alpha5";
 
     // We require Drupal console and drush for some tests.
     $config->require->{"drupal/console"} = "~1.0";

--- a/modules/apigee_edge_actions/composer.json
+++ b/modules/apigee_edge_actions/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=7.1",
         "drupal/apigee_edge": "*",
-        "drupal/rules": "^3.0@alpha"
+        "drupal/rules": "3.0.0-alpha5"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
Rules introduced some breaking changes in https://www.drupal.org/project/rules/releases/8.x-3.0-alpha6

Let's lock to alpha5 for now. 

I created a separate issue to track the upgrade: https://github.com/apigee/apigee-edge-drupal/issues/448