### PR TITLE
Fix - warning after user registration with SimpleSAMLphp

### DIFF
--- a/src/UserDeveloperConverter.php
+++ b/src/UserDeveloperConverter.php
@@ -90,9 +90,12 @@ class UserDeveloperConverter implements UserDeveloperConverterInterface {
    */
   public function convertUser(UserInterface $user): UserToDeveloperConversionResult {
     $problems = [];
+    $developer = NULL;
     $successful_changes = 0;
     $email = isset($user->original) ? $user->original->getEmail() : $user->getEmail();
-    $developer = $this->entityTypeManager->getStorage('developer')->load($email);
+    if ($email) {
+      $developer = $this->entityTypeManager->getStorage('developer')->load($email);
+    }
     if (!$developer) {
       /** @var \Drupal\apigee_edge\Entity\DeveloperInterface $developer */
       $developer = $this->entityTypeManager->getStorage('developer')->create([]);


### PR DESCRIPTION
Closes #614 

This PR checks if email is null during user_load from edge and fix `Warning: array_flip(): Can only flip STRING and INTEGER values!`