### PR TITLE
Code sniffer validations

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,5 +18,9 @@
   <rule ref="Drupal.NamingConventions.ValidVariableName.LowerCamelName">
     <severity>0</severity>
   </rule>
+  <!-- Ignore long array declaration lines. -->
+  <rule ref="Drupal.Arrays.Array.LongLineDeclaration">
+    <severity>0</severity>
+  </rule>
 
 </ruleset>

--- a/src/Exception/AuthenticationKeyValueMalformedException.php
+++ b/src/Exception/AuthenticationKeyValueMalformedException.php
@@ -2,8 +2,6 @@
 
 namespace Drupal\apigee_edge\Exception;
 
-use Throwable;
-
 /**
  * Defines an exception for when a key value is malformed.
  */
@@ -30,7 +28,7 @@ class AuthenticationKeyValueMalformedException extends AuthenticationKeyExceptio
    * @param \Throwable|null $previous
    *   Previous exception.
    */
-  public function __construct($problematic_field, $message = 'Apigee Edge API authentication key is malformed or not readable.', $code = 0, Throwable $previous = NULL) {
+  public function __construct($problematic_field, $message = 'Apigee Edge API authentication key is malformed or not readable.', $code = 0, \Throwable $previous = NULL) {
     $this->problematicField = $problematic_field;
     $message = strtr($message, ['@field' => $problematic_field]);
     parent::__construct($message, $code, $previous);

--- a/src/Form/ConnectionConfigForm.php
+++ b/src/Form/ConnectionConfigForm.php
@@ -67,13 +67,13 @@ class ConnectionConfigForm extends ConfigFormBase {
       '#required' => TRUE,
     ];
 
-     $form['http_proxy'] = [
-           '#type' => 'textfield',
-           '#title' => $this->t('HTTP client proxy'),
-           '#description' => $this->t('The Http proxy used to connect to Apigee Edge.'),
-           '#default_value' => $this->config('apigee_edge.client')->get('http_client_proxy'),
-           '#required' => FALSE,
-     ];
+    $form['http_proxy'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('HTTP client proxy'),
+      '#description' => $this->t('Leave empty unless an HTTP proxy is needed to connect to Apigee Edge.'),
+      '#default_value' => $this->config('apigee_edge.client')->get('http_client_proxy'),
+      '#required' => FALSE,
+    ];
 
     return parent::buildForm($form, $form_state);
   }
@@ -85,7 +85,7 @@ class ConnectionConfigForm extends ConfigFormBase {
     $this->config('apigee_edge.client')
       ->set('http_client_connect_timeout', $form_state->getValue('connect_timeout'))
       ->set('http_client_timeout', $form_state->getValue('request_timeout'))
-      ->set('http_client_proxy', $form_state->getValue('http_proxy'))
+      ->set('http_client_proxy', trim($form_state->getValue('http_proxy')))
       ->save();
     parent::submitForm($form, $form_state);
   }

--- a/src/KeyEntityFormEnhancer.php
+++ b/src/KeyEntityFormEnhancer.php
@@ -24,7 +24,6 @@ use Apigee\Edge\Exception\ApiRequestException;
 use Apigee\Edge\Exception\HybridOauth2AuthenticationException;
 use Apigee\Edge\Exception\OauthAuthenticationException;
 use Apigee\Edge\HttpClient\Plugin\Authentication\Oauth;
-use DomainException;
 use Drupal\apigee_edge\Exception\AuthenticationKeyException;
 use Drupal\apigee_edge\Exception\InvalidArgumentException;
 use Drupal\apigee_edge\Exception\KeyProviderRequirementsException;
@@ -478,7 +477,7 @@ final class KeyEntityFormEnhancer {
       ]);
 
       // Invalid key / OpenSSL unable to sign data.
-      if ($exception->getPrevious() && $exception->getPrevious() instanceof DomainException) {
+      if ($exception->getPrevious() && $exception->getPrevious() instanceof \DomainException) {
         $suggestion = $this->t('@fail_text The private key in the GCP service account key JSON is invalid.', [
           '@fail_text' => $fail_text,
         ]);

--- a/src/Plugin/FieldStorageFormatManager.php
+++ b/src/Plugin/FieldStorageFormatManager.php
@@ -23,7 +23,6 @@ use Drupal\apigee_edge\Annotation\ApigeeFieldStorageFormat;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
-use Traversable;
 
 /**
  * Provides a FieldStorageFormat plugin manager.
@@ -33,7 +32,7 @@ class FieldStorageFormatManager extends DefaultPluginManager implements FieldSto
   /**
    * {@inheritdoc}
    */
-  public function __construct(Traversable $namespaces, CacheBackendInterface $cache, ModuleHandlerInterface $module_handler) {
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache, ModuleHandlerInterface $module_handler) {
     parent::__construct(
       'Plugin/ApigeeFieldStorageFormat',
       $namespaces,

--- a/tests/src/Functional/DeveloperAppUITest.php
+++ b/tests/src/Functional/DeveloperAppUITest.php
@@ -482,8 +482,10 @@ class DeveloperAppUITest extends ApigeeEdgeFunctionalTestBase {
       ->save();
     \Drupal::entityTypeManager()->clearCachedDefinitions();
 
-    $this->products[] = $product1 = $this->createProduct();;
-    $this->products[] = $product2 = $this->createProduct();
+    $product1 = $this->createProduct();
+    $product2 = $this->createProduct();
+    $this->products[] = $product1;
+    $this->products[] = $product2;
     $app = $this->createDeveloperApp(['name' => $this->randomMachineName(), 'displayName' => $this->randomString()], $this->account, [$product1->id(), $product2->id()]);
     $app_edit_url = $app->toUrl('edit-form-for-developer');
 
@@ -517,7 +519,8 @@ class DeveloperAppUITest extends ApigeeEdgeFunctionalTestBase {
       ->save();
 
     $callback_url = $this->randomMachineName();
-    $this->products[] = $product = $this->createProduct();;
+    $product = $this->createProduct();
+    $this->products[] = $product;
     $app = $this->createDeveloperApp([
       'name' => $callback_url,
       'displayName' => $this->randomString(),

--- a/tests/src/Unit/Command/Util/ApigeeEdgeManagementCliServiceTest.php
+++ b/tests/src/Unit/Command/Util/ApigeeEdgeManagementCliServiceTest.php
@@ -31,7 +31,6 @@ use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
 use Psr\Http\Message\RequestInterface;
-use ReflectionClass;
 use Symfony\Component\Console\Style\StyleInterface;
 
 /**
@@ -479,7 +478,7 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
 
     // Make method under test not private.
     $apigee_edge_management_cli_service = new ApigeeEdgeManagementCliService($this->httpClient->reveal());
-    $apigee_edge_management_cli_service_reflection = new ReflectionClass($apigee_edge_management_cli_service);
+    $apigee_edge_management_cli_service_reflection = new \ReflectionClass($apigee_edge_management_cli_service);
     $method_set_default_permissions = $apigee_edge_management_cli_service_reflection->getMethod('setDefaultPermissions');
     $method_set_default_permissions->setAccessible(TRUE);
 


### PR DESCRIPTION
This PR fixes code sniffer validations after update to drupal/coder 8.3.10 (example of current failing tests: https://app.circleci.com/pipelines/github/apigee/apigee-edge-drupal/258/workflows/87d8bfbf-c1b5-4884-bdbf-2472f7a32046/jobs/1108), and updates the help message of the new configuration field introduced in #475 .