### PR TITLE
Field_ui dependency removed from Apigee Edge module #466

### DIFF
--- a/apigee_edge.info.yml
+++ b/apigee_edge.info.yml
@@ -8,7 +8,6 @@ core_version_requirement: ^8.7.7 || ^9
 dependencies:
   - drupal:file
   - drupal:user
-  - drupal:field_ui
   - entity:entity
   - drupal:filter
   - drupal:options

--- a/modules/apigee_edge_teams/tests/src/Functional/UiTest.php
+++ b/modules/apigee_edge_teams/tests/src/Functional/UiTest.php
@@ -34,13 +34,14 @@ class UiTest extends ApigeeEdgeTeamsFunctionalTestBase {
 
   use EntityUtilsTrait;
   use FieldUiTestTrait;
- 
+
   /**
    * {@inheritdoc}
    */
   protected static $modules = [
     'field_ui',
   ];
+
   /**
    * The team entity storage.
    *

--- a/modules/apigee_edge_teams/tests/src/Functional/UiTest.php
+++ b/modules/apigee_edge_teams/tests/src/Functional/UiTest.php
@@ -34,7 +34,13 @@ class UiTest extends ApigeeEdgeTeamsFunctionalTestBase {
 
   use EntityUtilsTrait;
   use FieldUiTestTrait;
-
+ 
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'field_ui',
+  ];
   /**
    * The team entity storage.
    *

--- a/tests/src/Functional/ConfigurationPermissionTest.php
+++ b/tests/src/Functional/ConfigurationPermissionTest.php
@@ -35,6 +35,7 @@ class ConfigurationPermissionTest extends ApigeeEdgeFunctionalTestBase {
    */
   protected static $modules = [
     'block',
+    'field_ui',
   ];
 
   /**

--- a/tests/src/Functional/DeveloperAppFieldTest.php
+++ b/tests/src/Functional/DeveloperAppFieldTest.php
@@ -46,6 +46,7 @@ class DeveloperAppFieldTest extends ApigeeEdgeFunctionalTestBase {
   protected static $modules = [
     'link',
     'block',
+    'field_ui',
   ];
 
   /**

--- a/tests/src/Functional/DeveloperAppUITest.php
+++ b/tests/src/Functional/DeveloperAppUITest.php
@@ -37,12 +37,14 @@ class DeveloperAppUITest extends ApigeeEdgeFunctionalTestBase {
   use EntityUtilsTrait;
 
   protected const DUPLICATE_MACHINE_NAME = 'The machine-readable name is already in use. It must be unique.';
+
   /**
    * {@inheritdoc}
    */
   protected static $modules = [
     'field_ui',
   ];
+  
   /**
    * {@inheritdoc}
    */

--- a/tests/src/Functional/DeveloperAppUITest.php
+++ b/tests/src/Functional/DeveloperAppUITest.php
@@ -44,7 +44,7 @@ class DeveloperAppUITest extends ApigeeEdgeFunctionalTestBase {
   protected static $modules = [
     'field_ui',
   ];
-  
+
   /**
    * {@inheritdoc}
    */

--- a/tests/src/Functional/DeveloperAppUITest.php
+++ b/tests/src/Functional/DeveloperAppUITest.php
@@ -37,7 +37,12 @@ class DeveloperAppUITest extends ApigeeEdgeFunctionalTestBase {
   use EntityUtilsTrait;
 
   protected const DUPLICATE_MACHINE_NAME = 'The machine-readable name is already in use. It must be unique.';
-
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'field_ui',
+  ];
   /**
    * {@inheritdoc}
    */

--- a/tests/src/Functional/DeveloperSyncTest.php
+++ b/tests/src/Functional/DeveloperSyncTest.php
@@ -55,6 +55,7 @@ class DeveloperSyncTest extends ApigeeEdgeFunctionalTestBase {
   protected static $modules = [
     'link',
     'block',
+    'field_ui',
   ];
 
   /**


### PR DESCRIPTION
Closes #466 

Removed field_ui dependency from Apigee Edge module.
Updated the unit test files as field_ui is required for CircleCI testing.
