### PR TITLE
Move teams related update function to apigee_edge_teams

### DIFF
--- a/apigee_edge.install
+++ b/apigee_edge.install
@@ -28,7 +28,6 @@ use Drupal\apigee_edge\Plugin\EdgeKeyTypeInterface;
 use Drupal\Core\Installer\InstallerKernel;
 use Drupal\Core\Url;
 use Drupal\user\RoleInterface;
-use Drupal\views\Views;
 
 /**
  * Implements hook_requirements().
@@ -321,20 +320,7 @@ function apigee_edge_update_8104() {
 }
 
 /**
- * Remove the "Manage team members and invitations" access for the Team invitations view.
+ * Deprecated update function.
  */
 function apigee_edge_update_8105() {
-  /** @var \Drupal\views\ViewExecutable $view */
-  $view = Views::getView('team_invitations');
-  $view->setDisplay('team');
-  $access = $view->getDisplay()->getOption('access');
-  if (empty($access['type']) || $access['type'] !== "team_permission") {
-    return;
-  }
-
-  $view->getDisplay()->setOption('access', [
-    'type' => 'none',
-    'options' => [],
-  ]);
-  $view->save();
 }

--- a/modules/apigee_edge_teams/apigee_edge_teams.install
+++ b/modules/apigee_edge_teams/apigee_edge_teams.install
@@ -21,6 +21,7 @@
 use Apigee\Edge\Utility\OrganizationFeatures;
 use Drupal\Core\Config\FileStorage;
 use Drupal\user\RoleInterface;
+use Drupal\views\Views;
 
 /**
  * @file
@@ -137,5 +138,24 @@ function apigee_edge_teams_update_8703() {
       'decline own team invitation',
     ];
     user_role_grant_permissions(RoleInterface::AUTHENTICATED_ID, $authenticated_user_permissions);
+  }
+}
+
+/**
+ * Remove the "Manage team members and invitations" access for the Team invitations view.
+ */
+function apigee_edge_teams_update_8704() {
+  if ($view = Views::getView('team_invitations')) {
+    $view->setDisplay('team');
+    $access = $view->getDisplay()->getOption('access');
+    if (empty($access['type']) || $access['type'] !== "team_permission") {
+      return;
+    }
+
+    $view->getDisplay()->setOption('access', [
+      'type' => 'none',
+      'options' => [],
+    ]);
+    $view->save();
   }
 }


### PR DESCRIPTION
The `apigee_edge` `function apigee_edge_update_8105()` update function fails if the `apigee_edge_teams` is not enabled. This PR moves that update function to the `apigee_edge_teams` module.