### PR TITLE
[#492] Refactor app warnings

### DIFF
--- a/apigee_edge.install
+++ b/apigee_edge.install
@@ -274,3 +274,27 @@ function apigee_edge_update_8103() {
     user_role_grant_permissions(RoleInterface::AUTHENTICATED_ID, $authenticated_user_permissions);
   }
 }
+
+/**
+ * Enable warnings field in default app view displays.
+ */
+function apigee_edge_update_8104() {
+  foreach (['developer_app', 'team_app'] as $entity_type_id) {
+    if (!\Drupal::entityTypeManager()->getDefinition($entity_type_id, FALSE)) {
+      continue;
+    }
+
+    /** @var \Drupal\Core\Entity\EntityDisplayRepository $entity_display_repository */
+    $entity_display_repository = \Drupal::service('entity_display.repository');
+    $entity_view_display = $entity_display_repository->getViewDisplay($entity_type_id, $entity_type_id);
+
+    if ($entity_view_display->getComponent('warnings')) {
+      continue;
+    }
+
+    $entity_view_display->setComponent('warnings', [
+      'region' => 'content',
+      'weight' => -100,
+    ])->save();
+  }
+}

--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -351,6 +351,11 @@ function apigee_edge_entity_extra_field_info() {
         'weight' => 100,
         'visible' => TRUE,
       ];
+      $extra[$definition->id()][$definition->id()]['display']['warnings'] = [
+        'label' => new TranslatableMarkup('Warnings'),
+        'description' => new TranslatableMarkup('Displays app warnings'),
+        'visible' => TRUE,
+      ];
     }
   }
   return $extra;
@@ -442,6 +447,20 @@ function apigee_edge_entity_view(array &$build, EntityInterface $entity, EntityV
           ],
         ],
       ]))->toRenderable();
+    }
+  }
+
+  if ($display->getComponent('warnings')) {
+    /** @var \Drupal\apigee_edge\Entity\AppWarningsCheckerInterface $app_warnings_checker */
+    $app_warnings_checker = \Drupal::service('apigee_edge.entity.app_warnings_checker');
+    $warnings = array_filter($app_warnings_checker->getWarnings($entity));
+    if (count($warnings)) {
+      $build['warnings'] = [
+        '#theme' => 'status_messages',
+        '#message_list' => [
+          'warning' => $warnings,
+        ],
+      ];
     }
   }
 }

--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -354,6 +354,7 @@ function apigee_edge_entity_extra_field_info() {
       $extra[$definition->id()][$definition->id()]['display']['warnings'] = [
         'label' => new TranslatableMarkup('Warnings'),
         'description' => new TranslatableMarkup('Displays app warnings'),
+        'weight' => -100,
         'visible' => TRUE,
       ];
     }

--- a/apigee_edge.services.yml
+++ b/apigee_edge.services.yml
@@ -106,6 +106,10 @@ services:
     class: Drupal\apigee_edge\Entity\Controller\Cache\DeveloperAppNameCacheFactory
     arguments: ['@apigee_edge.entity.controller.cache.app_name_cache_by_owner_factory', '@entity_type.manager', '@email.validator']
 
+  apigee_edge.entity.app_warnings_checker:
+    class: Drupal\apigee_edge\Entity\AppWarningsChecker
+    arguments: ['@entity_type.manager', '@datetime.time']
+
   apigee_edge.cache.memory_cache_factory:
     class: Drupal\apigee_edge\MemoryCacheFactory
 

--- a/src/Entity/AppWarningsChecker.php
+++ b/src/Entity/AppWarningsChecker.php
@@ -108,7 +108,7 @@ class AppWarningsChecker implements AppWarningsCheckerInterface {
 
     // If all credentials are revoked, show a warning.
     if (count($app->getCredentials()) === count($revoked_credentials)) {
-      $warnings['revokedCred'] = $this->t('All credentials associated with this @app are in revoked status.', $args);
+      $warnings['revokedCred'] = $this->t('No valid credentials associated with this @app.', $args);
     }
 
     return $warnings;

--- a/src/Entity/AppWarningsChecker.php
+++ b/src/Entity/AppWarningsChecker.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * Copyright 2020 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_edge\Entity;
+
+use Apigee\Edge\Api\Management\Entity\AppCredentialInterface;
+use Apigee\Edge\Structure\CredentialProduct;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * A service for handling app warnings.
+ */
+class AppWarningsChecker implements AppWarningsCheckerInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The time service.
+   *
+   * @var \Drupal\Component\Datetime\TimeInterface
+   */
+  protected $time;
+
+  /**
+   * AppWarningsChecker constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   *   The time service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, TimeInterface $time) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->time = $time;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getWarnings(AppInterface $app): array {
+    $warnings = [];
+    $warnings['revokedCred'] = FALSE;
+    $warnings['revokedOrPendingCredProduct'] = FALSE;
+    $warnings['expiredCred'] = FALSE;
+    $revoked_credentials = [];
+    $args = [
+      '@app' => mb_strtolower($app->getEntityType()->getSingularLabel()),
+    ];
+
+    foreach ($app->getCredentials() as $credential) {
+      // Check for revoked credentials.
+      if ($credential->getStatus() === AppCredentialInterface::STATUS_REVOKED) {
+        $revoked_credentials[] = $credential;
+        continue;
+      }
+
+      // Check for expired credentials.
+      if (($expired_date = $credential->getExpiresAt()) && $this->time->getRequestTime() - $expired_date->getTimestamp() > 0) {
+        $warnings['expiredCred'] = $this->t('At least one of the credentials associated with this @app is expired.', $args);
+      }
+
+      // Check status of API products for credential.
+      foreach ($credential->getApiProducts() as $cred_product) {
+        if ($cred_product->getStatus() == CredentialProduct::STATUS_REVOKED || $cred_product->getStatus() == CredentialProduct::STATUS_PENDING) {
+          $args['@api_product'] = mb_strtolower($this->entityTypeManager->getDefinition('api_product')
+            ->getSingularLabel());
+          $args['@status'] = $cred_product->getStatus() == CredentialProduct::STATUS_REVOKED ? $this->t('revoked') : $this->t('pending');
+          if (count($app->getCredentials()) === 1) {
+            /** @var \Drupal\apigee_edge\Entity\ApiProductInterface $apiProduct */
+            $api_product = $this->entityTypeManager->getStorage('api_product')
+              ->load($cred_product->getApiproduct());
+            $args['%name'] = $api_product->label();
+            $warnings['revokedOrPendingCredProduct'] = $this->t('%name @api_product associated with this @app is in @status status.', $args);
+          }
+          else {
+            $warnings['revokedOrPendingCredProduct'] = $this->t('At least one @api_product associated with one of the credentials of this @app is in @status status.', $args);
+          }
+          break;
+        }
+      }
+    }
+
+    // If all credentials are revoked, show a warning.
+    if (count($app->getCredentials()) === count($revoked_credentials)) {
+      $warnings['revokedCred'] = $this->t('All credentials associated with this @app are in revoked status.', $args);
+    }
+
+    return $warnings;
+  }
+
+}

--- a/src/Entity/AppWarningsChecker.php
+++ b/src/Entity/AppWarningsChecker.php
@@ -88,8 +88,8 @@ class AppWarningsChecker implements AppWarningsCheckerInterface {
       // Check status of API products for credential.
       foreach ($credential->getApiProducts() as $cred_product) {
         if ($cred_product->getStatus() == CredentialProduct::STATUS_REVOKED || $cred_product->getStatus() == CredentialProduct::STATUS_PENDING) {
-          $args['@api_product'] = mb_strtolower($this->entityTypeManager->getDefinition('api_product')
-            ->getSingularLabel());
+          $args['@api_product'] = $this->entityTypeManager->getDefinition('api_product')
+            ->getSingularLabel();
           $args['@status'] = $cred_product->getStatus() == CredentialProduct::STATUS_REVOKED ? $this->t('revoked') : $this->t('pending');
           if (count($app->getCredentials()) === 1) {
             /** @var \Drupal\apigee_edge\Entity\ApiProductInterface $apiProduct */

--- a/src/Entity/AppWarningsCheckerInterface.php
+++ b/src/Entity/AppWarningsCheckerInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Copyright 2020 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_edge\Entity;
+
+/**
+ * Defines an interface for an app warnings checker service.
+ */
+interface AppWarningsCheckerInterface {
+
+  /**
+   * Checks credentials of an app and returns warnings about them.
+   *
+   * @param \Drupal\apigee_edge\Entity\AppInterface $app
+   *   The app entity to be checked.
+   *
+   * @return array
+   *   An associative array that contains information about the revoked
+   *   credentials and revoked or pending API products in a credential.
+   */
+  public function getWarnings(AppInterface $app): array;
+
+}

--- a/src/Entity/ListBuilder/AppListBuilder.php
+++ b/src/Entity/ListBuilder/AppListBuilder.php
@@ -20,9 +20,6 @@
 
 namespace Drupal\apigee_edge\Entity\ListBuilder;
 
-use Apigee\Edge\Api\Management\Entity\AppCredential;
-use Apigee\Edge\Api\Management\Entity\AppCredentialInterface;
-use Apigee\Edge\Structure\CredentialProduct;
 use Drupal\apigee_edge\Entity\AppInterface;
 use Drupal\apigee_edge\Entity\AppWarningsCheckerInterface;
 use Drupal\Component\Datetime\TimeInterface;
@@ -102,6 +99,7 @@ class AppListBuilder extends EdgeEntityListBuilder {
       $config_factory = \Drupal::service('config.factory');
     }
     if (!$app_warnings_checker) {
+      @trigger_error('Calling ' . __METHOD__ . ' without the $app_warnings_checker is deprecated in apigee_edge:8-x-1.18 and is required before apigee_edge:8.x-2.0. See https://github.com/apigee/apigee-edge-drupal/pull/507', E_USER_DEPRECATED);
       $app_warnings_checker = \Drupal::service('apigee_edge.entity.app_warnings_checker');
     }
 

--- a/tests/src/Kernel/Entity/ListBuilder/AppListBuilderTest.php
+++ b/tests/src/Kernel/Entity/ListBuilder/AppListBuilderTest.php
@@ -22,15 +22,18 @@ namespace Drupal\Tests\apigee_edge\Kernel\Entity\ListBuilder;
 
 use Apigee\Edge\Api\Management\Entity\App;
 use Apigee\Edge\Api\Management\Entity\AppCredentialInterface;
+use Drupal\apigee_edge\Entity\ApiProduct;
 use Drupal\apigee_edge\Entity\AppInterface;
 use Drupal\apigee_edge\Entity\Developer;
 use Drupal\apigee_edge\Entity\DeveloperApp;
 use Drupal\Component\Utility\Html;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\apigee_edge\Kernel\ApigeeEdgeKernelTestTrait;
+use Drupal\Tests\apigee_edge\Traits\CredsUtilsTrait;
 use Drupal\Tests\apigee_mock_api_client\Traits\ApigeeMockApiClientHelperTrait;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\user\Entity\User;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Tests the AppListBuilder.
@@ -40,7 +43,7 @@ use Drupal\user\Entity\User;
  */
 class AppListBuilderTest extends KernelTestBase {
 
-  use ApigeeMockApiClientHelperTrait, ApigeeEdgeKernelTestTrait, UserCreationTrait;
+  use ApigeeMockApiClientHelperTrait, ApigeeEdgeKernelTestTrait, UserCreationTrait, CredsUtilsTrait;
 
   /**
    * Indicates this test class is mock API client ready.
@@ -63,7 +66,7 @@ class AppListBuilderTest extends KernelTestBase {
     'apigee_mock_api_client',
     'key',
     'user',
-    'options'
+    'options',
   ];
 
   /**
@@ -263,60 +266,96 @@ class AppListBuilderTest extends KernelTestBase {
   public function testAppWarnings() {
     /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager */
     $entity_type_manager = $this->container->get('entity_type.manager');
-    $approved_credential = [
-      "consumerKey" => $this->randomMachineName(),
-      "consumerSecret" => $this->randomMachineName(),
-      "status" => AppCredentialInterface::STATUS_APPROVED,
-      'expiresAt' => ($this->container->get('datetime.time')->getRequestTime() + 24 * 60 * 60) * 1000,
-    ];
 
-    $revoked_credential = [
-      "consumerKey" => $this->randomMachineName(),
-      "consumerSecret" => $this->randomMachineName(),
-      "status" => AppCredentialInterface::STATUS_REVOKED,
-      'expiresAt' => ($this->container->get('datetime.time')->getRequestTime() + 24 * 60 * 60) * 1000,
-    ];
+    if ($this->integration_enabled) {
+      $this->apiProduct = ApiProduct::create([
+        'name' => $this->randomMachineName(),
+        'displayName' => $this->randomMachineName(),
+        'approvalType' => ApiProduct::APPROVAL_TYPE_AUTO,
+      ]);
+      $this->apiProduct->save();
 
-    $expired_credential = [
-      "consumerKey" => $this->randomMachineName(),
-      "consumerSecret" => $this->randomMachineName(),
-      "status" => AppCredentialInterface::STATUS_APPROVED,
-      'expiresAt' => ($this->container->get('datetime.time')->getRequestTime() - 24 * 60 * 60) * 1000,
-    ];
+      // Revoke old credential and create a new valid one.
+      $this->operationOnCredential($this->approvedAppWithOneRevokedCredential, 'revoke', 0);
+      $this->operationOnCredential($this->approvedAppWithOneRevokedCredential, 'generate');
 
-    $this->stack->queueMockResponse([
-      'get_developer_apps_with_credentials' => [
-        'apps' => [
-          $this->approvedAppWithApprovedCredential,
-          $this->approvedAppWithOneRevokedCredential,
-          $this->revokedAppWithRevokedCredential,
-          $this->approvedAppWithExpiredCredential,
-          $this->revokedAppWithExpiredCredential,
+      // Revoke old credential.
+      $this->operationOnCredential($this->approvedAppWithAllRevokedCredential, 'revoke', 0);
+
+      // Revoke old credential.
+      $this->operationOnCredential($this->revokedAppWithRevokedCredential, 'revoke', 0);
+      $this->operationOnCredential($this->revokedAppWithRevokedCredential, 'generate');
+
+      // Create a new cred that will expire in 5 seconds, delete old.
+      $this->operationOnCredential($this->approvedAppWithExpiredCredential, 'delete', 0);
+      $this->operationOnCredential($this->approvedAppWithExpiredCredential, 'generate', 0, 5 * 1000);
+
+      // Create a new cred that will expire in 5 seconds, delete old.
+      $this->operationOnCredential($this->revokedAppWithExpiredCredential, 'delete', 0);
+      $this->operationOnCredential($this->revokedAppWithExpiredCredential, 'generate', 0, 5 * 1000);
+
+      // Wait a bit and reset "request time" to make sure credentials
+      // are considered expired.
+      sleep(6);
+      $request = Request::create('/', 'GET');
+      $this->container->get('http_kernel')->handle($request);
+    }
+    else {
+      $approved_credential = [
+        "consumerKey" => $this->randomMachineName(),
+        "consumerSecret" => $this->randomMachineName(),
+        "status" => AppCredentialInterface::STATUS_APPROVED,
+        'expiresAt' => ($this->container->get('datetime.time')->getRequestTime() + 24 * 60 * 60) * 1000,
+      ];
+
+      $revoked_credential = [
+        "consumerKey" => $this->randomMachineName(),
+        "consumerSecret" => $this->randomMachineName(),
+        "status" => AppCredentialInterface::STATUS_REVOKED,
+        'expiresAt' => ($this->container->get('datetime.time')->getRequestTime() + 24 * 60 * 60) * 1000,
+      ];
+
+      $expired_credential = [
+        "consumerKey" => $this->randomMachineName(),
+        "consumerSecret" => $this->randomMachineName(),
+        "status" => AppCredentialInterface::STATUS_APPROVED,
+        'expiresAt' => ($this->container->get('datetime.time')->getRequestTime() - 24 * 60 * 60) * 1000,
+      ];
+
+      $this->stack->queueMockResponse([
+        'get_developer_apps_with_credentials' => [
+          'apps' => [
+            $this->approvedAppWithApprovedCredential,
+            $this->approvedAppWithOneRevokedCredential,
+            $this->revokedAppWithRevokedCredential,
+            $this->approvedAppWithExpiredCredential,
+            $this->revokedAppWithExpiredCredential,
+          ],
+          'credentials' => [
+            $this->approvedAppWithApprovedCredential->id() => [
+              $approved_credential,
+            ],
+            $this->approvedAppWithOneRevokedCredential->id() => [
+              $approved_credential,
+              $revoked_credential,
+            ],
+            $this->approvedAppWithAllRevokedCredential->id() => [
+              $revoked_credential,
+            ],
+            $this->revokedAppWithRevokedCredential->id() => [
+              $approved_credential,
+              $revoked_credential,
+            ],
+            $this->approvedAppWithExpiredCredential->id() => [
+              $expired_credential,
+            ],
+            $this->revokedAppWithExpiredCredential->id() => [
+              $expired_credential,
+            ],
+          ],
         ],
-        'credentials' => [
-          $this->approvedAppWithApprovedCredential->id() => [
-            $approved_credential,
-          ],
-          $this->approvedAppWithOneRevokedCredential->id() => [
-            $approved_credential,
-            $revoked_credential,
-          ],
-          $this->approvedAppWithAllRevokedCredential->id() => [
-            $revoked_credential,
-          ],
-          $this->revokedAppWithRevokedCredential->id() => [
-            $approved_credential,
-            $revoked_credential,
-          ],
-          $this->approvedAppWithExpiredCredential->id() => [
-            $expired_credential,
-          ],
-          $this->revokedAppWithExpiredCredential->id() => [
-            $expired_credential,
-          ],
-        ],
-      ],
-    ]);
+      ]);
+    }
 
     $build = $entity_type_manager->getListBuilder(static::ENTITY_TYPE)->render();
 

--- a/tests/src/Traits/CredsUtilsTrait.php
+++ b/tests/src/Traits/CredsUtilsTrait.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Copyright 2020 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\Tests\apigee_edge\Traits;
+
+use Drupal\apigee_edge\Entity\Controller\AppCredentialControllerInterface;
+use Drupal\apigee_edge\Entity\DeveloperAppInterface;
+
+/**
+ * A trait to common functions of Apigee Edge credential entity tests.
+ */
+trait CredsUtilsTrait {
+
+  /**
+   * API product to test.
+   *
+   * @var \Drupal\apigee_edge\Entity\ApiProductInterface
+   */
+  protected $apiProduct;
+
+  /**
+   * Returns the developer app credential controller.
+   *
+   * @param string $owner
+   *   The developer id (UUID), email address or team (company) name.
+   * @param string $app_name
+   *   The name of an app.
+   *
+   * @return \Drupal\apigee_edge\Entity\Controller\AppCredentialControllerInterface
+   *   The app credential controller.
+   */
+  protected function getAppCredentialController(string $owner, string $app_name): AppCredentialControllerInterface {
+    return \Drupal::service('apigee_edge.controller.developer_app_credential_factory')
+      ->developerAppCredentialController($owner, $app_name);
+  }
+
+  /**
+   * Perform an operation on the given credential (by index) of the app.
+   *
+   * @param \Drupal\apigee_edge\Entity\DeveloperAppInterface $app
+   *   The app.
+   * @param string $op
+   *   The operation to perform (revoke,  delete, generate).
+   * @param int $cred_index
+   *   The index of the credential (only applies to revoke/delete operations).
+   * @param int $expires_in
+   *   The milliseconds from now that the cred should expire (only applies for
+   *   generate operation). Defaults to "-1" (never).
+   */
+  protected function operationOnCredential(DeveloperAppInterface $app, $op = 'revoke', $cred_index = 0, $expires_in = -1) {
+    $controller = $this->getAppCredentialController($app->getAppOwner(), $app->getName());
+
+    if ($op == 'generate') {
+      $controller->generate([$this->apiProduct->id()], $app->getAttributes(), '', [], $expires_in);
+      return;
+    }
+
+    $key = $app
+      ->getCredentials()[$cred_index]
+      ->getConsumerKey();
+
+    if ($op == 'revoke') {
+      $controller->setStatus($key, AppCredentialControllerInterface::STATUS_REVOKE);
+    }
+    elseif ($op == 'delete') {
+      $controller->delete($key);
+    }
+  }
+
+}


### PR DESCRIPTION
Fixes #492 

This PR

1. Adds a warning for appe with all credentials revoked.
2. Moves the warning checks from the AppListBuilder into a separate service: `\Drupal\apigee_edge\Entity\AppWarningsChecker` so that it can be re-used (example in Apigee Kickstart).
3. Adds a *Warnings* extra field to app entities for showing warnings in entity view displays.