### PR TITLE
[#235] Add translation to debug exception errors

### DIFF
--- a/src/Controller/ErrorPageController.php
+++ b/src/Controller/ErrorPageController.php
@@ -57,7 +57,7 @@ class ErrorPageController extends ControllerBase {
     $build['content'] = [
       '#type' => 'processed_text',
       '#format' => $this->configFactory->get('apigee_edge.error_page')->get('error_page_content.format'),
-      '#text' => $this->configFactory->get('apigee_edge.error_page')->get('error_page_content.value'),
+      '#text' => $this->t($this->configFactory->get('apigee_edge.error_page')->get('error_page_content.value')),
     ];
     return $build;
   }

--- a/src/Exception/DeveloperDoesNotExistException.php
+++ b/src/Exception/DeveloperDoesNotExistException.php
@@ -47,7 +47,7 @@ class DeveloperDoesNotExistException extends ApiException implements ApigeeEdgeE
    */
   public function __construct(string $email, string $message = 'Developer with @email email address not found. Running the developer sync could fix this.', int $code = 0, \Throwable $previous = NULL) {
     $this->email = $email;
-    $message = strtr($message, ['@email' => $email]);
+    $message = \Drupal::translation()->translate($message, ['@email' => $email]);
     parent::__construct($message, $code, $previous);
   }
 


### PR DESCRIPTION
Fixes #235.
This PR adds the translation for the exception added in #227.
![translation2](https://user-images.githubusercontent.com/75604843/103644559-92a8b100-4f7c-11eb-90be-501b6b971501.PNG)
![translation1](https://user-images.githubusercontent.com/75604843/103644564-93d9de00-4f7c-11eb-9986-6322b86cc2e7.PNG)


