### PR TITLE
[#499] Use ManageTeamMembersAccess::access for team invitations

### DIFF
--- a/apigee_edge.install
+++ b/apigee_edge.install
@@ -27,6 +27,7 @@ use Drupal\apigee_edge\OauthTokenFileStorage;
 use Drupal\Core\Installer\InstallerKernel;
 use Drupal\Core\Url;
 use Drupal\user\RoleInterface;
+use Drupal\views\Views;
 
 /**
  * Implements hook_requirements().
@@ -274,3 +275,23 @@ function apigee_edge_update_8103() {
     user_role_grant_permissions(RoleInterface::AUTHENTICATED_ID, $authenticated_user_permissions);
   }
 }
+
+/**
+ * Remove the "Manage team members and invitations" access for the Team invitations view.
+ */
+function apigee_edge_update_8104() {
+  /** @var \Drupal\views\ViewExecutable $view */
+  $view = Views::getView('team_invitations');
+  $view->setDisplay('team');
+  $access = $view->getDisplay()->getOption('access');
+  if (empty($access['type']) || $access['type'] !== "team_permission") {
+    return;
+  }
+
+  $view->getDisplay()->setOption('access', [
+    'type' => 'none',
+    'options' => [],
+  ]);
+  $view->save();
+}
+

--- a/modules/apigee_edge_teams/config/optional/views.view.team_invitations.yml
+++ b/modules/apigee_edge_teams/config/optional/views.view.team_invitations.yml
@@ -721,9 +721,8 @@ display:
         empty: false
         access: false
       access:
-        type: team_permission
-        options:
-          permission: team_manage_members
+        type: none
+        options: {  }
     cache_metadata:
       max-age: -1
       contexts:

--- a/modules/apigee_edge_teams/src/Entity/TeamInvitation.php
+++ b/modules/apigee_edge_teams/src/Entity/TeamInvitation.php
@@ -60,7 +60,7 @@ use Drupal\user\UserInterface;
  *   },
  *   base_table = "team_invitation",
  *   data_table = "team_invitation_field_data",
- *   admin_permission = "administer team invitations",
+ *   admin_permission = "manage team members",
  *   entity_keys = {
  *     "id" = "uuid",
  *     "label" = "label",

--- a/modules/apigee_edge_teams/src/Entity/TeamInvitationAccessControlHandler.php
+++ b/modules/apigee_edge_teams/src/Entity/TeamInvitationAccessControlHandler.php
@@ -94,7 +94,7 @@ final class TeamInvitationAccessControlHandler extends EntityAccessControlHandle
     // Note: This is handled at team level permissions.
     if ($operation === 'delete' || $operation === "resend") {
       return AccessResult::allowedIf(in_array('team_manage_members', $this->teamPermissionHandler->getDeveloperPermissionsByTeam($entity->getTeam(), $account)))
-        ->orIf(AccessResult::allowedIfHasPermission($account, 'administer team invitations'))
+        ->orIf(AccessResult::allowedIfHasPermissions($account, ['administer team', 'manage team members'], 'OR'))
         ->addCacheableDependency($entity)
         ->cachePerUser();
     }


### PR DESCRIPTION
Fixes #499 

This PR removes the `team_manage_members` access config from the `Team invitations` view.

This view is embedded as part of `\Drupal\apigee_edge_teams\Controller\TeamMembersList::overview` and access for this is already handled in `\Drupal\apigee_edge_teams\Access\ManageTeamMembersAccess::access`.

https://github.com/apigee/apigee-edge-drupal/blob/c4ccce70d6b09b3d855446a06d83d1f83432d990/modules/apigee_edge_teams/src/Access/ManageTeamMembersAccess.php#L77-L101

Removing the access control on the view allows one source of truth for handling access for both members and team invitations.

Another possible fix would be a new view access plugin that does the same thing as `\Drupal\apigee_edge_teams\Access\ManageTeamMembersAccess::access`.