### PR TITLE
[#516-517] Fix team invitations for multiple and deleted teams

### DIFF
--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -470,9 +470,9 @@ class RoboFile extends \Robo\Tasks
         break;
 
       case '8':
-        $config->require->{"drupal/core-composer-scaffold"} = '~8';
-        $config->require->{"drupal/core-recommended"} = '~8';
-        $config->require->{"drupal/core-dev"} = '~8';
+        $config->require->{"drupal/core-composer-scaffold"} = '^8.9@stable';
+        $config->require->{"drupal/core-recommended"} = '^8.9@stable';
+        $config->require->{"drupal/core-dev"} = '^8.9';
 
         // Add rules for testing apigee_edge_actions (only for D8).
         $config->require->{"drupal/rules"} = "3.0.0-alpha6";

--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -47,6 +47,7 @@ class RoboFile extends \Robo\Tasks
     $config = json_decode(file_get_contents('composer.json'));
     $config->extra->{"enable-patching"} = 'true';
     $config->extra->{"patches"} = new \stdClass();
+    unset($config->require->{"wikimedia/composer-merge-plugin"});
     $config->extra->{"drupal-scaffold"} = new \stdClass();
     $config->extra->{"drupal-scaffold"}->{"locations"} = (object) [
       'web-root' => '.',
@@ -111,6 +112,38 @@ class RoboFile extends \Robo\Tasks
       $base = isset($config->extra->{"patches"}) ?  (array)$config->extra->{"patches"} : [];
       $config->extra->{"patches"} = (object)array_merge($base,
         (array)$this->getPatches($module));
+    }
+
+    file_put_contents('composer.json', json_encode($config));
+  }
+
+  /**
+   * Adds another composer.json requires and requires-dev to this project.
+   *
+   * @param string $composerFilePath
+   *   Path to the composer.json file to merge.
+   */
+  public function addDependenciesFrom(string $composerFilePath)
+  {
+    $config = json_decode(file_get_contents('composer.json'));
+    $additional = json_decode(file_get_contents($composerFilePath));
+
+    if (!empty($additional->require)) {
+      foreach ($additional->require as $key => $value) {
+        if (!isset($config->require->{$key})) {
+          $config->require->{$key} = $value;
+        }
+      }
+    }
+    if (!empty($additional->{"require-dev"})) {
+      foreach ($additional->{"require-dev"} as $key => $value) {
+        if (!isset($config->{"require-dev"}->{$key})) {
+          if (!isset($config->{"require-dev"})) {
+            $config->{"require-dev"} = new \stdClass();
+          }
+          $config->{"require-dev"}->{$key} = $value;
+        }
+      }
     }
 
     file_put_contents('composer.json', json_encode($config));
@@ -429,9 +462,10 @@ class RoboFile extends \Robo\Tasks
 
     switch ($drupalCoreVersion) {
       case '9':
-        $config->require->{"drupal/core-composer-scaffold"} = '^9';
-        $config->require->{"drupal/core-recommended"} = '^9';
-        $config->require->{"drupal/core-dev"} = '^9';
+        $config->require->{"drupal/core-composer-scaffold"} = '^9.1@stable';
+        $config->require->{"drupal/core-recommended"} = '^9.1@stable';
+        $config->require->{"drupal/core-dev"} = '^9.1';
+        $config->require->{"phpspec/prophecy-phpunit"} = '^2';
 
         break;
 

--- a/.circleci/update-dependencies.sh
+++ b/.circleci/update-dependencies.sh
@@ -5,6 +5,7 @@ cp modules/apigee_edge/.circleci/RoboFile.php ./
 
 robo setup:skeleton
 robo add:modules $1
+robo add:dependencies-from modules/$1/composer.json
 robo drupal:version $2
 robo configure:module-dependencies
 robo update:dependencies

--- a/modules/apigee_edge_teams/apigee_edge_teams.install
+++ b/modules/apigee_edge_teams/apigee_edge_teams.install
@@ -159,3 +159,23 @@ function apigee_edge_teams_update_8704() {
     $view->save();
   }
 }
+
+/**
+ * Set disable_sql_rewrite to false for Team invitations view.
+ */
+function apigee_edge_teams_update_8705() {
+  /** @var \Drupal\views\ViewExecutable $view */
+  if ($view = Views::getView('team_invitations')) {
+    $view->setDisplay('user');
+    $query = $view->getDisplay()->getOption('query');
+    if (empty($query['options']['disable_sql_rewrite']) || $query['options']['disable_sql_rewrite'] === FALSE) {
+      return;
+    }
+
+    $query['options']['disable_sql_rewrite'] = FALSE;
+    $view->getDisplay()->setOption('query', $query);
+    $view->save();
+  }
+}
+
+

--- a/modules/apigee_edge_teams/apigee_edge_teams.module
+++ b/modules/apigee_edge_teams/apigee_edge_teams.module
@@ -153,6 +153,18 @@ function apigee_edge_teams_developer_delete(EntityInterface $entity) {
 }
 
 /**
+ * Implements hook_ENTITY_TYPE_delete().
+ */
+function apigee_edge_teams_team_delete(EntityInterface $entity) {
+  // Delete all invitations from this team.
+  /** @var \Drupal\apigee_edge_teams\Entity\Storage\TeamStorageInterface $storage */
+  $storage = \Drupal::entityTypeManager()->getStorage('team_invitation');
+  if ($invitations = $storage->loadByProperties(['team' => $entity->id()])) {
+    $storage->delete($invitations);
+  }
+}
+
+/**
  * Implements hook_system_breadcrumb_alter().
  */
 function apigee_edge_teams_system_breadcrumb_alter(Breadcrumb &$breadcrumb, RouteMatchInterface $route_match, array $context) {

--- a/modules/apigee_edge_teams/apigee_edge_teams.services.yml
+++ b/modules/apigee_edge_teams/apigee_edge_teams.services.yml
@@ -103,6 +103,12 @@ services:
     tags:
       - { name: event_subscriber }
 
+  apigee_edge_teams.team_invitation_query_access_subscriber:
+    class: Drupal\apigee_edge_teams\EventSubscriber\TeamInvitationQueryAccessSubscriber
+    arguments: ['@entity_type.manager']
+    tags:
+      - { name: event_subscriber }
+
   route.subscriber.apigee_edge_teams.team_app_by_name:
     class: Drupal\apigee_edge_teams\Routing\TeamAppByNameRouteAlterSubscriber
     tags:

--- a/modules/apigee_edge_teams/config/optional/views.view.team_invitations.yml
+++ b/modules/apigee_edge_teams/config/optional/views.view.team_invitations.yml
@@ -1150,7 +1150,7 @@ display:
       query:
         type: views_query
         options:
-          disable_sql_rewrite: true
+          disable_sql_rewrite: false
           distinct: false
           replica: false
           query_comment: ''

--- a/modules/apigee_edge_teams/src/Entity/TeamInvitation.php
+++ b/modules/apigee_edge_teams/src/Entity/TeamInvitation.php
@@ -289,4 +289,14 @@ class TeamInvitation extends ContentEntityBase implements TeamInvitationInterfac
     }
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheTags() {
+    if ($this->getTeam()) {
+      $this->cacheTags = array_merge($this->cacheTags, $this->getTeam()->getCacheTags());
+    }
+    return parent::getCacheTags();
+  }
+
 }

--- a/modules/apigee_edge_teams/src/Entity/TeamInvitationAccessControlHandler.php
+++ b/modules/apigee_edge_teams/src/Entity/TeamInvitationAccessControlHandler.php
@@ -71,6 +71,12 @@ final class TeamInvitationAccessControlHandler extends EntityAccessControlHandle
     /** @var \Drupal\apigee_edge_teams\Entity\TeamInvitation $entity */
     $account = $this->prepareUser($account);
 
+    // Check if team exists.
+    if (!$entity->getTeam()) {
+      return AccessResult::forbidden('Team does not exist.')
+        ->addCacheableDependency($entity);
+    }
+
     // Access is allowed if the user can accept invitation and the invitation
     // is pending.
     if ($entity->isPending() && $operation === 'accept') {

--- a/modules/apigee_edge_teams/src/EventSubscriber/TeamInvitationQueryAccessSubscriber.php
+++ b/modules/apigee_edge_teams/src/EventSubscriber/TeamInvitationQueryAccessSubscriber.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Copyright 2020 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_edge_teams\EventSubscriber;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\entity\QueryAccess\QueryAccessEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Subscribes to query access events for team_invitation.
+ */
+class TeamInvitationQueryAccessSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * TeamInvitationQueryAccessSubscriber constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      'entity.query_access.team_invitation' => 'onQueryAccess',
+    ];
+  }
+
+  /**
+   * Modifies the access conditions for team_invitation.
+   *
+   * @param \Drupal\entity\QueryAccess\QueryAccessEvent $event
+   *   The event.
+   */
+  public function onQueryAccess(QueryAccessEvent $event) {
+    // Add a condition to check for a valid team.
+    // We query team from storage instead of check for a null team field because
+    // the team might have been deleted on the remote server.
+    $team_ids = array_keys($this->entityTypeManager->getStorage('team')->loadMultiple());
+    $event->getConditions()->addCondition('team', $team_ids);
+  }
+
+}

--- a/modules/apigee_edge_teams/src/Form/AddTeamMembersForm.php
+++ b/modules/apigee_edge_teams/src/Form/AddTeamMembersForm.php
@@ -194,7 +194,7 @@ class AddTeamMembersForm extends TeamMembersFormBase {
     $invites = array_diff($emails, $members);
     $has_invitation = [];
     foreach ($invites as $invite) {
-      $pending_invitations = array_filter($this->teamInvitationStorage->loadByRecipient($invite), function (TeamInvitationInterface $team_invitation) {
+      $pending_invitations = array_filter($this->teamInvitationStorage->loadByRecipient($invite, $this->team->id()), function (TeamInvitationInterface $team_invitation) {
         return $team_invitation->isPending();
       });
 

--- a/modules/apigee_edge_teams/tests/src/Functional/TeamInvitationsTest.php
+++ b/modules/apigee_edge_teams/tests/src/Functional/TeamInvitationsTest.php
@@ -1,0 +1,214 @@
+<?php
+
+/**
+ * Copyright 2020 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\Tests\apigee_edge_teams\Functional;
+
+use Drupal\apigee_edge_teams\Entity\TeamRoleInterface;
+use Drupal\Core\Url;
+use Drupal\views\Views;
+
+/**
+ * Team invitation test.
+ *
+ * @group apigee_edge
+ * @group apigee_edge_teams
+ */
+class TeamInvitationsTest extends ApigeeEdgeTeamsFunctionalTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'user',
+    'options',
+    'datetime',
+    'views',
+    'apigee_edge_teams',
+  ];
+
+  /**
+   * The team entity storage.
+   *
+   * @var \Drupal\apigee_edge_teams\Entity\Storage\TeamStorageInterface
+   */
+  protected $teamStorage;
+
+  /**
+   * Admin user.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $accountAdmin;
+
+  /**
+   * Authenticated user.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $accountUser;
+
+  /**
+   * Team entity to test.
+   *
+   * @var \Drupal\apigee_edge_teams\Entity\TeamInterface
+   */
+  protected $teamA;
+
+  /**
+   * Team entity to test.
+   *
+   * @var \Drupal\apigee_edge_teams\Entity\TeamInterface
+   */
+  protected $teamB;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->teamStorage = $this->container->get('entity_type.manager')->getStorage('team');
+
+    $this->teamA = $this->teamStorage->create([
+      'name' => mb_strtolower($this->getRandomGenerator()->name()),
+    ]);
+    $this->teamA->save();
+
+    $this->teamB = $this->teamStorage->create([
+      'name' => mb_strtolower($this->getRandomGenerator()->name()),
+    ]);
+    $this->teamB->save();
+
+    $this->accountAdmin = $this->createAccount(['administer team']);
+    $this->accountUser = $this->createAccount([
+      'accept own team invitation',
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown() {
+    $teams = [
+      $this->teamA,
+      $this->teamB,
+    ];
+    foreach ($teams as $team) {
+      if ($team !== NULL) {
+        try {
+          $team->delete();
+        }
+        catch (\Exception $exception) {
+          $this->logException($exception);
+        }
+      }
+    }
+
+    $accounts = [
+      $this->accountAdmin,
+      $this->accountUser,
+    ];
+    foreach ($accounts as $account) {
+      if ($account !== NULL) {
+        try {
+          $account->delete();
+        }
+        catch (\Exception $exception) {
+          $this->logException($exception);
+        }
+      }
+    }
+
+    parent::tearDown();
+  }
+
+  /**
+   * Tests that an email can be invited to one or more teams.
+   */
+  public function testMultipleInvitations() {
+    $this->drupalLogin($this->accountAdmin);
+
+    $teams = [
+      $this->teamA,
+      $this->teamB,
+    ];
+
+    foreach ($teams as $team) {
+      $this->drupalGet(Url::fromRoute('entity.team.add_members', [
+        'team' => $team->id(),
+      ]));
+      $this->assertSession()->pageTextContains('Invite members');
+
+      $this->submitForm([
+        'developers' => $this->accountUser->getEmail(),
+      ], 'Invite members');
+
+      $successMessage = t('The following developer has been invited to the @team @team_label: @developer.', [
+        '@developer' => $this->accountUser->getEmail(),
+        '@team' => $team->label(),
+        '@team_label' => mb_strtolower($team->getEntityType()->getSingularLabel()),
+      ]);
+      $this->assertSession()->pageTextContains($successMessage);
+    }
+  }
+
+  /**
+   * Tests that a user can see their list of invitations.
+   */
+  public function testInvitationsList() {
+    // Ensure "team_invitations" views page is installed.
+    $this->assertNotNull(Views::getView('team_invitations'));
+
+    /** @var \Drupal\apigee_edge_teams\Entity\Storage\TeamInvitationStorageInterface $teamInvitationStorage */
+    $teamInvitationStorage = $this->container->get('entity_type.manager')->getStorage('team_invitation');
+    $selected_roles = [TeamRoleInterface::TEAM_MEMBER_ROLE => TeamRoleInterface::TEAM_MEMBER_ROLE];
+    $teams = [
+      $this->teamA,
+      $this->teamB,
+    ];
+
+    // Invite user to both teams.
+    foreach ($teams as $team) {
+      $teamInvitationStorage->create([
+        'team' => ['target_id' => $team->id()],
+        'team_roles' => array_values(array_map(function (string $role) {
+          return ['target_id' => $role];
+        }, $selected_roles)),
+        'recipient' => $this->accountUser->getEmail(),
+      ])->save();
+    }
+
+    // Check that user can see both invitations.
+    $this->drupalLogin($this->accountUser);
+    $invitationsUrl = Url::fromRoute('view.team_invitations.user', [
+      'user' => $this->accountUser->id(),
+    ]);
+    $this->drupalGet($invitationsUrl);
+    foreach ($teams as $team) {
+      $this->assertSession()->pageTextContains('Invitation to join ' . $team->label());
+    }
+
+    // Delete a team and ensure related team invitation was deleted too.
+    $this->teamA->delete();
+    $this->drupalGet($invitationsUrl);
+    $this->assertSession()->pageTextNotContains('Invitation to join ' . $this->teamA->label());
+    $this->assertSession()->pageTextContains('Invitation to join ' . $this->teamB->label());
+  }
+
+}

--- a/modules/apigee_edge_teams/tests/src/Functional/TeamInvitationsTest.php
+++ b/modules/apigee_edge_teams/tests/src/Functional/TeamInvitationsTest.php
@@ -152,15 +152,24 @@ class TeamInvitationsTest extends ApigeeEdgeTeamsFunctionalTestBase {
       $this->teamA,
       $this->teamB,
     ];
+    $companies = [
+      $this->teamA->decorated(),
+      $this->teamB->decorated(),
+    ];
 
+    $inCache = FALSE;
     foreach ($teams as $team) {
-      $this->queueCompanyResponse($team->decorated());
+      if (!$inCache) {
+        $this->queueCompanyResponse($team->decorated());
+      }
       $this->drupalGet(Url::fromRoute('entity.team.add_members', [
         'team' => $team->id(),
       ]));
       $this->assertSession()->pageTextContains('Invite members');
 
       $this->queueDevsInCompanyResponse([]);
+      $this->queueCompaniesResponse($companies);
+      $this->queueCompaniesResponse($companies);
       $this->submitForm([
         'developers' => $this->accountUser->getEmail(),
       ], 'Invite members');
@@ -171,6 +180,7 @@ class TeamInvitationsTest extends ApigeeEdgeTeamsFunctionalTestBase {
         '@team_label' => mb_strtolower($team->getEntityType()->getSingularLabel()),
       ]);
       $this->assertSession()->pageTextContains($successMessage);
+      $inCache = TRUE;
     }
   }
 
@@ -187,6 +197,10 @@ class TeamInvitationsTest extends ApigeeEdgeTeamsFunctionalTestBase {
     $teams = [
       $this->teamA,
       $this->teamB,
+    ];
+    $companies = [
+      $this->teamA->decorated(),
+      $this->teamB->decorated(),
     ];
 
     // Invite user to both teams.
@@ -206,6 +220,8 @@ class TeamInvitationsTest extends ApigeeEdgeTeamsFunctionalTestBase {
     $invitationsUrl = Url::fromRoute('view.team_invitations.user', [
       'user' => $this->accountUser->id(),
     ]);
+
+    $this->queueCompaniesResponse($companies);
     $this->drupalGet($invitationsUrl);
     foreach ($teams as $team) {
       $this->assertSession()->pageTextContains('Invitation to join ' . $team->label());
@@ -215,6 +231,7 @@ class TeamInvitationsTest extends ApigeeEdgeTeamsFunctionalTestBase {
     $this->queueCompanyResponse($this->teamA->decorated());
     $teamALabel = $this->teamA->label();
     $this->teamA->delete();
+    $this->queueCompaniesResponse($companies);
     $this->queueCompanyResponse($this->teamB->decorated());
     $this->drupalGet($invitationsUrl);
     $this->assertSession()->pageTextNotContains('Invitation to join ' . $teamALabel);

--- a/tests/src/Functional/DeveloperSyncTest.php
+++ b/tests/src/Functional/DeveloperSyncTest.php
@@ -595,16 +595,16 @@ class DeveloperSyncTest extends ApigeeEdgeFunctionalTestBase {
     $printed_output = $output->fetch();
 
     foreach ($this->edgeDevelopers as $email => $developer) {
-      $this->assertContains("Copying developer ({$email}) from Apigee Edge.", $printed_output);
+      $this->assertStringContainsString("Copying developer ({$email}) from Apigee Edge.", $printed_output);
     }
     foreach ($this->drupalUsers as $email => $user) {
-      $this->assertContains("Copying user ({$email}) to Apigee Edge.", $printed_output);
+      $this->assertStringContainsString("Copying user ({$email}) to Apigee Edge.", $printed_output);
     }
     foreach ($this->modifiedEdgeDevelopers as $email => $developer) {
-      $this->assertContains("Updating user ({$email}) from Apigee Edge.", $printed_output);
+      $this->assertStringContainsString("Updating user ({$email}) from Apigee Edge.", $printed_output);
     }
     foreach ($this->modifiedDrupalUsers as $email => $user) {
-      $this->assertContains("Updating developer ({$email}) in Apigee Edge.", $printed_output);
+      $this->assertStringContainsString("Updating developer ({$email}) in Apigee Edge.", $printed_output);
     }
 
     $this->verify();


### PR DESCRIPTION
Fixes #516 and #517 

This PR:

1. Adds the team id when validation existing team_invitations for user.
2. Implements a query access subscriber to add a condition to check for existing teams.