### PR TITLE
Apigee edge debug module - debug logs and recent logs formatting enhancement #333 & #331

### DIFF
--- a/modules/apigee_edge_debug/src/HttpClientMiddleware/ApiClientProfiler.php
+++ b/modules/apigee_edge_debug/src/HttpClientMiddleware/ApiClientProfiler.php
@@ -115,8 +115,10 @@ class ApiClientProfiler {
           if (!$request_clone->hasHeader(SDKConnector::HEADER)) {
             return;
           }
+		  $debugMessageTitle = explode("\n", trim($formatter->formatRequest($request_clone)));
+		  $debugMessageTitle = str_replace('/v1/organizations/***organization***', '', $debugMessageTitle[0]);
           $context = [
-            'request_formatted' => ">>>>>>>>\n" . $formatter->formatRequest($request_clone),
+            'request_formatted' => $debugMessageTitle . "\n>>>>>>>>\n" . $formatter->formatRequest($request_clone),
             'stats' => $formatter->formatStats($stats),
           ];
           if ($stats->hasResponse()) {

--- a/modules/apigee_edge_debug/src/HttpClientMiddleware/ApiClientProfiler.php
+++ b/modules/apigee_edge_debug/src/HttpClientMiddleware/ApiClientProfiler.php
@@ -116,14 +116,14 @@ class ApiClientProfiler {
             return;
           }
           $context = [
-            'request_formatted' => $formatter->formatRequest($request_clone),
+            'request_formatted' => ">>>>>>>>\n" . $formatter->formatRequest($request_clone),
             'stats' => $formatter->formatStats($stats),
           ];
           if ($stats->hasResponse()) {
             // Do not modify the original response object in the subsequent
             // calls.
             $response_clone = clone $stats->getResponse();
-            $context['response_formatted'] = $formatter->formatResponse($response_clone, $request_clone);
+            $context['response_formatted'] = "<<<<<<<<\n" . $formatter->formatResponse($response_clone, $request_clone);
             if ($stats->getResponse()->getStatusCode() >= 400) {
               $level = LogLevel::WARNING;
             }

--- a/modules/apigee_edge_debug/src/HttpClientMiddleware/ApiClientProfiler.php
+++ b/modules/apigee_edge_debug/src/HttpClientMiddleware/ApiClientProfiler.php
@@ -115,8 +115,8 @@ class ApiClientProfiler {
           if (!$request_clone->hasHeader(SDKConnector::HEADER)) {
             return;
           }
-		  $debugMessageTitle = explode("\n", trim($formatter->formatRequest($request_clone)));
-		  $debugMessageTitle = str_replace('/v1/organizations/***organization***', '', $debugMessageTitle[0]);
+          $debugMessageTitle = explode("\n", trim($formatter->formatRequest($request_clone)));
+          $debugMessageTitle = str_replace('/v1/organizations/***organization***', '', $debugMessageTitle[0]);
           $context = [
             'request_formatted' => $debugMessageTitle . "\n>>>>>>>>\n" . $formatter->formatRequest($request_clone),
             'stats' => $formatter->formatStats($stats),

--- a/modules/apigee_edge_debug/src/Plugin/DebugMessageFormatter/FullHttpMessageFormatter.php
+++ b/modules/apigee_edge_debug/src/Plugin/DebugMessageFormatter/FullHttpMessageFormatter.php
@@ -41,7 +41,7 @@ class FullHttpMessageFormatter extends DebugMessageFormatterPluginBase {
    *
    * @var int
    */
-  private $maxBodyLength = 10000;
+  private $maxBodyLength = null;
 
   /**
    * The original full HTTP message formatter.
@@ -76,7 +76,7 @@ class FullHttpMessageFormatter extends DebugMessageFormatterPluginBase {
    * {@inheritdoc}
    */
   public function formatResponse(ResponseInterface $response, RequestInterface $request): string {
-    return sprintf("Response body got truncated to %d characters.\n\n%s", $this->maxBodyLength, parent::formatResponse($response, $request));
+    return parent::formatResponse($response, $request);
   }
 
 }

--- a/modules/apigee_edge_debug/src/Plugin/DebugMessageFormatter/FullHttpMessageFormatter.php
+++ b/modules/apigee_edge_debug/src/Plugin/DebugMessageFormatter/FullHttpMessageFormatter.php
@@ -41,7 +41,7 @@ class FullHttpMessageFormatter extends DebugMessageFormatterPluginBase {
    *
    * @var int
    */
-  private $maxBodyLength = null;
+  private $maxBodyLength = NULL;
 
   /**
    * The original full HTTP message formatter.


### PR DESCRIPTION
Closes #333 & #331 
Enhanced formatting on Apigee edge debug module recent logs and request/response logs to Improve Readability.

1. Removed limitation of showing 10000 characters on detail logs.
2. Request and response differentiated by showing arrows (<<<< / >>>>).
3. In recent logs truncated  "/v1/organizations/***organization***" for better readability of debug logs.

**_Screenshot - Updated recent log page which was earlier showing "/v1/organizations/***organization***"_**
Resolves #331 
![recent-log](https://user-images.githubusercontent.com/75600200/103010773-d5bb5b00-455e-11eb-9c3a-e6fea5b992a4.png)

**_Screenshot - Updated debug logs request and response._**
Resolves #333
![debug-log](https://user-images.githubusercontent.com/75600200/103010785-db18a580-455e-11eb-9f4a-bd3f84c0dd31.png)
