### PR TITLE
fix #655: let drupal validation if email address is empty

### DIFF
--- a/src/Plugin/Validation/Constraint/DeveloperEmailUniqueValidator.php
+++ b/src/Plugin/Validation/Constraint/DeveloperEmailUniqueValidator.php
@@ -60,7 +60,7 @@ class DeveloperEmailUniqueValidator extends ConstraintValidator implements Conta
    * {@inheritdoc}
    */
   public function validate($items, Constraint $constraint) {
-    if (in_array($items->value, static::$whitelist)) {
+    if (empty($items->value) || in_array($items->value, static::$whitelist)) {
       return;
     }
     /** @var \Drupal\Core\Entity\EntityInterface $entity */


### PR DESCRIPTION
Fix #655

- To let drupal validation on registration form if address email is empty