### PR TITLE
[#343] Hides portal environment in app analytics config

### DIFF
--- a/src/Form/AppAnalyticsSettingsForm.php
+++ b/src/Form/AppAnalyticsSettingsForm.php
@@ -84,7 +84,9 @@ class AppAnalyticsSettingsForm extends ConfigFormBase {
     // Portal environment is for internal use with integrated portals and
     // is not an actual environment for customers use.
     // To reduce confusion portal environment is hidden from configuration.
-    $environments = array_diff($this->environmentController->getEntityIds(), ['portal']);
+    $environments = $this->environmentController->getEntityIds();
+    $environments = array_combine($environments, $environments);
+    unset($environments['portal']);
 
     $form['label'] = [
       '#type' => 'fieldset',
@@ -97,7 +99,7 @@ class AppAnalyticsSettingsForm extends ConfigFormBase {
       '#required' => TRUE,
       '#title' => $this->t('Which environments should be displayed on the form to query analytics data?'),
       '#default_value' => $this->config('apigee_edge.common_app_settings')->get('analytics_available_environments') ?: [],
-      '#options' => array_combine($environments, $environments),
+      '#options' => $environments,
     ];
 
     $form['label']['environment'] = [
@@ -105,7 +107,7 @@ class AppAnalyticsSettingsForm extends ConfigFormBase {
       '#required' => TRUE,
       '#title' => $this->t('Which environment should be selected by default?'),
       '#default_value' => $this->config('apigee_edge.common_app_settings')->get('analytics_environment'),
-      '#options' => array_combine($environments, $environments),
+      '#options' => $environments,
     ];
 
     return parent::buildForm($form, $form_state);

--- a/src/Form/AppAnalyticsSettingsForm.php
+++ b/src/Form/AppAnalyticsSettingsForm.php
@@ -81,6 +81,9 @@ class AppAnalyticsSettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
+    // Portal environment is for internal use with integrated portals and
+    // is not an actual environment for customers use.
+    // To reduce confusion portal environment is hidden from configuration.
     $environments = array_diff($this->environmentController->getEntityIds(), ['portal']);
 
     $form['label'] = [

--- a/src/Form/AppAnalyticsSettingsForm.php
+++ b/src/Form/AppAnalyticsSettingsForm.php
@@ -81,7 +81,7 @@ class AppAnalyticsSettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $environments = $this->environmentController->getEntityIds();
+    $environments = array_diff($this->environmentController->getEntityIds(), ['portal']);
 
     $form['label'] = [
       '#type' => 'fieldset',


### PR DESCRIPTION
The portal environment is for internal use with integrated portals and is not an actual environment for customer's use. To reduce confusion portal environment is hidden from the app analytics configuration.
This fixes #343. 