### PR TITLE
Display warning on status page.

### DIFF
--- a/modules/apigee_edge_debug/apigee_edge_debug.install
+++ b/modules/apigee_edge_debug/apigee_edge_debug.install
@@ -29,11 +29,11 @@
  */
 function apigee_edge_debug_requirements($phase) {
   $requirements = [];
-  if ($phase == 'runtime') {
+  if ($phase === 'runtime') {
     $requirements['apigee_debug'] = [
-      'title' => t('Apigee Edge debug'),
-      'value' => t('Apigee Edge debug module is enabled.'),
-      'description' => t("It's recommended to disable this module on production sites."),
+      'title' => t('Apigee Edge Debug'),
+      'value' => t('Apigee Edge Debug module is enabled.'),
+      'description' => t('It is recommended to disable this module on production sites.'),
       'severity' => REQUIREMENT_WARNING,
     ];
   }

--- a/modules/apigee_edge_debug/apigee_edge_debug.install
+++ b/modules/apigee_edge_debug/apigee_edge_debug.install
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @file
+ * Copyright 2020 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ */
+
+/**
+ * @file
+ * Install, update and uninstall functions for Apigee Edge Debug.
+ */
+
+/**
+ * Implements hook_requirements().
+ */
+function apigee_edge_debug_requirements($phase) {
+  $requirements = [];
+  if ($phase == 'runtime') {
+    $requirements['apigee_debug'] = [
+      'title' => t('Apigee Edge debug'),
+      'value' => t('Apigee Edge debug module is enabled.'),
+      'description' => t("It's recommended to disable this module on production sites."),
+      'severity' => REQUIREMENT_WARNING,
+    ];
+  }
+  return $requirements;
+}


### PR DESCRIPTION
Added an install file in apigee_edge_debug module to show the warning message on the status page if the module is enabled. This fixes #334.