### PR TITLE
Fix - developer portal fails to recognize Apigee Registered Developers while using SSO

### DIFF
--- a/src/UserDeveloperConverter.php
+++ b/src/UserDeveloperConverter.php
@@ -103,6 +103,13 @@ class UserDeveloperConverter implements UserDeveloperConverterInterface {
     foreach (static::DEVELOPER_PROP_USER_BASE_FIELD_MAP as $developer_prop => $base_field) {
       $setter = 'set' . ucfirst($developer_prop);
       $getter = 'get' . ucfirst($developer_prop);
+
+      // Default value for firstname lastname if null.
+      if ($user->get($base_field)->value === NULL && ($base_field === "first_name" || $base_field === "last_name")) {
+        $base_field_value = $developer->{$getter}() !== NULL ? $developer->{$getter}() : ucfirst($developer_prop);
+        $user->set($base_field, $base_field_value);
+      }
+
       if ($user->get($base_field)->value !== $developer->{$getter}()) {
         $developer->{$setter}($user->get($base_field)->value);
         $successful_changes++;


### PR DESCRIPTION
Closes #586 and #315 

Fixes below issues.
1. Whenever a user logs in using SSO, if First Name, Last Name is null or if the developer already exists in Apigee during this process, the site throws
 `§ TypeError: Argument 1 passed to Drupal\apigee_edge\Entity\Developer::setFirstName() must be of the type string, null given, called in /var/www/html/devportal/web/modules/contrib/apigee_edge/src/UserDeveloperConverter.php on line 107 in Drupal\apigee_edge\Entity\Developer->setFirstName()`.

2. If developer does not exist on both Apigee Edge as well as Drupal portal, then the developer is not registered on Apigee and throws error while doing a POST request to Apigee.
`"error": {
        "code": 400,
        "message": "Following elements are required: Email, User Name, First Name, Last Name",
        "status": "INVALID_ARGUMENT",
        "details": [...`
 
The above issue occurs when First-name/Last-name is null, fixed by providing a default value.
