### PR TITLE
Fix 587 - throw exception when change the email address using PUT /developers for ApigeeX

### DIFF
--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -1371,6 +1371,14 @@ function apigee_edge_user_presave(UserInterface $account) {
           $logger->error("Unable to save @developer developer's developer id on user.", $context);
         }
       }
+      elseif ($previous->getEdgeErrorCode() === Developer::APIGEE_EDGE_ERROR_CODE_DEVELOPER_EMAIL_MISMATCH) {
+        // Apigee X and hybrid runtime versions 1.5.0 and 1.5.1 a call to change the developer's email address will not work so need
+        // to prevent user email update on drupal as well.
+        // @see https://github.com/apigee/apigee-client-php/issues/153
+        // @see https://github.com/apigee/apigee-edge-drupal/issues/587
+        \Drupal::messenger()->addMessage(t($previous->getMessage()), 'error');
+        throw new \Exception(t($previous->getMessage()));
+      }
     }
     else {
       $context += Error::decodeException($exception);

--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -31,6 +31,7 @@ use Drupal\apigee_edge\Element\StatusPropertyElement;
 use Drupal\apigee_edge\Entity\ApiProduct;
 use Drupal\apigee_edge\Entity\AppInterface;
 use Drupal\apigee_edge\Entity\Developer;
+use Drupal\apigee_edge\Exception\DeveloperUpdateFailedException;
 use Drupal\apigee_edge\Exception\UserDeveloperConversionNoStorageFormatterFoundException;
 use Drupal\apigee_edge\Exception\UserDeveloperConversionUserFieldDoesNotExistException;
 use Drupal\apigee_edge\Form\DeveloperSettingsForm;
@@ -1371,13 +1372,14 @@ function apigee_edge_user_presave(UserInterface $account) {
           $logger->error("Unable to save @developer developer's developer id on user.", $context);
         }
       }
-      elseif ($previous->getEdgeErrorCode() === Developer::APIGEE_EDGE_ERROR_CODE_DEVELOPER_EMAIL_MISMATCH) {
-        // Apigee X and hybrid runtime versions 1.5.0 and 1.5.1 a call to change the developer's email address will not work so need
-        // to prevent user email update on drupal as well.
+      elseif ($previous->getEdgeErrorCode() === Developer::APIGEE_HYBRID_ERROR_CODE_DEVELOPER_EMAIL_MISMATCH) {
+        // Apigee X and Hybrid runtime v1.5.0 and v1.5.1 a call to change the developer's
+        // email address will not work so need to prevent user email update on
+        // Drupal as well.
         // @see https://github.com/apigee/apigee-client-php/issues/153
         // @see https://github.com/apigee/apigee-edge-drupal/issues/587
-        \Drupal::messenger()->addMessage(t($previous->getMessage()), 'error');
-        throw new \Exception(t($previous->getMessage()));
+        \Drupal::messenger()->addMessage("Unable to update developer's profile.", 'error');
+        throw new DeveloperUpdateFailedException($account->getEmail(), $exception);
       }
     }
     else {

--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -1378,8 +1378,7 @@ function apigee_edge_user_presave(UserInterface $account) {
         // Drupal as well.
         // @see https://github.com/apigee/apigee-client-php/issues/153
         // @see https://github.com/apigee/apigee-edge-drupal/issues/587
-        \Drupal::messenger()->addMessage("Unable to update developer's profile.", 'error');
-        throw new DeveloperUpdateFailedException($account->getEmail(), $exception);
+        throw new DeveloperUpdateFailedException($account->getEmail(), "Developer @email profile cannot be updated. " . $previous->getMessage());
       }
     }
     else {

--- a/src/Entity/Developer.php
+++ b/src/Entity/Developer.php
@@ -66,11 +66,11 @@ class Developer extends EdgeEntityBase implements DeveloperInterface {
   const APIGEE_EDGE_ERROR_CODE_DEVELOPER_DOES_NOT_EXISTS = 'developer.service.DeveloperDoesNotExist';
 
   /**
-   * Developer email in the url doesnot match with the email in the request payload.
+   * Resource name in the url doesnot match with the name in the request payload.
    *
    * @var string
    */
-  const APIGEE_EDGE_ERROR_CODE_DEVELOPER_EMAIL_MISMATCH = 'rest.interceptor.name_mismatch';
+  const APIGEE_HYBRID_ERROR_CODE_DEVELOPER_EMAIL_MISMATCH = 'rest.interceptor.name_mismatch';
 
   /**
    * The decorated SDK entity.

--- a/src/Entity/Developer.php
+++ b/src/Entity/Developer.php
@@ -66,6 +66,13 @@ class Developer extends EdgeEntityBase implements DeveloperInterface {
   const APIGEE_EDGE_ERROR_CODE_DEVELOPER_DOES_NOT_EXISTS = 'developer.service.DeveloperDoesNotExist';
 
   /**
+   * Developer email in the url doesnot match with the email in the request payload.
+   *
+   * @var string
+   */
+  const APIGEE_EDGE_ERROR_CODE_DEVELOPER_EMAIL_MISMATCH = 'rest.interceptor.name_mismatch';
+
+  /**
    * The decorated SDK entity.
    *
    * @var \Apigee\Edge\Api\Management\Entity\Developer

--- a/src/Exception/DeveloperUpdateFailedException.php
+++ b/src/Exception/DeveloperUpdateFailedException.php
@@ -24,14 +24,14 @@ use Apigee\Edge\Exception\ApiException;
 /**
  * This exception is thrown when the developer profile update fails.
  */
-class DeveloperUpdateFailedException extends ApiException implements ApigeeEdgeExceptionInterface {
+final class DeveloperUpdateFailedException extends ApiException implements ApigeeEdgeExceptionInterface {
 
   /**
    * Email address of the developer.
    *
    * @var string
    */
-  protected $email;
+  private $email;
 
   /**
    * DeveloperUpdateFailedException constructor.

--- a/src/Exception/DeveloperUpdateFailedException.php
+++ b/src/Exception/DeveloperUpdateFailedException.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Copyright 2021 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_edge\Exception;
+
+use Apigee\Edge\Exception\ApiException;
+
+/**
+ * This exception is thrown when the developer profile update fails.
+ */
+class DeveloperUpdateFailedException extends ApiException implements ApigeeEdgeExceptionInterface {
+
+  /**
+   * Email address of the developer.
+   *
+   * @var string
+   */
+  protected $email;
+
+  /**
+   * DeveloperUpdateFailedException constructor.
+   *
+   * @param string $email
+   *   Developer email.
+   * @param string $message
+   *   Exception message.
+   * @param int $code
+   *   Error code.
+   * @param \Throwable|null $previous
+   *   Previous exception.
+   */
+  public function __construct(string $email, string $message = 'Developer @email profile update failed.', int $code = 0, \Throwable $previous = NULL) {
+    $this->email = $email;
+    $message = strtr($message, ['@email' => $email]);
+    parent::__construct($message, $code, $previous);
+  }
+
+  /**
+   * Email address of the developer.
+   *
+   * @return string
+   *   Email address.
+   */
+  public function getEmail(): string {
+    return $this->email;
+  }
+
+}


### PR DESCRIPTION
Closes #587 

`PUT /developers` throwing `INVALID_ARGUMENT -  rest.interceptor.name_mismatch` error while updating user email address on
Apigee X and hybrid runtime versions 1.5.0 and 1.5.1.

To prevent user email address getting updated on Drupal portal and not on `Apigee edge` due to above issue, we are throwing exception on Drupal portal to prevent updating the email address on Drupal, which creates new account on` Apigee edge` if user again tries to update the same account.

This issue is related to [this](https://github.com/apigee/apigee-client-php/pull/154) 