### PR TITLE
Removing multiple occurances of @file annotations. Issue# 541.

### DIFF
--- a/apigee_edge.api.php
+++ b/apigee_edge.api.php
@@ -20,7 +20,6 @@
  */
 
 /**
- * @file
  * Hooks for apigee_edge module.
  */
 /**

--- a/apigee_edge.install
+++ b/apigee_edge.install
@@ -19,7 +19,6 @@
  */
 
 /**
- * @file
  * Install, update and uninstall functions for Apigee Edge.
  */
 

--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -19,7 +19,6 @@
  */
 
 /**
- * @file
  * Main module file for Apigee Edge.
  */
 

--- a/modules/apigee_edge_apiproduct_rbac/apigee_edge_apiproduct_rbac.module
+++ b/modules/apigee_edge_apiproduct_rbac/apigee_edge_apiproduct_rbac.module
@@ -20,7 +20,6 @@
  */
 
 /**
- * @file
  * Module file for Apigee Edge API Product RBAC.
  */
 

--- a/modules/apigee_edge_apiproduct_rbac/tests/modules/apigee_edge_apiproduct_rbac_test/apigee_edge_apiproduct_rbac_test.module
+++ b/modules/apigee_edge_apiproduct_rbac/tests/modules/apigee_edge_apiproduct_rbac_test/apigee_edge_apiproduct_rbac_test.module
@@ -20,7 +20,6 @@
  */
 
 /**
- * @file
  * Module file for Apigee Edge API Product RBAC tests.
  */
 

--- a/modules/apigee_edge_teams/apigee_edge_teams.api.php
+++ b/modules/apigee_edge_teams/apigee_edge_teams.api.php
@@ -20,7 +20,6 @@
  */
 
 /**
- * @file
  * Hooks for apigee_edge_teams module.
  */
 /**

--- a/modules/apigee_edge_teams/apigee_edge_teams.install
+++ b/modules/apigee_edge_teams/apigee_edge_teams.install
@@ -24,7 +24,6 @@ use Drupal\user\RoleInterface;
 use Drupal\views\Views;
 
 /**
- * @file
  * Install, update and uninstall functions for Apigee Edge Teams.
  */
 

--- a/modules/apigee_edge_teams/tests/modules/apigee_edge_teams_test/apigee_edge_teams_test.module
+++ b/modules/apigee_edge_teams/tests/modules/apigee_edge_teams_test/apigee_edge_teams_test.module
@@ -20,7 +20,6 @@
  */
 
 /**
- * @file
  * Helper module for the Apigee Edge Team module tests.
  */
 

--- a/tests/modules/apigee_edge_test/apigee_edge_test.module
+++ b/tests/modules/apigee_edge_test/apigee_edge_test.module
@@ -19,7 +19,6 @@
  */
 
 /**
- * @file
  * Helper module for the apigee_edge tests.
  */
 


### PR DESCRIPTION
@file annotations can only be used once in a file. Edited all the .module and .install files that had @file repeated multiple times. 
closes #541 