### PR TITLE
[#508] Disable team actions if team is inactive

### DIFF
--- a/modules/apigee_edge_teams/apigee_edge_teams.libraries.yml
+++ b/modules/apigee_edge_teams/apigee_edge_teams.libraries.yml
@@ -16,3 +16,9 @@ switcher:
   css:
     theme:
       css/apigee_edge_teams.switcher.css: {}
+
+disabled_action:
+  version: VERSION
+  css:
+    theme:
+      css/apigee_edge_teams.disabled_action.css: {}

--- a/modules/apigee_edge_teams/apigee_edge_teams.module
+++ b/modules/apigee_edge_teams/apigee_edge_teams.module
@@ -20,8 +20,10 @@
  */
 
 use Drupal\apigee_edge\Exception\DeveloperDoesNotExistException;
+use Drupal\apigee_edge_teams\Entity\TeamInterface;
 use Drupal\apigee_edge_teams\Entity\TeamInvitationInterface;
 use Drupal\apigee_edge_teams\Entity\TeamRoleInterface;
+use Drupal\apigee_edge_teams\EventSubscriber\TeamInactiveStatusSubscriber;
 use Drupal\Component\Render\PlainTextOutput;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Breadcrumb\Breadcrumb;
@@ -168,6 +170,53 @@ function apigee_edge_teams_system_breadcrumb_alter(Breadcrumb &$breadcrumb, Rout
     /** @var \Drupal\apigee_edge_teams\Entity\TeamInterface $team */
     $team = $route_match->getParameter('team');
     $breadcrumb->addLink(Link::createFromRoute($team_app_entity_def->getPluralLabel(), 'entity.team_app.collection_by_team', ['team' => $team->id()]));
+  }
+}
+
+/**
+ * Implements hook_preprocess().
+ */
+function apigee_edge_teams_preprocess(&$variables, $hook) {
+  if (!in_array($hook, ['menu_local_action', 'menu_local_task'])) {
+    return;
+  }
+
+  /** @var \Drupal\Core\Url $url */
+  $url = $variables['link']['#url'];
+  if (!in_array($url->getRouteName(), TeamInactiveStatusSubscriber::getDisabledRoutes())) {
+    return;
+  }
+
+  // If a team is inactive, for the local tasks and local actions, set the url
+  // to <none>.
+  $variables['link']['#url'] = Url::fromRoute('<none>', [], [
+    'absolute' => TRUE,
+  ]);
+    // Add a title attribute.
+  $variables['link']['#options']['attributes']['title'] = t('This @team is inactive.', [
+    '@team' => \Drupal::entityTypeManager()->getDefinition('team')->getSingularLabel(),
+  ]);
+  // Add a disabled class.
+  $variables['link']['#options']['attributes']['class'][] = 'team-disabled-action';
+  $variables['#attached']['library'][] = 'apigee_edge_teams/disabled_action';
+}
+
+/**
+ * Implements hook_entity_operation_alter().
+ */
+function apigee_edge_teams_entity_operation_alter(array &$operations, EntityInterface $entity) {
+  foreach ($operations as $key => $operation) {
+    if (!in_array($operation['url']->getRouteName(), TeamInactiveStatusSubscriber::getDisabledRoutes())) {
+      continue;
+    }
+
+    $team = \Drupal::routeMatch()->getParameter('team');
+    if (!$team || $team->getStatus() !== TeamInterface::STATUS_INACTIVE) {
+      continue;
+    }
+
+    // Remove the entity operation if the team is inactive.
+    unset($operations[$key]);
   }
 }
 

--- a/modules/apigee_edge_teams/apigee_edge_teams.module
+++ b/modules/apigee_edge_teams/apigee_edge_teams.module
@@ -187,6 +187,11 @@ function apigee_edge_teams_preprocess(&$variables, $hook) {
     return;
   }
 
+  $team = \Drupal::routeMatch()->getParameter('team');
+  if (!$team || $team->getStatus() !== TeamInterface::STATUS_INACTIVE) {
+    return;
+  }
+
   // If a team is inactive, for the local tasks and local actions, set the url
   // to <none>.
   $variables['link']['#url'] = Url::fromRoute('<none>', [], [

--- a/modules/apigee_edge_teams/apigee_edge_teams.services.yml
+++ b/modules/apigee_edge_teams/apigee_edge_teams.services.yml
@@ -93,6 +93,16 @@ services:
     class: Drupal\apigee_edge_teams\TeamInvitationNotifierEmail
     arguments: ['@plugin.manager.mail', '@language_manager']
 
+  apigee_edge_teams.team_inactive_status_subscriber:
+    class: Drupal\apigee_edge_teams\EventSubscriber\TeamInactiveStatusSubscriber
+    arguments:
+      - '@class_resolver'
+      - '@current_route_match'
+      - '%main_content_renderers%'
+      - '@current_user'
+    tags:
+      - { name: event_subscriber }
+
   route.subscriber.apigee_edge_teams.team_app_by_name:
     class: Drupal\apigee_edge_teams\Routing\TeamAppByNameRouteAlterSubscriber
     tags:

--- a/modules/apigee_edge_teams/css/apigee_edge_teams.disabled_action.css
+++ b/modules/apigee_edge_teams/css/apigee_edge_teams.disabled_action.css
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+.team-disabled-action {
+  cursor: not-allowed !important;
+  opacity: 0.5;
+}

--- a/modules/apigee_edge_teams/src/Controller/TeamMembersList.php
+++ b/modules/apigee_edge_teams/src/Controller/TeamMembersList.php
@@ -91,7 +91,8 @@ class TeamMembersList extends ControllerBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('apigee_edge_teams.team_membership_manager'),
-      $container->get('entity_type.manager')
+      $container->get('entity_type.manager'),
+      $container->get('module_handler')
     );
   }
 

--- a/modules/apigee_edge_teams/src/Controller/TeamMembersList.php
+++ b/modules/apigee_edge_teams/src/Controller/TeamMembersList.php
@@ -71,7 +71,7 @@ class TeamMembersList extends ControllerBase {
    */
   public function __construct(TeamMembershipManagerInterface $team_membership_manager, EntityTypeManagerInterface $entity_type_manager, ModuleHandlerInterface $module_handler = NULL) {
     if (!$module_handler) {
-      @trigger_error('Calling ' . __METHOD__ . ' without the $module_handler is deprecated in apigee_edge:8-x-1.19 and is required before apigee_edge:8.x-2.0.', E_USER_DEPRECATED);
+      @trigger_error('Calling ' . __METHOD__ . ' without the $module_handler is deprecated in apigee_edge:8-x-1.19 and is required before apigee_edge:8.x-2.0. See https://github.com/apigee/apigee-edge-drupal/pull/518.', E_USER_DEPRECATED);
       $module_handler = \Drupal::moduleHandler();
     }
 

--- a/modules/apigee_edge_teams/src/Controller/TeamMembersList.php
+++ b/modules/apigee_edge_teams/src/Controller/TeamMembersList.php
@@ -27,6 +27,7 @@ use Drupal\apigee_edge_teams\TeamMembershipManagerInterface;
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Url;
 use Drupal\user\UserInterface;
 use Drupal\views\Views;
@@ -52,20 +53,36 @@ class TeamMembersList extends ControllerBase {
   protected $defaultRoles = [];
 
   /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface|null
+   */
+  protected $moduleHandler;
+
+  /**
    * TeamMembersList constructor.
    *
    * @param \Drupal\apigee_edge_teams\TeamMembershipManagerInterface $team_membership_manager
    *   The team membership manager service.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface|null $module_handler
+   *   The module handler.
    */
-  public function __construct(TeamMembershipManagerInterface $team_membership_manager, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(TeamMembershipManagerInterface $team_membership_manager, EntityTypeManagerInterface $entity_type_manager, ModuleHandlerInterface $module_handler = NULL) {
+    if (!$module_handler) {
+      @trigger_error('Calling ' . __METHOD__ . ' without the $module_handler is deprecated in apigee_edge:8-x-1.19 and is required before apigee_edge:8.x-2.0.', E_USER_DEPRECATED);
+      $module_handler = \Drupal::moduleHandler();
+    }
+
     $this->teamMembershipManager = $team_membership_manager;
     $this->entityTypeManager = $entity_type_manager;
 
     if ($role = $this->entityTypeManager()->getStorage('team_role')->load(TeamRoleInterface::TEAM_MEMBER_ROLE)) {
       $this->defaultRoles = [$role->id() => $role->label()];
     }
+
+    $this->moduleHandler = $module_handler;
   }
 
   /**
@@ -252,6 +269,9 @@ class TeamMembersList extends ControllerBase {
         'url' => $url,
       ];
     }
+
+    // Allow modules to alter operations.
+    $this->moduleHandler->alter('entity_operation', $operations, $team);
 
     return $operations;
   }

--- a/modules/apigee_edge_teams/src/Entity/ListBuilder/TeamInvitationListBuilder.php
+++ b/modules/apigee_edge_teams/src/Entity/ListBuilder/TeamInvitationListBuilder.php
@@ -31,9 +31,9 @@ class TeamInvitationListBuilder extends EntityListBuilder {
   /**
    * {@inheritdoc}
    */
-  public function getOperations(EntityInterface $entity) {
+  public function getDefaultOperations(EntityInterface $entity) {
     /** @var \Drupal\apigee_edge_teams\Entity\TeamInvitationInterface $entity */
-    $operations = [];
+    $operations = parent::getDefaultOperations($entity);
 
     if ($entity->isPending() && $entity->access('accept') && $entity->hasLinkTemplate('accept-form')) {
       $operations['accept'] = [

--- a/modules/apigee_edge_teams/src/EventSubscriber/TeamInactiveStatusSubscriber.php
+++ b/modules/apigee_edge_teams/src/EventSubscriber/TeamInactiveStatusSubscriber.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * Copyright 2020 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_edge_teams\EventSubscriber;
+
+use Drupal\apigee_edge_teams\Entity\TeamInterface;
+use Drupal\Core\DependencyInjection\ClassResolverInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Displays an error message on team pages if team is inactive.
+ */
+class TeamInactiveStatusSubscriber implements EventSubscriberInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The class resolver service.
+   *
+   * @var \Drupal\Core\Controller\ControllerResolverInterface
+   */
+  protected $classResolver;
+
+  /**
+   * The route match service.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * The available main content renderer services, keyed per format.
+   *
+   * @var array
+   */
+  protected $mainContentRenderers;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
+   * TeamInactiveStatusSubscriber constructor.
+   *
+   * @param \Drupal\Core\DependencyInjection\ClassResolverInterface $class_resolver
+   *   The class resolver service.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The route match service.
+   * @param array $main_content_renderers
+   *   The available main content renderer service IDs.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   */
+  public function __construct(ClassResolverInterface $class_resolver, RouteMatchInterface $route_match, array $main_content_renderers, AccountInterface $current_user) {
+    $this->classResolver = $class_resolver;
+    $this->routeMatch = $route_match;
+    $this->mainContentRenderers = $main_content_renderers;
+    $this->currentUser = $current_user;
+  }
+
+  /**
+   * Display an error message on inactive team routes.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+   *   The event to process.
+   */
+  public function onRespond(FilterResponseEvent $event) {
+    if ($this->currentUser->isAnonymous() || !in_array($this->routeMatch->getRouteName(), $this->getDisabledRoutes())) {
+      return;
+    }
+
+    /** @var \Drupal\apigee_edge_teams\Entity\TeamInterface $team */
+    $team = $this->routeMatch->getParameter('team');
+    if (!$team || $team->getStatus() !== TeamInterface::STATUS_INACTIVE) {
+      return;
+    }
+
+    $content = [
+      'content' => [
+        '#theme' => 'status_messages',
+        '#message_list' => [
+          'error' => [
+            $this->t('The %team_name @team is inactive. This operation is now allowed.', [
+              '%team_name' => $team->label(),
+              '@team' => $team->getEntityType()->getSingularLabel(),
+            ]),
+          ],
+        ],
+      ],
+    ];
+
+    $renderer = $this->classResolver->getInstanceFromDefinition($this->mainContentRenderers['html']);
+    /* @var \Symfony\Component\HttpFoundation\Response $response */
+    $response = $renderer->renderResponse($content, $event->getRequest(), $this->routeMatch);
+    $response->setStatusCode(Response::HTTP_FORBIDDEN);
+
+    $event->setResponse($response);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[KernelEvents::RESPONSE][] = ['onRespond', 5];
+    return $events;
+  }
+
+  /**
+   * Returns an array of route names for which the warning message should be displayed.
+   *
+   * @return array
+   *   An array of route names.
+   */
+  public static function getDisabledRoutes(): array {
+    return [
+      // Team.
+      'entity.team.edit_form',
+      'entity.team.delete_form',
+
+      // Team app.
+      'entity.team_app.add_form_for_team',
+      'entity.team_app.edit_form',
+      'entity.team_app.delete_form',
+      'entity.team_app.analytics',
+
+      // Team member.
+      'entity.team.add_members',
+      'entity.team.member.edit',
+      'entity.team.member.remove',
+
+      // Team invitation.
+      'entity.team_invitation.resend_form',
+      'entity.team_invitation.delete_form',
+    ];
+  }
+
+}


### PR DESCRIPTION
Fixes #508 

Since Drupal does not render links with `\Drupal\Core\Access\AccessResultForbidden`, we can't alter access here.

This PR implements an `event_subscriber` to alter the response when a team is inactive. An error message is displayed.

![](https://user-images.githubusercontent.com/124599/98710324-ecd22f00-239c-11eb-921c-970cb9887539.jpg)

As for the UI part, we are replacing local actions and tasks with url `<none>` and showing a disabled state using CSS. 

![](https://user-images.githubusercontent.com/124599/98710348-f360a680-239c-11eb-8881-9f2ae89ef9aa.jpg)
