### PR TITLE
Disabled email address field on edit profile page

### DIFF
--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -702,6 +702,8 @@ function apigee_edge_form_user_form_alter(&$form, FormStateInterface $form_state
   // Apigee Edge.
   $form['account']['mail']['#required'] = TRUE;
   $user = \Drupal::currentUser();
+  // The email field should be disabled since users should not edit it.
+  $form['account']['mail']['#attributes'] = array('readonly' => 'readonly');
   // Make the same information available here as on user_register_form.
   // @see \Drupal\user\RegisterForm::form()
   $form['administer_users'] = [

--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -703,7 +703,7 @@ function apigee_edge_form_user_form_alter(&$form, FormStateInterface $form_state
   $form['account']['mail']['#required'] = TRUE;
   $user = \Drupal::currentUser();
   // The email field should be disabled since users should not edit it.
-  $form['account']['mail']['#attributes'] = array('readonly' => 'readonly');
+  $form['account']['mail']['#attributes'] = array('disabled' => 'disabled');
   // Make the same information available here as on user_register_form.
   // @see \Drupal\user\RegisterForm::form()
   $form['administer_users'] = [


### PR DESCRIPTION
Internally it was decided to prevent users from editing their email addresses. This code will disable the email field on edit profile page to prevent users from editing their email address.