### PR TITLE
[#499] Update permissions for team invitations

### DIFF
--- a/modules/apigee_edge_teams/src/DefaultTeamPermissionsProvider.php
+++ b/modules/apigee_edge_teams/src/DefaultTeamPermissionsProvider.php
@@ -61,8 +61,8 @@ final class DefaultTeamPermissionsProvider implements DynamicTeamPermissionProvi
         'label' => $this->t('Team'),
         'permissions' => [
           'manage_members' => [
-            'label' => $this->t('Manage team members'),
-            'description' => $this->t('Add/remove team members and administer permissions.'),
+            'label' => $this->t('Manage team members and invitations'),
+            'description' => $this->t('Add/remove team members and administer team invitations.'),
           ],
         ],
       ],

--- a/modules/apigee_edge_teams/src/Entity/TeamInvitationPermissionProvider.php
+++ b/modules/apigee_edge_teams/src/Entity/TeamInvitationPermissionProvider.php
@@ -33,7 +33,7 @@ class TeamInvitationPermissionProvider extends EntityPermissionProvider {
    */
   public function buildPermissions(EntityTypeInterface $entity_type) {
     $permissions['administer team_invitation'] = [
-      'title' => $this->t('Administer team invitations'),
+      'title' => $this->t('Administer team invitation settings'),
       'provider' => 'apigee_edge_teams',
       'restrict access' => TRUE,
     ];


### PR DESCRIPTION
Fixes #499 

1. Renames the **team permission** `Manage team members` to `Manage team members and invitations`.
2. Renames the **global permission** `Administer team invitations` to `Administer team invitation settings`.

<img width="936" alt="Permissions___Apigee" src="https://user-images.githubusercontent.com/124599/94808375-1db85f00-0402-11eb-8055-6a21a0082694.png">
