### PR TITLE
[#480] Add warnings to form and status page if using basic auth.

### DIFF
--- a/apigee_edge.install
+++ b/apigee_edge.install
@@ -84,15 +84,20 @@ function apigee_edge_requirements($phase) {
       }
 
       // Warning message in status report if using basic auth.
-      if ($key && $key->getKeyType() instanceof EdgeKeyTypeInterface &&
-        $key->getKeyType()->getAuthenticationType($key) === EdgeKeyTypeInterface::EDGE_AUTH_TYPE_BASIC) {
-        $requirements['apigee_edge_http_basic_auth'] = [
-          'title' => t('Apigee Edge'),
-          'description' => t('Apigee Edge HTTP basic authentication will be deprecated. Please choose another authentication method. Visit the <a href=":url">Apigee Edge general settings</a> page to get more information.', [
-            ':url' => Url::fromRoute('apigee_edge.settings', ['destination' => 'admin/reports/status'])->toString(),
-          ]),
-          'severity' => REQUIREMENT_WARNING,
-        ];
+      try {
+        if ($key && $key->getKeyType() instanceof EdgeKeyTypeInterface &&
+          $key->getKeyType()->getAuthenticationType($key) === EdgeKeyTypeInterface::EDGE_AUTH_TYPE_BASIC) {
+          $requirements['apigee_edge_http_basic_auth'] = [
+            'title' => t('Apigee Edge'),
+            'description' => t('Apigee Edge HTTP basic authentication will be deprecated. Please choose another authentication method. Visit the <a href=":url">Apigee Edge general settings</a> page to get more information.', [
+              ':url' => Url::fromRoute('apigee_edge.settings', ['destination' => 'admin/reports/status'])->toString(),
+            ]),
+            'severity' => REQUIREMENT_WARNING,
+          ];
+        }
+      }
+      catch (Exception $e) {
+        // Do nothing.
       }
     }
   }

--- a/apigee_edge.install
+++ b/apigee_edge.install
@@ -24,6 +24,7 @@
  */
 
 use Drupal\apigee_edge\OauthTokenFileStorage;
+use Drupal\apigee_edge\Plugin\EdgeKeyTypeInterface;
 use Drupal\Core\Installer\InstallerKernel;
 use Drupal\Core\Url;
 use Drupal\user\RoleInterface;
@@ -68,14 +69,28 @@ function apigee_edge_requirements($phase) {
         'severity' => REQUIREMENT_WARNING,
       ];
     }
-    // Warning message in status report if insecure Configuration Key provider is being used.
+
     $auth_config = \Drupal::config('apigee_edge.auth');
-    if ($key = $auth_config->get('active_key')) {
-      $key_repository = \Drupal::service('key.repository')->getKey($key);
-      if ($key_repository && $key_repository->getKeyProvider()->getPluginId() === "config") {
+    if ($key_id = $auth_config->get('active_key')) {
+
+      // Warning message if insecure Configuration Key provider is being used.
+      $key = \Drupal::service('key.repository')->getKey($key_id);
+      if ($key && $key->getKeyProvider()->getPluginId() === "config") {
         $requirements['apigee_edge_insecure_config_key_provider'] = [
           'title' => t('Apigee Edge'),
           'description' => t('Edge connection settings are stored in Drupal’s configuration system, which is not designed to store sensitive information. When installing Kickstart for uses other than local development, we highly recommend changing the Apigee Edge connection key provider to a more secure storage location. <a href="https://www.drupal.org/docs/8/modules/apigee-developer-portal-kickstart/apigee-kickstart-faqs#s-during-installation-a-warning-is-displayed-that-the-apigee-edge-connection-key-provider-is-not-considered-secure-what-should-i-do" target="_blank">Learn more.</a>'),
+          'severity' => REQUIREMENT_WARNING,
+        ];
+      }
+
+      // Warning message in status report if using basic auth.
+      if ($key && $key->getKeyType() instanceof EdgeKeyTypeInterface &&
+        $key->getKeyType()->getAuthenticationType($key) === EdgeKeyTypeInterface::EDGE_AUTH_TYPE_BASIC) {
+        $requirements['apigee_edge_http_basic_auth'] = [
+          'title' => t('Apigee Edge'),
+          'description' => t('Apigee Edge HTTP basic authentication will be deprecated. Please choose another authentication method. Visit the <a href=":url">Apigee Edge general settings</a> page to get more information.', [
+            ':url' => Url::fromRoute('apigee_edge.settings', ['destination' => 'admin/reports/status'])->toString(),
+          ]),
           'severity' => REQUIREMENT_WARNING,
         ];
       }

--- a/src/Plugin/KeyInput/ApigeeAuthKeyInput.php
+++ b/src/Plugin/KeyInput/ApigeeAuthKeyInput.php
@@ -45,6 +45,10 @@ class ApigeeAuthKeyInput extends KeyInputBase {
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
     $values = $this->getFormDefaultValues($form_state);
 
+    if (!empty($values['auth_type']) && $values['auth_type'] == EdgeKeyTypeInterface::EDGE_AUTH_TYPE_BASIC) {
+      $this->messenger()->addWarning($this->t('HTTP basic authentication will be deprecated. Please choose another authentication method.'));
+    }
+
     $state_for_public = [
       ':input[name="key_input_settings[instance_type]"]' => ['value' => EdgeKeyTypeInterface::INSTANCE_TYPE_PUBLIC],
     ];
@@ -76,9 +80,9 @@ class ApigeeAuthKeyInput extends KeyInputBase {
       '#required' => TRUE,
       '#options' => [
         EdgeKeyTypeInterface::EDGE_AUTH_TYPE_OAUTH => $this->t('OAuth'),
-        EdgeKeyTypeInterface::EDGE_AUTH_TYPE_BASIC => $this->t('HTTP basic'),
+        EdgeKeyTypeInterface::EDGE_AUTH_TYPE_BASIC => $this->t('HTTP basic (deprecated)'),
       ],
-      '#default_value' => $values['auth_type'] ?? EdgeKeyTypeInterface::EDGE_AUTH_TYPE_BASIC,
+      '#default_value' => $values['auth_type'] ?? EdgeKeyTypeInterface::EDGE_AUTH_TYPE_OAUTH,
       '#states' => [
         'visible' => [$state_for_public, $state_for_private],
         'required' => [$state_for_public, $state_for_private],

--- a/tests/src/FunctionalJavascript/Form/AuthenticationFormJsTest.php
+++ b/tests/src/FunctionalJavascript/Form/AuthenticationFormJsTest.php
@@ -286,11 +286,14 @@ class AuthenticationFormJsTest extends ApigeeEdgeFunctionalJavascriptTestBase {
     $visitFormAsAdmin();
 
     // Make sure the default fields are visible and empty.
-    $web_assert->fieldValueEquals('Authentication type', 'basic');
+    $web_assert->fieldValueEquals('Authentication type', 'oauth');
     $web_assert->fieldValueEquals('Username', '');
     $web_assert->fieldValueEquals('Password', '');
     $web_assert->fieldValueEquals('Organization', '');
     $web_assert->fieldValueEquals('Apigee Edge endpoint', '');
+
+    // Select basic auth.
+    $page->selectFieldOption('key_input_settings[auth_type]', EdgeKeyTypeInterface::EDGE_AUTH_TYPE_BASIC);
 
     // Make sure the oauth fields are hidden.
     $this->assertFalse($this->cssSelect('input[name="key_input_settings[authorization_server]"]')[0]->isVisible());
@@ -348,6 +351,7 @@ class AuthenticationFormJsTest extends ApigeeEdgeFunctionalJavascriptTestBase {
     $page->fillField('Username', $this->username);
     $page->fillField('Password', $this->password);
     $page->fillField('Organization', $this->organization);
+    $page->selectFieldOption('key_input_settings[auth_type]', EdgeKeyTypeInterface::EDGE_AUTH_TYPE_BASIC);
 
     // Test invalid password.
     $random_pass = $this->randomString();


### PR DESCRIPTION
Closes #480 . As a note, we discussed that we could not safely migrate everyone to using oauth because they might be using a custom authorization server, so for now we will only show warning messages.
 
This PR:
- Adds a warning message to the connection settings form if using basic auth.
- Marks the "basic auth" option on the dropdown as deprecated.
- Adds a warning message to Drupal's status report page if using basic auth.

Screenshots:

Connection settings form:
![image](https://user-images.githubusercontent.com/4062676/97487407-13628580-191a-11eb-8c04-9568ee094ce8.png)

Status report page:
![image](https://user-images.githubusercontent.com/4062676/97487347-fded5b80-1919-11eb-9b99-c1f46c5d0e4d.png)



