### PR TITLE
Updates php-http/guzzle6-adapter to 2.x

### DIFF
--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -467,6 +467,19 @@ class RoboFile extends \Robo\Tasks
         $config->require->{"drupal/core-dev"} = '^9.1';
         $config->require->{"phpspec/prophecy-phpunit"} = '^2';
 
+        /**
+         * Allow tests to run against PHP Unit ^9.
+         *
+         * @todo Remove once the following issue has been fixed in a stable
+         * release from Drupal Core.
+         *
+         * @see https://www.drupal.org/project/drupal/issues/3186443
+         */
+        if (!isset($config->extra->{"patches"}->{"drupal/core"})) {
+          $config->extra->{"patches"}->{"drupal/core"} = new \stdClass();
+        }
+        $config->extra->{"patches"}->{"drupal/core"}->{"PHPUnit 9.5 Call to undefined method ::getAnnotations()"} = 'https://www.drupal.org/files/issues/2020-12-04/3186443-1.patch';
+
         break;
 
       case '8':

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,11 @@
     "require": {
         "php": ">=7.1",
         "ext-json": "*",
-        "apigee/apigee-client-php": "^2.0.4",
+        "apigee/apigee-client-php": "^2.0.6",
         "drupal/core": "^8.7.7 || ^9",
         "drupal/entity": "^1.0",
         "drupal/key": "^1.8",
-        "php-http/guzzle6-adapter": "^1.1.1"
+        "php-http/guzzle6-adapter": "^2.0"
     },
     "require-dev": {
         "apigee/apigee-mock-client-php": "^1.0",


### PR DESCRIPTION
Supports https://github.com/apigee/apigee-client-php/pull/106, to drop support of HTTPlug 1.x. Will need to re-run tests once a new version of `apigee/apigee-client-php` has been released, until then, CI will fail.
