### PR TITLE
Fix deprecated methods in Drupal 8/9 is removed from Drupal 10

### DIFF
--- a/.circleci/RoboFile.php
+++ b/.circleci/RoboFile.php
@@ -487,13 +487,11 @@ class RoboFile extends \Robo\Tasks
         $config->require->{"drupal/core-recommended"} = '^8.9@stable';
         $config->require->{"drupal/core-dev"} = '^8.9';
 
-        // We require Drupal drush and console for some tests.
-        $config->require->{"drupal/console"} = "~1.0";
-
       default:
         break;
     }
-
+    // We require Drupal drush and console for some tests.
+    $config->require->{"drupal/console"} = "~1.0";
     // Add rules for testing apigee_edge_actions.
     $config->require->{"drupal/rules"} = "3.0.0-alpha7";
 

--- a/modules/apigee_edge_actions/modules/apigee_edge_actions_debug/src/EventSubscriber/ApigeeEdgeActionsDebugEventSubscriber.php
+++ b/modules/apigee_edge_actions/modules/apigee_edge_actions_debug/src/EventSubscriber/ApigeeEdgeActionsDebugEventSubscriber.php
@@ -22,7 +22,7 @@ namespace Drupal\apigee_edge_actions_debug\EventSubscriber;
 
 use Drupal\apigee_edge_actions\Event\ApigeeEdgeActionsEventInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -50,7 +50,7 @@ class ApigeeEdgeActionsDebugEventSubscriber implements EventSubscriberInterface 
   /**
    * Responds to rules events.
    *
-   * @param \Symfony\Component\EventDispatcher\Event $event
+   * @param \Symfony\Contracts\EventDispatcher\Event $event
    *   The event object.
    * @param string $event_name
    *   The event name.

--- a/modules/apigee_edge_actions/src/EventSubscriber/AppCredentialEventSubscriber.php
+++ b/modules/apigee_edge_actions/src/EventSubscriber/AppCredentialEventSubscriber.php
@@ -28,7 +28,7 @@ use Drupal\Component\Plugin\Exception\PluginException;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Session\AccountInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -121,7 +121,7 @@ class AppCredentialEventSubscriber implements EventSubscriberInterface {
    *
    * @param string $rules_event_name
    *   The name of the rules event.
-   * @param \Symfony\Component\EventDispatcher\Event $event
+   * @param \Symfony\Contracts\EventDispatcher\Event $event
    *   The api credential event.
    * @param array $api_products
    *   An array of api products.

--- a/modules/apigee_edge_apiproduct_rbac/tests/src/FunctionalJavascript/ApiProductRoleBasedAccessTestBase.php
+++ b/modules/apigee_edge_apiproduct_rbac/tests/src/FunctionalJavascript/ApiProductRoleBasedAccessTestBase.php
@@ -87,7 +87,8 @@ abstract class ApiProductRoleBasedAccessTestBase extends ApiProductAccessTest {
       }
     }
     $this->drupalLogin($this->users[self::USER_WITH_ADMIN_PERM]);
-    $this->drupalPostForm(Url::fromRoute('apigee_edge.settings.developer.api_product_access'), $post, 'Save configuration');
+    $this->drupalGet(Url::fromRoute('apigee_edge.settings.developer.api_product_access'));
+    $this->submitForm($post, 'Save configuration');
     $this->drupalLogout();
   }
 

--- a/modules/apigee_edge_debug/src/Plugin/DebugMessageFormatter/DebugMessageFormatterPluginBase.php
+++ b/modules/apigee_edge_debug/src/Plugin/DebugMessageFormatter/DebugMessageFormatterPluginBase.php
@@ -23,7 +23,7 @@ namespace Drupal\apigee_edge_debug\Plugin\DebugMessageFormatter;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginBase;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use GuzzleHttp\TransferStats;
 use Http\Message\Formatter;
 use Psr\Http\Message\RequestInterface;
@@ -101,7 +101,7 @@ abstract class DebugMessageFormatterPluginBase extends PluginBase implements Con
         $body = preg_replace('/(.*mfa_token=)([^\&]+)(.*)/', '$1***mfa-token***$3', $body);
         $body = preg_replace('/(.*username=)([^\&]+)(.*)/', '$1***username***$3', $body);
         $body = preg_replace('/(.*password=)([^\&]+)(.*)/', '$1***password***$3', $body);
-        $request = $request->withBody(Psr7\stream_for($body));
+        $request = $request->withBody(Utils::streamFor($body));
       }
     }
     if ($this->maskOrganization) {
@@ -139,7 +139,7 @@ abstract class DebugMessageFormatterPluginBase extends PluginBase implements Con
             $value = $masks[$key];
           }
         });
-        $response = $response->withBody(Psr7\stream_for(json_encode((object) $json, JSON_PRETTY_PRINT)));
+        $response = $response->withBody(Utils::streamFor(json_encode((object) $json, JSON_PRETTY_PRINT)));
       }
 
       if ($request->getMethod() === 'POST' && $request->getUri()->getPath() === '/oauth/token') {
@@ -151,7 +151,7 @@ abstract class DebugMessageFormatterPluginBase extends PluginBase implements Con
           if (isset($json['refresh_token'])) {
             $json['refresh_token'] = '***refresh-token***';
           }
-          $response = $response->withBody(Psr7\stream_for(json_encode((object) $json)));
+          $response = $response->withBody(Utils::streamFor(json_encode((object) $json)));
         }
       }
     }

--- a/modules/apigee_edge_teams/apigee_edge_teams.install
+++ b/modules/apigee_edge_teams/apigee_edge_teams.install
@@ -113,7 +113,7 @@ function apigee_edge_teams_update_8702() {
   ];
   /** @var \Drupal\Core\Config\StorageInterface $config_storage */
   $config_storage = \Drupal::service('config.storage');
-  $module_path = drupal_get_path('module', 'apigee_edge_teams');
+  $module_path = \Drupal::service('extension.list.module')->getPath('apigee_edge_teams');
   $source = new FileStorage("$module_path/config/install");
   $new_team_settings = $source->read('apigee_edge_teams.team_settings');
   $team_settings = $config_storage->read('apigee_edge_teams.team_settings');

--- a/modules/apigee_edge_teams/src/Event/TeamInvitationEvent.php
+++ b/modules/apigee_edge_teams/src/Event/TeamInvitationEvent.php
@@ -21,7 +21,7 @@
 namespace Drupal\apigee_edge_teams\Event;
 
 use Drupal\apigee_edge_teams\Entity\TeamInvitationInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Defines the team_invitation event.

--- a/modules/apigee_edge_teams/src/EventSubscriber/TeamInactiveStatusSubscriber.php
+++ b/modules/apigee_edge_teams/src/EventSubscriber/TeamInactiveStatusSubscriber.php
@@ -27,7 +27,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -87,10 +87,10 @@ class TeamInactiveStatusSubscriber implements EventSubscriberInterface {
   /**
    * Display an error message on inactive team routes.
    *
-   * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
    *   The event to process.
    */
-  public function onRespond(FilterResponseEvent $event) {
+  public function onRespond(ResponseEvent $event) {
     if ($this->currentUser->isAnonymous() || !in_array($this->routeMatch->getRouteName(), $this->getDisabledRoutes())) {
       return;
     }

--- a/modules/apigee_edge_teams/src/EventSubscriber/TeamMemberApiProductAccessHandlerCacheReset.php
+++ b/modules/apigee_edge_teams/src/EventSubscriber/TeamMemberApiProductAccessHandlerCacheReset.php
@@ -26,7 +26,7 @@ use Drupal\apigee_edge\Event\AppCredentialDeleteApiProductEvent;
 use Drupal\apigee_edge\Event\AppCredentialDeleteEvent;
 use Drupal\apigee_edge\Event\AppCredentialGenerateEvent;
 use Drupal\apigee_edge_teams\TeamMemberApiProductAccessHandlerInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -67,7 +67,7 @@ final class TeamMemberApiProductAccessHandlerCacheReset implements EventSubscrib
   /**
    * Clears API product entity access cache.
    *
-   * @param \Symfony\Component\EventDispatcher\Event $event
+   * @param \Symfony\Contracts\EventDispatcher\Event $event
    *   Event that triggered this subscriber.
    */
   public function clearApiProductCache(Event $event): void {

--- a/modules/apigee_edge_teams/src/EventSubscriber/TeamStatusWarningSubscriber.php
+++ b/modules/apigee_edge_teams/src/EventSubscriber/TeamStatusWarningSubscriber.php
@@ -29,7 +29,7 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -94,10 +94,10 @@ class TeamStatusWarningSubscriber implements EventSubscriberInterface {
   /**
    * Display's a warning message if team's status is inactive.
    *
-   * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
    *   The event to process.
    */
-  public function onRespond(FilterResponseEvent $event) {
+  public function onRespond(ResponseEvent $event) {
     // Anonymous user's does not have access to these routes.
     if ($this->currentUser->isAuthenticated() && strpos($this->routeMatch->getRouteName(), 'entity.team_app.') === 0) {
       // Team is available in most of the team app routes as a route parameter.

--- a/modules/apigee_edge_teams/tests/src/Functional/AccessTest.php
+++ b/modules/apigee_edge_teams/tests/src/Functional/AccessTest.php
@@ -404,7 +404,8 @@ class AccessTest extends ApigeeEdgeTeamsFunctionalTestBase {
     // Create roles for every team membership level permission.
     $this->drupalLogin($this->rootUser);
     foreach (array_keys(self::TEAM_MEMBER_PERMISSION_MATRIX) as $permission) {
-      $this->drupalPostForm(Url::fromRoute('entity.team_role.add_form'), [
+      $this->drupalGet(Url::fromRoute('entity.team_role.add_form'));
+      $this->submitForm([
         'label' => $permission,
         'id' => $permission,
       ], 'Save');
@@ -677,7 +678,8 @@ class AccessTest extends ApigeeEdgeTeamsFunctionalTestBase {
       $permission_changes["{$role_name}[{$permission}]"] = in_array($permission, $permissions);
     }
 
-    $this->drupalPostForm(Url::fromRoute('apigee_edge_teams.settings.team.permissions'), $permission_changes, 'Save permissions');
+    $this->drupalGet(Url::fromRoute('apigee_edge_teams.settings.team.permissions'));
+    $this->submitForm($permission_changes, 'Save permissions');
     // Dump permission configuration to the HTML output.
     $this->drupalGet(Url::fromRoute('apigee_edge_teams.settings.team.permissions'));
     // Because changes made on the UI therefore _this_ instance of the team role

--- a/modules/apigee_edge_teams/tests/src/Functional/UiTest.php
+++ b/modules/apigee_edge_teams/tests/src/Functional/UiTest.php
@@ -206,7 +206,8 @@ class UiTest extends ApigeeEdgeTeamsFunctionalTestBase {
     ]);
 
     // Team members have access to every team app and membership operations.
-    $this->drupalPostForm(Url::fromRoute('apigee_edge_teams.settings.team.permissions'), [
+    $this->drupalGet(Url::fromRoute('apigee_edge_teams.settings.team.permissions'));
+    $this->submitForm([
       'member[team_manage_members]' => TRUE,
       'member[team_app_create]' => TRUE,
       'member[team_app_update]' => TRUE,

--- a/modules/apigee_edge_teams/tests/src/Kernel/Entity/TeamViewBuilderTest.php
+++ b/modules/apigee_edge_teams/tests/src/Kernel/Entity/TeamViewBuilderTest.php
@@ -98,7 +98,7 @@ class TeamViewBuilderTest extends KernelTestBase {
     $entity_type_manager = $this->container->get('entity_type.manager');
     $build = $entity_type_manager->getViewBuilder(static::ENTITY_TYPE)->view($this->entity);
 
-    static::assertEqual(900, $build['#cache']['max-age']);
+    static::assertEquals(900, $build['#cache']['max-age']);
 
     // Update the cache setting.
     $this->config('apigee_edge_teams.team_settings')
@@ -106,7 +106,7 @@ class TeamViewBuilderTest extends KernelTestBase {
       ->save();
 
     $build = $entity_type_manager->getViewBuilder(static::ENTITY_TYPE)->view($this->entity);
-    static::assertEqual(0, $build['#cache']['max-age']);
+    static::assertEquals(0, $build['#cache']['max-age']);
   }
 
 }

--- a/src/Controller/DeveloperSyncController.php
+++ b/src/Controller/DeveloperSyncController.php
@@ -80,7 +80,7 @@ class DeveloperSyncController extends ControllerBase {
    *   Job tag.
    */
   protected static function generateTag(string $type): string {
-    return "developer_sync_{$type}_" . user_password();
+    return "developer_sync_{$type}_" . \Drupal::service('password_generator')->generate();
   }
 
   /**

--- a/src/Event/AbstractAppCredentialEvent.php
+++ b/src/Event/AbstractAppCredentialEvent.php
@@ -21,7 +21,7 @@
 namespace Drupal\apigee_edge\Event;
 
 use Apigee\Edge\Api\Management\Entity\AppCredentialInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Base class for app credential create, generate and add products events.

--- a/src/Event/EdgeEntityFieldConfigListAlterEvent.php
+++ b/src/Event/EdgeEntityFieldConfigListAlterEvent.php
@@ -20,7 +20,7 @@
 
 namespace Drupal\apigee_edge\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Triggered when an Apigee Edge entity's field config UI gets built.

--- a/src/EventSubscriber/ApiProductEntityAccessCacheReset.php
+++ b/src/EventSubscriber/ApiProductEntityAccessCacheReset.php
@@ -26,7 +26,7 @@ use Drupal\apigee_edge\Event\AppCredentialDeleteApiProductEvent;
 use Drupal\apigee_edge\Event\AppCredentialDeleteEvent;
 use Drupal\apigee_edge\Event\AppCredentialGenerateEvent;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -71,7 +71,7 @@ final class ApiProductEntityAccessCacheReset implements EventSubscriberInterface
   /**
    * Clears API product entity access cache.
    *
-   * @param \Symfony\Component\EventDispatcher\Event $event
+   * @param \Symfony\Contracts\EventDispatcher\Event $event
    *   Event that triggered this subscriber.
    */
   public function clearApiProductCache(Event $event): void {

--- a/src/EventSubscriber/DeveloperStatusWarningSubscriber.php
+++ b/src/EventSubscriber/DeveloperStatusWarningSubscriber.php
@@ -29,7 +29,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -92,10 +92,10 @@ final class DeveloperStatusWarningSubscriber implements EventSubscriberInterface
   /**
    * Display's a warning message if developer's status is inactive.
    *
-   * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
    *   The event to process.
    */
-  public function onRespond(FilterResponseEvent $event) {
+  public function onRespond(ResponseEvent $event) {
     // Anonymous user's does not have access to these routes.
     if ($this->currentUser->isAuthenticated() && strpos($this->routeMatch->getRouteName(), 'entity.developer_app.') === 0) {
       $developer_storage = $this->entityTypeManager->getStorage('developer');

--- a/src/EventSubscriber/EdgeExceptionSubscriber.php
+++ b/src/EventSubscriber/EdgeExceptionSubscriber.php
@@ -118,11 +118,11 @@ final class EdgeExceptionSubscriber implements EventSubscriberInterface {
   /**
    * Displays the Edge connection error page.
    *
-   * @param \Symfony\Component\HttpKernel\Event\ExceptionEvent|\Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent $event
+   * @param \Symfony\Component\HttpKernel\Event\ExceptionEvent $event
    *   The exception event.
    */
-  public function onException($event) {
-    $exception = ($event instanceof ExceptionEvent) ? $event->getThrowable() : $event->getException();
+  public function onException(ExceptionEvent $event) {
+    $exception = $event->getThrowable();
     if ($exception instanceof ApiException || $exception->getPrevious() instanceof ApiException) {
       $context = Error::decodeException($exception);
       $this->logger->critical('@message %function (line %line of %file). <pre>@backtrace_string</pre>', $context);

--- a/src/UserDeveloperConverter.php
+++ b/src/UserDeveloperConverter.php
@@ -180,7 +180,7 @@ class UserDeveloperConverter implements UserDeveloperConverterInterface {
     if (!$user) {
       // Initialize new user object with minimum data.
       $user = $user_storage->create([
-        'pass' => user_password(),
+        'pass' => \Drupal::service('password_generator')->generate(),
       ]);
       // Suppress invalid email validation errors.
       DeveloperEmailUniqueValidator::whitelist($developer->id());

--- a/tests/src/Functional/DeveloperAppApiKeyTest.php
+++ b/tests/src/Functional/DeveloperAppApiKeyTest.php
@@ -255,7 +255,6 @@ class DeveloperAppApiKeyTest extends ApigeeEdgeFunctionalTestBase {
         'product' => $this->apiProducts[0],
       ],
     ]);
-    $this->drupalGet(NULL);
     $this->submitForm([
       'expiry' => 'date',
       'expiry_date' => "07/20/2030",
@@ -315,7 +314,6 @@ class DeveloperAppApiKeyTest extends ApigeeEdgeFunctionalTestBase {
         'product' => $this->apiProducts[1],
       ],
     ]);
-    $this->drupalGet(NULL);
     $this->submitForm([
       'expiry' => 'date',
       'expiry_date' => "07/20/2030",
@@ -361,7 +359,6 @@ class DeveloperAppApiKeyTest extends ApigeeEdgeFunctionalTestBase {
     $this->stack->queueMockResponse('no_content');
 
     $this->queueDeveloperAppResponse($this->developerApp, 200, $credentials);
-    $this->drupalGet(NULL);
     $this->submitForm([], 'Revoke');
     $this->assertSession()->pageTextContains('API key ' . $this->consumer_key . ' revoked from ' . $this->developerApp->getName() . '.');
 
@@ -416,7 +413,6 @@ class DeveloperAppApiKeyTest extends ApigeeEdgeFunctionalTestBase {
     $this->queueDeveloperAppResponse($this->developerApp, 200, $credentials);
     $this->queueDeveloperAppResponse($this->developerApp, 200, $credentials);
     $this->stack->queueMockResponse('no_content');
-    $this->drupalGet(NULL);
     $this->submitForm([], 'Delete');
     $this->assertSession()->pageTextContains('API key ' . $this->consumer_key . ' deleted from ' . $this->developerApp->getName() . '.');
 

--- a/tests/src/Functional/DeveloperAppApiKeyTest.php
+++ b/tests/src/Functional/DeveloperAppApiKeyTest.php
@@ -255,7 +255,8 @@ class DeveloperAppApiKeyTest extends ApigeeEdgeFunctionalTestBase {
         'product' => $this->apiProducts[0],
       ],
     ]);
-    $this->drupalPostForm(NULL, [
+    $this->drupalGet(NULL);
+    $this->submitForm([
       'expiry' => 'date',
       'expiry_date' => "07/20/2030",
     ], 'Confirm');
@@ -314,7 +315,8 @@ class DeveloperAppApiKeyTest extends ApigeeEdgeFunctionalTestBase {
         'product' => $this->apiProducts[1],
       ],
     ]);
-    $this->drupalPostForm(NULL, [
+    $this->drupalGet(NULL);
+    $this->submitForm([
       'expiry' => 'date',
       'expiry_date' => "07/20/2030",
     ], 'Confirm');
@@ -359,7 +361,8 @@ class DeveloperAppApiKeyTest extends ApigeeEdgeFunctionalTestBase {
     $this->stack->queueMockResponse('no_content');
 
     $this->queueDeveloperAppResponse($this->developerApp, 200, $credentials);
-    $this->drupalPostForm(NULL, [], 'Revoke');
+    $this->drupalGet(NULL);
+    $this->submitForm([], 'Revoke');
     $this->assertSession()->pageTextContains('API key ' . $this->consumer_key . ' revoked from ' . $this->developerApp->getName() . '.');
 
     // Access denied for the only active key.
@@ -413,7 +416,8 @@ class DeveloperAppApiKeyTest extends ApigeeEdgeFunctionalTestBase {
     $this->queueDeveloperAppResponse($this->developerApp, 200, $credentials);
     $this->queueDeveloperAppResponse($this->developerApp, 200, $credentials);
     $this->stack->queueMockResponse('no_content');
-    $this->drupalPostForm(NULL, [], 'Delete');
+    $this->drupalGet(NULL);
+    $this->submitForm([], 'Delete');
     $this->assertSession()->pageTextContains('API key ' . $this->consumer_key . ' deleted from ' . $this->developerApp->getName() . '.');
 
     // Access denied for the only active key.

--- a/tests/src/Functional/DeveloperAppFieldTest.php
+++ b/tests/src/Functional/DeveloperAppFieldTest.php
@@ -479,11 +479,11 @@ class DeveloperAppFieldTest extends ApigeeEdgeFunctionalTestBase {
    *   Whether to expect success or a validation error.
    */
   protected function submitBaseFieldConfigForm(bool $description_required = FALSE, bool $callback_url_required = FALSE, bool $expect_success = TRUE) {
-    $this->drupalPostForm(Url::fromRoute('entity.developer_app.field_ui_fields'), [
+    $this->drupalGet(Url::fromRoute('entity.developer_app.field_ui_fields'));
+    $this->submitForm([
       'table[description][required]' => $description_required,
       'table[callbackUrl][required]' => $callback_url_required,
     ], 'Save');
-
     if ($expect_success) {
       $this->assertSession()->pageTextContains('Field settings have been saved successfully.');
     }
@@ -506,7 +506,8 @@ class DeveloperAppFieldTest extends ApigeeEdgeFunctionalTestBase {
     foreach ($region_overrides as $field => $region) {
       $edit["fields[{$field}][region]"] = $region;
     }
-    $this->drupalPostForm(Url::fromRoute('entity.entity_form_display.developer_app.default'), $edit, 'Save');
+    $this->drupalGet(Url::fromRoute('entity.entity_form_display.developer_app.default'));
+    $this->submitForm($edit, 'Save');
 
     if ($expect_success) {
       $this->assertSession()->pageTextContains('Your settings have been saved.');
@@ -528,7 +529,8 @@ class DeveloperAppFieldTest extends ApigeeEdgeFunctionalTestBase {
     foreach ($region_overrides as $field => $region) {
       $edit["fields[{$field}][region]"] = $region;
     }
-    $this->drupalPostForm(Url::fromRoute('entity.entity_view_display.developer_app.default'), $edit, 'Save');
+    $this->drupalGet(Url::fromRoute('entity.entity_view_display.developer_app.default'));
+    $this->submitForm($edit, 'Save');
 
     $this->assertSession()->pageTextContains('Your settings have been saved.');
   }

--- a/tests/src/Functional/DeveloperAppUITest.php
+++ b/tests/src/Functional/DeveloperAppUITest.php
@@ -252,7 +252,8 @@ class DeveloperAppUITest extends ApigeeEdgeFunctionalTestBase {
   public function testCreateAppWithModifiedCredentialLifetime() {
     $url = Url::fromRoute('apigee_edge.settings.developer_app.credentials');
     // Change credential lifetime to 10 days from 0.
-    $this->drupalPostForm($url, [
+    $this->drupalGet($url);
+    $this->submitForm([
       'credential_lifetime' => 10,
     ], 'Save configuration');
     $this->assertSession()->pageTextContains('The configuration options have been saved.');
@@ -270,7 +271,8 @@ class DeveloperAppUITest extends ApigeeEdgeFunctionalTestBase {
     $this->assertSession()->pageTextMatches('/1 week (2|3) days hence/');
 
     // Change credential lifetime to 0 (Never) days from 10.
-    $this->drupalPostForm($url, [
+    $this->drupalGet($url);
+    $this->submitForm([
       'credential_lifetime' => 0,
     ], 'Save configuration');
     $this->assertSession()->pageTextContains('The configuration options have been saved.');
@@ -331,7 +333,10 @@ class DeveloperAppUITest extends ApigeeEdgeFunctionalTestBase {
    * Creates an app with a single product and then removes the product.
    */
   public function testAppCrudSingleProductChange() {
-    $this->submitAdminForm(['display_as_select' => TRUE, 'multiple_products' => FALSE]);
+    $this->submitAdminForm([
+      'display_as_select' => TRUE,
+      'multiple_products' => FALSE
+    ]);
     $this->products[] = $this->createProduct();
 
     $this->assertAppCrud(
@@ -493,7 +498,10 @@ class DeveloperAppUITest extends ApigeeEdgeFunctionalTestBase {
     $product2 = $this->createProduct();
     $this->products[] = $product1;
     $this->products[] = $product2;
-    $app = $this->createDeveloperApp(['name' => $this->randomMachineName(), 'displayName' => $this->randomString()], $this->account, [$product1->id(), $product2->id()]);
+    $app = $this->createDeveloperApp([
+      'name' => $this->randomMachineName(),
+      'displayName' => $this->randomString()
+    ], $this->account, [$product1->id(), $product2->id()]);
     $app_edit_url = $app->toUrl('edit-form-for-developer');
 
     $this->drupalGet($app_settings_url);
@@ -538,11 +546,18 @@ class DeveloperAppUITest extends ApigeeEdgeFunctionalTestBase {
     $this->drupalGet($app_edit_url);
     // Also test field description.
     $this->assertSession()->pageTextContains($description);
-    $this->drupalPostForm($app_edit_url, [], 'Save');
+    $this->drupalGet($app_edit_url);
+    $this->submitForm([], 'Save');
     $this->assertSession()->pageTextContains("The URL {$callback_url} is not valid.");
-    $this->drupalPostForm($app_edit_url, ['callbackUrl[0][value]' => 'http://example.com'], 'Save');
+    $this->drupalGet($app_edit_url);
+    $this->submitForm([
+      'callbackUrl[0][value]' => 'http://example.com'
+    ], 'Save');
     $this->assertSession()->pageTextContains("Callback URL field is not in the right format.");
-    $this->drupalPostForm($app_edit_url, ['callbackUrl[0][value]' => 'https://example.com'], 'Save');
+    $this->drupalGet($app_edit_url);
+    $this->submitForm([
+      'callbackUrl[0][value]' => 'https://example.com'
+    ], 'Save');
     $this->assertSession()->pageTextContains('App has been successfully updated.');
     $this->assertSession()->pageTextContains('https://example.com');
   }
@@ -582,8 +597,14 @@ class DeveloperAppUITest extends ApigeeEdgeFunctionalTestBase {
     $this->drupalGet($app_edit_form_for_developer_url);
     $this->assertSession()->fieldValueEquals('callbackUrl[0][value]', $callback_url);
 
-    $this->drupalPostForm(Url::fromRoute('entity.entity_view_display.developer_app.default'), ['fields[callbackUrl][region]' => 'hidden'], 'Save');
-    $this->drupalPostForm(Url::fromRoute('entity.entity_form_display.developer_app.default'), ['fields[callbackUrl][region]' => 'hidden'], 'Save');
+    $this->drupalGet(Url::fromRoute('entity.entity_view_display.developer_app.default'));
+    $this->submitForm([
+      'fields[callbackUrl][region]' => 'hidden'
+    ], 'Save');
+    $this->drupalGet(Url::fromRoute('entity.entity_form_display.developer_app.default'));
+    $this->submitForm([
+      'fields[callbackUrl][region]' => 'hidden'
+    ], 'Save');
 
     $this->drupalGet($app_view_url);
     $this->assertSession()->pageTextNotContains($callback_url_warning_msg);

--- a/tests/src/Functional/DeveloperAppUITest.php
+++ b/tests/src/Functional/DeveloperAppUITest.php
@@ -107,7 +107,7 @@ class DeveloperAppUITest extends ApigeeEdgeFunctionalTestBase {
     $this->assertSession()->elementContains('css', 'title', $type->getPluralLabel());
 
     // Assert link to "Apps" is changed.
-    $this->assertLink($type->getPluralLabel());
+    $this->assertSession()->linkExists($type->getPluralLabel());
   }
 
   /**

--- a/tests/src/Functional/DeveloperAppUITestTrait.php
+++ b/tests/src/Functional/DeveloperAppUITestTrait.php
@@ -99,7 +99,8 @@ trait DeveloperAppUITestTrait {
     $this->config('apigee_edge.common_app_settings')
       ->set('multiple_products', $multiple_products)
       ->save();
-    $this->drupalPostForm($url, $data, 'Save configuration');
+    $this->drupalGet($url);
+    $this->submitForm($data, 'Save configuration');
   }
 
   /**
@@ -115,14 +116,11 @@ trait DeveloperAppUITestTrait {
       $account = $this->account;
     }
 
-    $this->drupalPostForm(
-      Url::fromRoute(
+    $this->drupalGet(Url::fromRoute(
         'entity.developer_app.add_form_for_developer', [
           'user' => $account->id(),
-        ]),
-      $data,
-      'Add app'
-    );
+        ]));
+    $this->submitForm($data, 'Add app');
   }
 
   /**
@@ -140,7 +138,8 @@ trait DeveloperAppUITestTrait {
       $account = $this->account;
     }
 
-    $this->drupalPostForm("/user/{$account->id()}/apps/{$app_name}/edit", $data, 'Save');
+    $this->drupalGet("/user/{$account->id()}/apps/{$app_name}/edit");
+    $this->submitForm($data, 'Save');
   }
 
   /**

--- a/tests/src/Functional/DeveloperTest.php
+++ b/tests/src/Functional/DeveloperTest.php
@@ -177,7 +177,8 @@ class DeveloperTest extends ApigeeEdgeFunctionalTestBase {
 
     // Try to register with incorrect API credentials.
     $this->invalidateKey();
-    $this->drupalPostForm(Url::fromRoute('user.register'), $formdata, 'Create new account');
+    $this->drupalGet(Url::fromRoute('user.register'));
+    $this->submitForm($formdata, 'Create new account');
     $this->assertSession()->pageTextContains(self::USER_REGISTRATION_UNAVAILABLE);
 
     // Try to register with correct API credentials.
@@ -205,7 +206,8 @@ class DeveloperTest extends ApigeeEdgeFunctionalTestBase {
     $this->stack->queueMockResponse('get_not_found');
     $this->queueDeveloperResponse($account, 201);
 
-    $this->drupalPostForm(Url::fromRoute('user.register'), $formdata, 'Create new account');
+    $this->drupalGet(Url::fromRoute('user.register'));
+    $this->submitForm($formdata, 'Create new account');
 
     /** @var \Drupal\user\Entity\User $account */
     $account = user_load_by_mail($test_user['email']);
@@ -226,7 +228,8 @@ class DeveloperTest extends ApigeeEdgeFunctionalTestBase {
     $this->assertEqual($this->developerRegistered->getAttributeValue('IS_MOCK_CLIENT'), !$this->integration_enabled);
 
     $this->drupalLogin($this->rootUser);
-    $this->drupalPostForm(Url::fromRoute('entity.user.edit_form', ['user' => $account->id()]), ['status' => '1'], 'Save');
+    $this->drupalGet(Url::fromRoute('entity.user.edit_form', ['user' => $account->id()]));
+    $this->submitForm(['status' => '1'], 'Save');
 
     // Ensure status change was saved.
     $this->entityTypeManager->getStorage('user')->resetCache();
@@ -275,7 +278,8 @@ class DeveloperTest extends ApigeeEdgeFunctionalTestBase {
 
     // Try to register with incorrect API credentials.
     $this->invalidateKey();
-    $this->drupalPostForm(Url::fromRoute('user.admin_create'), $formdata, 'Create new account');
+    $this->drupalGet(Url::fromRoute('user.admin_create'));
+    $this->submitForm($formdata, 'Create new account');
     $this->assertSession()->pageTextContains(self::USER_REGISTRATION_UNAVAILABLE);
 
     // Try to register with correct API credentials.
@@ -297,7 +301,8 @@ class DeveloperTest extends ApigeeEdgeFunctionalTestBase {
     $this->stack->queueMockResponse('get_not_found');
     $this->queueDeveloperResponse($account, 201);
 
-    $this->drupalPostForm(Url::fromRoute('user.admin_create'), $formdata, 'Create new account');
+    $this->drupalGet(Url::fromRoute('user.admin_create'));
+    $this->submitForm($formdata, 'Create new account');
 
     /** @var \Drupal\user\Entity\User $account */
     $account = user_load_by_mail($test_user['email']);
@@ -325,7 +330,8 @@ class DeveloperTest extends ApigeeEdgeFunctionalTestBase {
     $formdata['last_name[0][value]'] = $test_user['last_name'];
     $formdata['status'] = $test_user['status'];
 
-    $this->drupalPostForm(Url::fromRoute('entity.user.edit_form', ['user' => $account->id()]), $formdata, 'Save');
+    $this->drupalGet(Url::fromRoute('entity.user.edit_form', ['user' => $account->id()]));
+    $this->submitForm($formdata, 'Save');
 
     // Flush user entity cache to ensure the updated user gets loaded.
     // (Especially in apigee_edge_developer_app_storage_load().)
@@ -373,16 +379,19 @@ class DeveloperTest extends ApigeeEdgeFunctionalTestBase {
       'status' => $test_user['status'],
     ];
 
-    $this->drupalPostForm(Url::fromRoute('entity.user.edit_form', ['user' => $account->id()]), $formdata, 'Save');
+    $this->drupalGet(Url::fromRoute('entity.user.edit_form', ['user' => $account->id()]));
+    $this->submitForm($formdata, 'Save');
 
     $formdata = [
       'user_cancel_method' => 'user_cancel_block',
     ];
     if (floatval(\Drupal::VERSION) >= 9.3) {
-      $this->drupalPostForm($account->toUrl('cancel-form')->toString(), $formdata, 'Confirm');
+      $this->drupalGet($account->toUrl('cancel-form')->toString());
+      $this->submitForm($formdata, 'Confirm');
     }
     else {
-      $this->drupalPostForm($account->toUrl('cancel-form')->toString(), $formdata, 'Cancel account');
+      $this->drupalGet($account->toUrl('cancel-form')->toString());
+      $this->submitForm($formdata, 'Cancel account');
     }
 
     $this->developerCreatedByAdmin = $this->developerStorage->load($test_user['email']);
@@ -400,16 +409,19 @@ class DeveloperTest extends ApigeeEdgeFunctionalTestBase {
       'pass[pass2]' => $test_user['password'],
       'status' => $test_user['status'],
     ];
-    $this->drupalPostForm(Url::fromRoute('entity.user.edit_form', ['user' => $account->id()]), $formdata, 'Save');
+    $this->drupalGet(Url::fromRoute('entity.user.edit_form', ['user' => $account->id()]));
+    $this->submitForm($formdata, 'Save');
 
     $formdata = [
       'user_cancel_method' => 'user_cancel_block_unpublish',
     ];
     if (floatval(\Drupal::VERSION) >= 9.3) {
-      $this->drupalPostForm($account->toUrl('cancel-form')->toString(), $formdata, 'Confirm');
+      $this->drupalGet($account->toUrl('cancel-form')->toString());
+      $this->submitForm($formdata, 'Confirm');
     }
     else {
-      $this->drupalPostForm($account->toUrl('cancel-form')->toString(), $formdata, 'Cancel account');
+      $this->drupalGet($account->toUrl('cancel-form')->toString());
+      $this->submitForm($formdata, 'Cancel account');
     }
 
     $this->developerCreatedByAdmin = $this->developerStorage->load($test_user['email']);
@@ -422,10 +434,12 @@ class DeveloperTest extends ApigeeEdgeFunctionalTestBase {
     ];
 
     if (floatval(\Drupal::VERSION) >= 9.3) {
-      $this->drupalPostForm($account->toUrl('cancel-form')->toString(), $formdata, 'Confirm');
+      $this->drupalGet($account->toUrl('cancel-form')->toString());
+      $this->submitForm($formdata, 'Confirm');
     }
     else {
-      $this->drupalPostForm($account->toUrl('cancel-form')->toString(), $formdata, 'Cancel account');
+      $this->drupalGet($account->toUrl('cancel-form')->toString());
+      $this->submitForm($formdata, 'Cancel account');
     }
 
     // Ensure that entity static cache is also invalidated in this scope

--- a/tests/src/Functional/DeveloperTest.php
+++ b/tests/src/Functional/DeveloperTest.php
@@ -225,7 +225,7 @@ class DeveloperTest extends ApigeeEdgeFunctionalTestBase {
     $this->assertEquals($this->developerRegistered->getStatus(), DeveloperInterface::STATUS_INACTIVE);
 
     // Attribute is set by mock twig template.
-    $this->assertEqual($this->developerRegistered->getAttributeValue('IS_MOCK_CLIENT'), !$this->integration_enabled);
+    $this->assertEquals($this->developerRegistered->getAttributeValue('IS_MOCK_CLIENT'), !$this->integration_enabled);
 
     $this->drupalLogin($this->rootUser);
     $this->drupalGet(Url::fromRoute('entity.user.edit_form', ['user' => $account->id()]));
@@ -262,7 +262,7 @@ class DeveloperTest extends ApigeeEdgeFunctionalTestBase {
       'first_name' => $this->getRandomGenerator()->word(16),
       'last_name' => $this->getRandomGenerator()->word(16),
       'username' => $this->randomMachineName(),
-      'password' => user_password(),
+      'password' => \Drupal::service('password_generator')->generate(),
       'status' => '0',
     ];
 

--- a/tests/src/Functional/EmailTest.php
+++ b/tests/src/Functional/EmailTest.php
@@ -102,14 +102,16 @@ class EmailTest extends ApigeeEdgeFunctionalTestBase {
     // Stack developer response.
     $this->queueDeveloperResponseFromDeveloper($this->developer);
 
-    $this->drupalPostForm(Url::fromRoute('entity.user.edit_form', ['user' => $account->id()]), [
+    $this->drupalGet(Url::fromRoute('entity.user.edit_form', ['user' => $account->id()]));
+    $this->submitForm([
       'mail' => $this->developer->getEmail(),
       'current_pass' => $account->passRaw,
     ], 'Save');
     $this->assertSession()->pageTextContains('This email address already exists in our system. You can register a new account if you would like to use it on the Developer Portal.');
 
     $this->drupalLogin($this->rootUser);
-    $this->drupalPostForm(Url::fromRoute('entity.user.edit_form', ['user' => $account->id()]), [
+    $this->drupalGet(Url::fromRoute('entity.user.edit_form', ['user' => $account->id()]));
+    $this->submitForm([
       'mail' => $this->developer->getEmail(),
     ], 'Save');
     $this->assertSession()->pageTextContains('This email address already belongs to a developer on Apigee Edge.');
@@ -131,25 +133,29 @@ class EmailTest extends ApigeeEdgeFunctionalTestBase {
     // Display only an error message to the user.
     $this->drupalLogin($this->rootUser);
     $error_message = trim($this->getRandomGenerator()->paragraphs(1));
-    $this->drupalPostForm($developer_settings_path, [
+    $this->drupalGet($developer_settings_path);
+    $this->submitForm([
       'verification_action' => DeveloperSettingsForm::VERIFICATION_ACTION_DISPLAY_ERROR_ONLY,
       'display_only_error_message_content[value]' => $error_message,
     ], 'Save configuration');
     $this->assertSession()->pageTextContains('The configuration options have been saved.');
     $this->drupalLogout();
 
-    $this->drupalPostForm($user_register_path, $edit, 'Create new account');
+    $this->drupalGet($user_register_path);
+    $this->submitForm($edit, 'Create new account');
     $this->assertSession()->pageTextContains($error_message);
 
     // Display an error message and send a verification email to the user.
     $this->drupalLogin($this->rootUser);
-    $this->drupalPostForm($developer_settings_path, [
+    $this->drupalGet($developer_settings_path);
+    $this->submitForm([
       'verification_action' => DeveloperSettingsForm::VERIFICATION_ACTION_VERIFY_EMAIL,
     ], 'Save configuration');
     $this->assertSession()->pageTextContains('The configuration options have been saved.');
     $this->drupalLogout();
 
-    $this->drupalPostForm($user_register_path, $edit, 'Create new account');
+    $this->drupalGet($user_register_path);
+    $this->submitForm($edit, 'Create new account');
     $this->assertSession()->pageTextContains("This email address already exists in our system. We have sent you an verification email to {$this->developer->getEmail()}.");
 
     $this->assertMail('id', 'apigee_edge_developer_email_verification');
@@ -160,7 +166,8 @@ class EmailTest extends ApigeeEdgeFunctionalTestBase {
     preg_match('%https?://[^/]+/user/register\?[^/\s]+%', $mail['body'], $matches);
     $link = $matches[0];
 
-    $this->drupalPostForm($link, $edit, 'Create new account');
+    $this->drupalGet($link);
+    $this->submitForm($edit, 'Create new account');
     $this->assertSession()->pageTextContains('A welcome message with further instructions has been sent to your email address.');
   }
 

--- a/tests/src/Functional/ErrorHandlerTest.php
+++ b/tests/src/Functional/ErrorHandlerTest.php
@@ -71,7 +71,8 @@ class ErrorHandlerTest extends ApigeeEdgeFunctionalTestBase {
   public function testErrorPages() {
     $this->drupalLogin($this->rootUser);
     $errorPageTitle = $this->getRandomGenerator()->word(16);
-    $this->drupalPostForm(Url::fromRoute('apigee_edge.settings.error_page'), [
+    $this->drupalGet(Url::fromRoute('apigee_edge.settings.error_page'));
+    $this->submitForm([
       'error_page_title' => $errorPageTitle,
     ], 'Save configuration');
     $this->assertSession()->pageTextContains('The configuration options have been saved.');

--- a/tests/src/FunctionalJavascript/CacheTest.php
+++ b/tests/src/FunctionalJavascript/CacheTest.php
@@ -208,7 +208,8 @@ class CacheTest extends ApigeeEdgeFunctionalJavascriptTestBase {
       "values:developer_app:{$this->developerApp->id()}",
       "app_names:developer_app:{$this->developer->uuid()}:{$this->developerApp->getName()}",
     ], function () {
-      $this->drupalPostForm(Url::fromRoute('entity.user.edit_form', ['user' => $this->account->id()]), [
+      $this->drupalGet(Url::fromRoute('entity.user.edit_form', ['user' => $this->account->id()]));
+      $this->submitForm([
         'first_name[0][value]' => $this->randomMachineName(),
         'last_name[0][value]' => $this->randomMachineName(),
       ], 'Save');

--- a/tests/src/FunctionalJavascript/DeveloperAppUITest.php
+++ b/tests/src/FunctionalJavascript/DeveloperAppUITest.php
@@ -94,18 +94,21 @@ class DeveloperAppUITest extends ApigeeEdgeFunctionalJavascriptTestBase {
     $app_edit_url = $app->toUrl('edit-form-for-developer');
 
     $this->drupalGet($app_edit_url);
-    $this->drupalPostForm($app_edit_url, [], 'Save');
+    $this->drupalGet($app_edit_url);
+    $this->submitForm([], 'Save');
     $this->createScreenshot('DeveloperAppUITest-' . __FUNCTION__);
     $this->assertFalse($isValidInput());
     $checkValidationMessage('Please enter a URL.');
-    $this->drupalPostForm($app_edit_url, ['callbackUrl[0][value]' => 'http://example.com'], 'Save');
+    $this->drupalGet($app_edit_url);
+    $this->submitForm(['callbackUrl[0][value]' => 'http://example.com'], 'Save');
     $this->createScreenshot('DeveloperAppUITest-' . __FUNCTION__);
     $this->assertFalse($isValidInput());
     // The format in Firefox is different, it is only one line:
     // "Please match the requested format: {$pattern_description}.".
     $checkValidationMessage('Please match the requested format.');
     $this->assertEquals($pattern_error_message, $this->getSession()->evaluateScript('document.getElementById("edit-callbackurl-0-value").title'));
-    $this->drupalPostForm($app_edit_url, ['callbackUrl[0][value]' => 'https://example.com'], 'Save');
+    $this->drupalGet($app_edit_url);
+    $this->submitForm(['callbackUrl[0][value]' => 'https://example.com'], 'Save');
     $this->assertSession()->pageTextContains('App has been successfully updated.');
     $this->assertSession()->pageTextContains('https://example.com');
   }

--- a/tests/src/FunctionalJavascript/Form/AuthenticationFormJsTest.php
+++ b/tests/src/FunctionalJavascript/Form/AuthenticationFormJsTest.php
@@ -329,7 +329,7 @@ class AuthenticationFormJsTest extends ApigeeEdgeFunctionalJavascriptTestBase {
     $web_assert->elementNotExists('css', 'details[data-drupal-selector="edit-debug"]');
     // Make sure the token file has not been left behind.
     $token_file_path = $this->container->get('file_system')->realpath(OauthTokenFileStorage::DEFAULT_DIRECTORY . '/oauth.dat');
-    $this->assertFileNotExists($token_file_path);
+    $this->assertFileDoesNotExist($token_file_path);
 
     // Switch back to basic auth.
     $this->cssSelect('select[name="key_input_settings[auth_type]"]')[0]->setValue('basic');

--- a/tests/src/Kernel/Entity/AppWarningsCheckerTest.php
+++ b/tests/src/Kernel/Entity/AppWarningsCheckerTest.php
@@ -375,7 +375,7 @@ class AppWarningsCheckerTest extends KernelTestBase {
     // One warning for approved app with all credentials revoked.
     $warnings = array_filter($app_warnings_checker->getWarnings($this->approvedAppWithAllRevokedCredential));
     $this->assertCount(1, $warnings);
-    $this->assertEqual('No valid credentials associated with this app.', (string) $warnings['revokedCred']);
+    $this->assertEquals('No valid credentials associated with this app.', (string) $warnings['revokedCred']);
 
     // No warnings to revoked app with revoked credentials.
     $this->assertEmpty(array_filter($app_warnings_checker->getWarnings($this->revokedAppWithRevokedCredential)));
@@ -383,12 +383,12 @@ class AppWarningsCheckerTest extends KernelTestBase {
     // One warning for approved app with expired credentials.
     $warnings = array_filter($app_warnings_checker->getWarnings($this->approvedAppWithExpiredCredential));
     $this->assertCount(1, $warnings);
-    $this->assertEqual('At least one of the credentials associated with this app is expired.', (string) $warnings['expiredCred']);
+    $this->assertEquals('At least one of the credentials associated with this app is expired.', (string) $warnings['expiredCred']);
 
     // One warning for revoked app with expired credentials.
     $warnings = array_filter($app_warnings_checker->getWarnings($this->revokedAppWithExpiredCredential));
     $this->assertCount(1, $warnings);
-    $this->assertEqual('At least one of the credentials associated with this app is expired.', (string) $warnings['expiredCred']);
+    $this->assertEquals('At least one of the credentials associated with this app is expired.', (string) $warnings['expiredCred']);
   }
 
 }

--- a/tests/src/Kernel/Entity/ListBuilder/AppListBuilderTest.php
+++ b/tests/src/Kernel/Entity/ListBuilder/AppListBuilderTest.php
@@ -368,7 +368,7 @@ class AppListBuilderTest extends KernelTestBase {
     // One warning for approved app with all credentials revoked.
     $warnings = $build['table']['#rows'][$this->getStatusRowKey($this->approvedAppWithAllRevokedCredential)]['data'];
     $this->assertCount(1, $warnings);
-    $this->assertEqual('No valid credentials associated with this app.', (string) $warnings['info']['data']['#items'][0]);
+    $this->assertEquals('No valid credentials associated with this app.', (string) $warnings['info']['data']['#items'][0]);
 
     // No warnings to revoked app with revoked credentials.
     $this->assertEmpty($build['table']['#rows'][$this->getStatusRowKey($this->revokedAppWithRevokedCredential)]['data']);
@@ -376,7 +376,7 @@ class AppListBuilderTest extends KernelTestBase {
     // One warning for approved app with expired credentials.
     $warnings = $build['table']['#rows'][$this->getStatusRowKey($this->approvedAppWithExpiredCredential)]['data'];
     $this->assertCount(1, $warnings);
-    $this->assertEqual('At least one of the credentials associated with this app is expired.', (string) $warnings['info']['data']['#items'][0]);
+    $this->assertEquals('At least one of the credentials associated with this app is expired.', (string) $warnings['info']['data']['#items'][0]);
 
     // No warnings for revoked app with expired credentials.
     // Note: \Drupal\apigee_edge\Entity\AppWarningsChecker::getWarnings will

--- a/tests/src/Kernel/Entity/ListBuilder/EntityListBuilderTest.php
+++ b/tests/src/Kernel/Entity/ListBuilder/EntityListBuilderTest.php
@@ -187,7 +187,7 @@ class EntityListBuilderTest extends KernelTestBase {
     $this->queueDeveloperResponse($this->account);
     /** @var \Drupal\Core\Render\HtmlResponse $response */
     $response = $this->container->get('http_kernel')->handle($request);
-    $this->assertEqual($response->getCacheableMetadata()->getCacheMaxAge(), 900);
+    $this->assertEquals($response->getCacheableMetadata()->getCacheMaxAge(), 900);
 
     // Update the config.
     $config = $this->config('apigee_edge.' . static::ENTITY_TYPE . '_settings');
@@ -202,7 +202,7 @@ class EntityListBuilderTest extends KernelTestBase {
     $this->queueDeveloperResponse($this->account);
     /** @var \Drupal\Core\Render\HtmlResponse $response */
     $response = $this->container->get('http_kernel')->handle($request);
-    $this->assertEqual($response->getCacheableMetadata()->getCacheMaxAge(), 100);
+    $this->assertEquals($response->getCacheableMetadata()->getCacheMaxAge(), 100);
   }
 
 }

--- a/tests/src/Kernel/TestFrameworkKernelTest.php
+++ b/tests/src/Kernel/TestFrameworkKernelTest.php
@@ -129,7 +129,7 @@ class TestFrameworkKernelTest extends KernelTestBase {
     $org_controller = $this->container->get('apigee_edge.controller.organization');
     $org = $org_controller->load($org_name);
 
-    $this->assertEqual($org->getName(), $org_name);
+    $this->assertEquals($org->getName(), $org_name);
   }
 
   /**
@@ -157,9 +157,9 @@ class TestFrameworkKernelTest extends KernelTestBase {
     /** @var \Drupal\apigee_edge\Entity\Developer $developer */
     $developer = $developerStorage->load($test_user['mail']);
 
-    $this->assertEqual($developer->getEmail(), $test_user['mail']);
+    $this->assertEquals($developer->getEmail(), $test_user['mail']);
     // Attribute is set by mock twig template.
-    $this->assertEqual($developer->getAttributeValue('IS_MOCK_CLIENT'), 1);
+    $this->assertEquals($developer->getAttributeValue('IS_MOCK_CLIENT'), 1);
   }
 
   /**
@@ -201,7 +201,7 @@ class TestFrameworkKernelTest extends KernelTestBase {
     $this->queueDeveloperResponseFromDeveloper($developer);
     $loaded_developer = $developerStorage->load($developer->getEmail());
     $this->assertInstanceOf(Developer::class, $loaded_developer);
-    $this->assertEqual($loaded_developer->getEmail(), $developer->getEmail());
+    $this->assertEquals($loaded_developer->getEmail(), $developer->getEmail());
 
     // This line is what actually tests that the mock is not used since the mock template sets this attribute.
     $this->assertEmpty($developer->getAttributeValue('IS_MOCK_CLIENT'));
@@ -260,9 +260,9 @@ class TestFrameworkKernelTest extends KernelTestBase {
     /** @var \Drupal\apigee_edge\Entity\Developer $developer */
     $developer = $developerStorage->load($test_user['mail']);
 
-    $this->assertEqual($developer->getEmail(), $test_user['mail']);
+    $this->assertEquals($developer->getEmail(), $test_user['mail']);
     // Attribute is set by mock twig template.
-    $this->assertEqual($developer->getAttributeValue('IS_MOCK_CLIENT'), 1);
+    $this->assertEquals($developer->getAttributeValue('IS_MOCK_CLIENT'), 1);
   }
 
   /**

--- a/tests/src/Traits/ApigeeEdgeFunctionalTestTrait.php
+++ b/tests/src/Traits/ApigeeEdgeFunctionalTestTrait.php
@@ -100,7 +100,7 @@ trait ApigeeEdgeFunctionalTestTrait {
       'first_name' => $this->randomMachineName(),
       'last_name' => $this->randomMachineName(),
       'name' => $this->randomMachineName(),
-      'pass' => user_password(),
+      'pass' => \Drupal::service('password_generator')->generate(),
       'status' => $status,
     ];
     if ($rid) {

--- a/tests/src/Traits/EntityUtilsTrait.php
+++ b/tests/src/Traits/EntityUtilsTrait.php
@@ -37,7 +37,8 @@ trait EntityUtilsTrait {
   protected function changeEntityAliasesAndValidate(string $entity_type_id, string $entity_settings_route_name) {
     $singular = $this->getRandomGenerator()->word(8);
     $plural = $this->getRandomGenerator()->word(8);
-    $this->drupalPostForm(Url::fromRoute($entity_settings_route_name), [
+    $this->drupalGet(Url::fromRoute($entity_settings_route_name));
+    $this->submitForm([
       'entity_label_singular' => $singular,
       'entity_label_plural' => $plural,
     ], 'Save configuration');

--- a/tests/src/Unit/Entity/ApiProductTest.php
+++ b/tests/src/Unit/Entity/ApiProductTest.php
@@ -51,7 +51,7 @@ class ApiProductTest extends UnitTestCase {
     $proxies_expected = ['proxy1', 'proxy2'];
     $this->apiProduct->setProxies(...$proxies_expected);
     $proxies_actual = $this->apiProduct->getProxies();
-    $this->assertArrayEquals($proxies_expected, $proxies_actual);
+    $this->assertEquals($proxies_expected, $proxies_actual);
 
   }
 
@@ -62,7 +62,7 @@ class ApiProductTest extends UnitTestCase {
     $scopes_expected = ['scope1', 'scope2'];
     $this->apiProduct->setScopes(...$scopes_expected);
     $scopes_actual = $this->apiProduct->getScopes();
-    $this->assertArrayEquals($scopes_expected, $scopes_actual);
+    $this->assertEquals($scopes_expected, $scopes_actual);
 
   }
 
@@ -73,7 +73,7 @@ class ApiProductTest extends UnitTestCase {
     $environments_expected = ['environment1', 'environment2'];
     $this->apiProduct->setEnvironments(...$environments_expected);
     $environments_actual = $this->apiProduct->getEnvironments();
-    $this->assertArrayEquals($environments_expected, $environments_actual);
+    $this->assertEquals($environments_expected, $environments_actual);
   }
 
 }

--- a/tests/src/Unit/EventSubscriber/EdgeExceptionSubscriberTest.php
+++ b/tests/src/Unit/EventSubscriber/EdgeExceptionSubscriberTest.php
@@ -33,7 +33,7 @@ use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 
 /**
  * Test EdgeExceptionSubscriber.
@@ -133,17 +133,10 @@ class EdgeExceptionSubscriberTest extends UnitTestCase {
     $this->routeMatch = $this->prophesize(RouteMatchInterface::class);
 
     // Drupal 9 / Symfony 4.x and up.
-    if (class_exists('\Symfony\Component\HttpKernel\Event\ExceptionEvent')) {
-      $this->getResponseForExceptionEvent = $this->prophesize('\Symfony\Component\HttpKernel\Event\ExceptionEvent');
-      $this->getResponseForExceptionEvent->getThrowable()
-        ->willReturn($this->exception);
-    }
-    // Drupal 8.
-    else {
-      $this->getResponseForExceptionEvent = $this->prophesize(GetResponseForExceptionEvent::class);
-      $this->getResponseForExceptionEvent->getException()
-        ->willReturn($this->exception);
-    }
+    $this->getResponseForExceptionEvent = $this->prophesize(ExceptionEvent::class);
+    $this->getResponseForExceptionEvent->getThrowable()
+      ->willReturn($this->exception);
+
     $this->getResponseForExceptionEvent->getRequest()
       ->willReturn(new Request());
     $this->getResponseForExceptionEvent->setResponse(Argument::any())


### PR DESCRIPTION
Fix #672 

Fixed deprecated methods `drupalPostForm()`, `assertEqual()`, `user_password()`, `assertArrayEquals()` and `assertFileNotExists()` which is removed from Drupal 10.0.0