### PR TITLE
[#461] Quickedit compatibility.

### DIFF
--- a/src/Entity/EdgeEntityBase.php
+++ b/src/Entity/EdgeEntityBase.php
@@ -161,4 +161,22 @@ abstract class EdgeEntityBase extends EntityBase implements EdgeEntityInterface 
     return FALSE;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getTranslation($langcode) {
+    if ($langcode == $this->language()->getId()) {
+      return $this;
+    }
+
+    throw new \InvalidArgumentException("Invalid translation language ($langcode) specified.");
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function hasTranslation($langcode) {
+    return $langcode == $this->language()->getId();
+  }
+
 }


### PR DESCRIPTION
Fixes #461 . The issue is that core's quickedit module assumes all content extends `ContentEntityBase`, which is not the case with Apigee Edge entities. This PR adds a couple of methods that are called in the quickedit module to make it compatible. 

Note: The best fix would be for the quick edit module to check if an entity is translatable or not before calling these methods (there is an [issue with a patch for that](https://www.drupal.org/project/drupal/issues/3082529)), but given that there is not much interest in core to account for edge use cases, it makes sense to fix it in the module.