### PR TITLE
Replaced deprecated "Formatter::formatResponse()" with "formatResponseForRequest" method

### DIFF
--- a/modules/apigee_edge_debug/src/Plugin/DebugMessageFormatter/DebugMessageFormatterPluginBase.php
+++ b/modules/apigee_edge_debug/src/Plugin/DebugMessageFormatter/DebugMessageFormatterPluginBase.php
@@ -155,7 +155,7 @@ abstract class DebugMessageFormatterPluginBase extends PluginBase implements Con
         }
       }
     }
-    return $this->getFormatter()->formatResponse($response);
+    return $this->getFormatter()->formatResponseForRequest($response);
   }
 
   /**

--- a/modules/apigee_edge_debug/src/Plugin/DebugMessageFormatter/DebugMessageFormatterPluginBase.php
+++ b/modules/apigee_edge_debug/src/Plugin/DebugMessageFormatter/DebugMessageFormatterPluginBase.php
@@ -155,7 +155,7 @@ abstract class DebugMessageFormatterPluginBase extends PluginBase implements Con
         }
       }
     }
-    return $this->getFormatter()->formatResponseForRequest($response);
+    return $this->getFormatter()->formatResponseForRequest($response, $request);
   }
 
   /**


### PR DESCRIPTION
Closes #667 
Replaced deprecated `Formatter::formatResponse()` with `formatResponseForRequest` method.
Reference : https://github.com/php-http/message/releases/tag/1.13.0