### PR TITLE
[#524] Ensure team view builder uses cache_expiration config

### DIFF
--- a/modules/apigee_edge_teams/src/Entity/Team.php
+++ b/modules/apigee_edge_teams/src/Entity/Team.php
@@ -45,6 +45,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
  *     "permission_provider" = "Drupal\apigee_edge_teams\Entity\TeamPermissionProvider",
  *     "access" = "Drupal\apigee_edge_teams\Entity\TeamAccessHandler",
  *     "list_builder" = "Drupal\apigee_edge_teams\Entity\ListBuilder\TeamListBuilder",
+ *     "view_builder" = "Drupal\apigee_edge_teams\Entity\TeamViewBuilder",
  *     "form" = {
  *        "default" = "Drupal\apigee_edge_teams\Entity\Form\TeamForm",
  *        "add" = "Drupal\apigee_edge_teams\Entity\Form\TeamForm",

--- a/modules/apigee_edge_teams/src/Entity/TeamViewBuilder.php
+++ b/modules/apigee_edge_teams/src/Entity/TeamViewBuilder.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Copyright 2020 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_edge_teams\Entity;
+
+use Drupal\apigee_edge\Entity\EdgeEntityViewBuilder;
+use Drupal\Core\Config\Config;
+use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Theme\Registry;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Entity view builder for team entities.
+ */
+class TeamViewBuilder extends EdgeEntityViewBuilder {
+
+  /**
+   * The 'apigee_edge_teams.team_settings' config.
+   *
+   * @var \Drupal\Core\Config\Config
+   */
+  protected $config;
+
+  /**
+   * TeamViewBuilder constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
+   *   The entity type definition.
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
+   *   The entity repository service.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   The language manager.
+   * @param \Drupal\Core\Config\Config $config
+   *   The 'apigee_edge_teams.team_settings' config.
+   * @param \Drupal\Core\Theme\Registry|null $theme_registry
+   *   The theme registry.
+   * @param \Drupal\Core\Entity\EntityDisplayRepositoryInterface|null $entity_display_repository
+   *   The entity display repository.
+   */
+  public function __construct(EntityTypeInterface $entity_type, EntityRepositoryInterface $entity_repository, LanguageManagerInterface $language_manager, Config $config, Registry $theme_registry = NULL, EntityDisplayRepositoryInterface $entity_display_repository = NULL) {
+    parent::__construct($entity_type, $entity_repository, $language_manager, $theme_registry, $entity_display_repository);
+    $this->config = $config;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
+    return new static(
+      $entity_type,
+      $container->get('entity.repository'),
+      $container->get('language_manager'),
+      $container->get('config.factory')->get('apigee_edge_teams.team_settings'),
+      $container->get('theme.registry'),
+      $container->get('entity_display.repository')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getBuildDefaults(EntityInterface $entity, $view_mode): array {
+    $build = parent::getBuildDefaults($entity, $view_mode);
+
+    // Use cache expiration defined in configuration.
+    $build['#cache']['max-age'] = $this->config->get('cache_expiration');
+
+    return $build;
+  }
+
+}

--- a/modules/apigee_edge_teams/tests/src/Kernel/Entity/TeamViewBuilderTest.php
+++ b/modules/apigee_edge_teams/tests/src/Kernel/Entity/TeamViewBuilderTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Copyright 2020 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+namespace Drupal\Tests\apigee_edge_teams\Kernel\Entity;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\apigee_edge\Kernel\ApigeeEdgeKernelTestTrait;
+use Drupal\Tests\apigee_mock_api_client\Traits\ApigeeMockApiClientHelperTrait;
+
+/**
+ * Tests the Team view builder.
+ *
+ * @group apigee_edge
+ * @group apigee_edge_kernel
+ * @group apigee_edge_teams
+ * @group apigee_edge_teams_kernel
+ */
+class TeamViewBuilderTest extends KernelTestBase {
+
+  use ApigeeMockApiClientHelperTrait, ApigeeEdgeKernelTestTrait;
+
+  /**
+   * Indicates this test class is mock API client ready.
+   *
+   * @var bool
+   */
+  protected static $mock_api_client_ready = TRUE;
+
+  /**
+   * The entity type to test.
+   */
+  const ENTITY_TYPE = 'team';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'apigee_edge',
+    'apigee_edge_teams',
+    'apigee_mock_api_client',
+    'key',
+    'user',
+    'options'
+  ];
+
+  /**
+   * The team entity.
+   *
+   * @var \Drupal\apigee_edge_teams\Entity\TeamInterface
+   */
+  protected $entity;
+
+  /**
+   * {@inheritdoc}
+   *
+   * @throws \Exception
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installConfig(['apigee_edge']);
+    $this->installConfig(['apigee_edge_teams']);
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('team_member_role');
+    $this->installSchema('system', ['sequences']);
+    $this->installSchema('user', ['users_data']);
+
+    $this->apigeeTestHelperSetup();
+
+    $this->addOrganizationMatchedResponse();
+
+    $this->entity = $this->createTeam();
+  }
+
+  /**
+   * Tests the cache max-age for the view builder.
+   */
+  public function testViewCacheExpiration() {
+    /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager */
+    $entity_type_manager = $this->container->get('entity_type.manager');
+    $build = $entity_type_manager->getViewBuilder(static::ENTITY_TYPE)->view($this->entity);
+
+    static::assertEqual(900, $build['#cache']['max-age']);
+
+    // Update the cache setting.
+    $this->config('apigee_edge_teams.team_settings')
+      ->set('cache_expiration', 0)
+      ->save();
+
+    $build = $entity_type_manager->getViewBuilder(static::ENTITY_TYPE)->view($this->entity);
+    static::assertEqual(0, $build['#cache']['max-age']);
+  }
+
+}


### PR DESCRIPTION
Fixes #524 

This adds the `apigee_edge_teams.team_settings.cache_expiration` config to the `Team` max-age.

We implemented this for `TeamListBuilder` but not for `ViewBuilder`.