### PR TITLE
Fix - Error message in EventSubscriber has a typo

### DIFF
--- a/modules/apigee_edge_teams/src/EventSubscriber/TeamInactiveStatusSubscriber.php
+++ b/modules/apigee_edge_teams/src/EventSubscriber/TeamInactiveStatusSubscriber.php
@@ -106,7 +106,7 @@ class TeamInactiveStatusSubscriber implements EventSubscriberInterface {
         '#theme' => 'status_messages',
         '#message_list' => [
           'error' => [
-            $this->t('The %team_name @team is inactive. This operation is now allowed.', [
+            $this->t('The %team_name @team is inactive. This operation is not allowed.', [
               '%team_name' => $team->label(),
               '@team' => $team->getEntityType()->getSingularLabel(),
             ]),


### PR DESCRIPTION
Closes #640 
Fix inactive teams error message typo.