### PR TITLE
#478 Enable CI testing for D9 and fix deprecations

### DIFF
--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -47,6 +47,10 @@ class RoboFile extends \Robo\Tasks
     $config = json_decode(file_get_contents('composer.json'));
     $config->extra->{"enable-patching"} = 'true';
     $config->extra->{"patches"} = new \stdClass();
+    $config->extra->{"drupal-scaffold"} = new \stdClass();
+    $config->extra->{"drupal-scaffold"}->{"locations"} = (object) [
+      'web-root' => '.',
+    ];
 
     file_put_contents('composer.json', json_encode($config));
 
@@ -425,12 +429,14 @@ class RoboFile extends \Robo\Tasks
 
     switch ($drupalCoreVersion) {
       case '9':
+        $config->require->{"drupal/core-composer-scaffold"} = '^9';
         $config->require->{"drupal/core-recommended"} = '^9';
         $config->require->{"drupal/core-dev"} = '^9';
 
         break;
 
       case '8':
+        $config->require->{"drupal/core-composer-scaffold"} = '~8';
         $config->require->{"drupal/core-recommended"} = '~8';
         $config->require->{"drupal/core-dev"} = '~8';
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,7 +246,7 @@ workflows:
           name: update-dependencies-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [8]
+              core-version: [8, 9]
       - run-code-sniffer:
           requires:
             - update-dependencies-8
@@ -257,21 +257,21 @@ workflows:
           name: run-unit-kernel-tests-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [8]
+              core-version: [8, 9]
           requires:
             - update-dependencies-<< matrix.core-version >>
       - run-functional-tests:
           name: run-functional-tests-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [8]
+              core-version: [8, 9]
           requires:
             - update-dependencies-<< matrix.core-version >>
       - run-functional-js-tests:
           name: run-functional-js-tests-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [8]
+              core-version: [8, 9]
           requires:
             - update-dependencies-<< matrix.core-version >>
 #      - run-code-coverage:

--- a/src/Entity/ListBuilder/EdgeEntityListBuilder.php
+++ b/src/Entity/ListBuilder/EdgeEntityListBuilder.php
@@ -88,7 +88,7 @@ class EdgeEntityListBuilder extends EntityListBuilder {
   public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
     return new static(
       $entity_type,
-      $container->get('entity.manager'),
+      $container->get('entity_type.manager'),
       $container->get('config.factory')
     );
   }

--- a/tests/modules/apigee_mock_api_client/src/TwigExtension/ResponseTemplateLoader.php
+++ b/tests/modules/apigee_mock_api_client/src/TwigExtension/ResponseTemplateLoader.php
@@ -52,7 +52,7 @@ class ResponseTemplateLoader extends \Twig_Loader_Filesystem {
   /**
    * {@inheritdoc}
    */
-  protected function findTemplate($name, $throw = true) {
+  protected function findTemplate($name, $throw = TRUE) {
     $name = str_replace('_', '-', $name);
 
     if (strpos($name, '.twig') === FALSE) {

--- a/tests/modules/apigee_mock_api_client/src/TwigExtension/ResponseTemplateLoader.php
+++ b/tests/modules/apigee_mock_api_client/src/TwigExtension/ResponseTemplateLoader.php
@@ -52,14 +52,14 @@ class ResponseTemplateLoader extends \Twig_Loader_Filesystem {
   /**
    * {@inheritdoc}
    */
-  protected function normalizeName($name) {
-    $name = str_replace('_', '-', parent::normalizeName($name));
+  protected function findTemplate($name, $throw = true) {
+    $name = str_replace('_', '-', $name);
 
     if (strpos($name, '.twig') === FALSE) {
       $name = "{$name}.json.twig";
     }
 
-    return $name;
+    return parent::findTemplate($name, $throw);
   }
 
 }

--- a/tests/src/Functional/DeveloperTest.php
+++ b/tests/src/Functional/DeveloperTest.php
@@ -416,7 +416,7 @@ class DeveloperTest extends ApigeeEdgeFunctionalTestBase {
     // too.
     $this->stack->queueMockResponse('get_not_found');
     $loaded = $this->developerStorage->loadUnchanged($test_user['email']);
-    $this->assertFalse($loaded, 'Developer does not exists anymore.');
+    $this->assertEmpty($loaded, 'Developer does not exists anymore.');
   }
 
   /**

--- a/tests/src/FunctionalJavascript/ApigeeEdgeFunctionalJavascriptTestBase.php
+++ b/tests/src/FunctionalJavascript/ApigeeEdgeFunctionalJavascriptTestBase.php
@@ -30,6 +30,13 @@ abstract class ApigeeEdgeFunctionalJavascriptTestBase extends WebDriverTestBase 
   use ApigeeEdgeFunctionalTestTrait;
 
   /**
+   * For tests relying on no markup at all or at least no core markup.
+   *
+   * @var string
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp() {

--- a/tests/src/FunctionalJavascript/Form/AuthenticationFormJsTest.php
+++ b/tests/src/FunctionalJavascript/Form/AuthenticationFormJsTest.php
@@ -35,6 +35,11 @@ use Drupal\Tests\apigee_edge\FunctionalJavascript\ApigeeEdgeFunctionalJavascript
 class AuthenticationFormJsTest extends ApigeeEdgeFunctionalJavascriptTestBase {
 
   /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'classy';
+
+  /**
    * Valid username.
    *
    * @var string


### PR DESCRIPTION
Closes #478. This PR:
- Enables the testing matrix against both D8 and D9.
- Fixes some tests and deprecations, so the `apigee_edge` module and submodules can run in both D8 and D9 (with the exception of `apigee_edge_actions`, which is only for D8 because the `rules` module still doesn't have a D9 release).

Example of the test matrix in CircleCI:
![image](https://user-images.githubusercontent.com/4062676/93269859-b6917e00-f764-11ea-9755-a604fe6a4d05.png)
