### PR TITLE
Temporary fix for phpmd/phpmd.

### DIFF
--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -47,6 +47,7 @@ class RoboFile extends \Robo\Tasks
     $config = json_decode(file_get_contents('composer.json'));
     $config->extra->{"enable-patching"} = 'true';
     $config->extra->{"patches"} = new \stdClass();
+
     file_put_contents('composer.json', json_encode($config));
 
     // Create a directory for our artifacts.

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "drupal/core-dev": "^8.7 || ^9",
         "drupal/drupal-extension": "master-dev",
         "drush/drush": "^9.0 || ^10.0",
-        "phpmd/phpmd": "^2.8",
+        "phpmd/phpmd": "2.8.2",
         "phpmetrics/phpmetrics": "^2.5",
         "mglaman/drupal-check": "^1.1"
     },


### PR DESCRIPTION
CircleCI tests are currently failing on the PHP Code Sniffer step. Example: https://app.circleci.com/pipelines/github/apigee/apigee-edge-drupal/230/workflows/69411519-48ff-4c98-afd1-8743e5c4ff14/jobs/996
Seems to be caused by this issue in the phpmd/phpmd project: https://github.com/phpmd/phpmd/issues/816, introduced in the latest release 2.9.0.
This PR locks phpmd to the 2.8.x branch, and should be removed once it gets fixed on their side (likely 2.9.1).