### PR TITLE
Apps credentials section consumer key/secret fisheye UI fix

### DIFF
--- a/css/apigee_edge.secret.css
+++ b/css/apigee_edge.secret.css
@@ -11,6 +11,7 @@
 .secret .secret__value,
 .secret .secret__toggle__hide {
   display: inline-block;
+  max-width: 11rem;
 }
 
 .secret--hidden .secret__value__hidden,


### PR DESCRIPTION
On **user/1/apps** page, consumer key and consumer secret was overlapping products section which was distorting the app key detail section UI.
Fixed

