### PR TITLE
Bump Drupal core version requirement to 9.2.13 and removed Drupal 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,9 +253,9 @@ workflows:
       - run-code-sniffer:
           requires:
             - update-dependencies-9
-#      - run-d9-check:
-#          requires:
-#            - update-dependencies-9
+      - run-d9-check:
+          requires:
+            - update-dependencies-9
       - run-unit-kernel-tests:
           name: run-unit-kernel-tests-<< matrix.core-version >>
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,6 +198,8 @@ code_coverage: &code_coverage
 d9_check: &d9_check
   <<: *defaults
   steps:
+    - run: rm -rf /var/www/html/core
+
     - attach_workspace:
         at: /var/www/html
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ defaults: &defaults
   parameters:
     core-version:
       type: integer
-      default: 8
+      default: 9
 
 # YAML does not support merging of lists. That means we can't have a default
 # 'steps' configuration, though we can have defaults for individual step
@@ -249,32 +249,32 @@ workflows:
           name: update-dependencies-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [8, 9]
+              core-version: [9]
       - run-code-sniffer:
           requires:
-            - update-dependencies-8
-      - run-d9-check:
-          requires:
-            - update-dependencies-8
+            - update-dependencies-9
+#      - run-d9-check:
+#          requires:
+#            - update-dependencies-9
       - run-unit-kernel-tests:
           name: run-unit-kernel-tests-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [8, 9]
+              core-version: [9]
           requires:
             - update-dependencies-<< matrix.core-version >>
       - run-functional-tests:
           name: run-functional-tests-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [8, 9]
+              core-version: [9]
           requires:
             - update-dependencies-<< matrix.core-version >>
       - run-functional-js-tests:
           name: run-functional-js-tests-<< matrix.core-version >>
           matrix:
             parameters:
-              core-version: [8, 9]
+              core-version: [9]
           requires:
             - update-dependencies-<< matrix.core-version >>
 #      - run-code-coverage:

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=7.1",
         "ext-json": "*",
         "apigee/apigee-client-php": "^2.0.12",
-        "drupal/core": "^8.9.19 || ^9.0.8",
+        "drupal/core": "^9.2.13",
         "drupal/entity": "^1.0",
         "drupal/key": "^1.8",
         "php-http/guzzle6-adapter": "^2.0"
@@ -17,7 +17,7 @@
         "behat/mink-extension": "^2.0",
         "bex/behat-screenshot": "^1.2",
         "cweagans/composer-patches": "^1.6",
-        "drupal/core-dev": "^8.7 || ^9",
+        "drupal/core-dev": "^9.2.13",
         "drupal/drupal-extension": "master-dev",
         "drush/drush": "^9.0 || ^10.0",
         "mglaman/drupal-check": "^1.1",


### PR DESCRIPTION
Fix #670  

Bump Drupal core version requirement to 9.2.13 from 9.0.8 and removed support for Drupal 8.

See : https://www.drupal.org/sa-core-2022-003
Fix `Incorrect authorization in Drupal core` and `Improper input validation in Drupal core`