### PR TITLE
PHP 8.1 : Fix for deprecated notice for FieldableEdgeEntityBase::getIterator()

### DIFF
--- a/src/Entity/FieldableEdgeEntityBase.php
+++ b/src/Entity/FieldableEdgeEntityBase.php
@@ -532,7 +532,7 @@ abstract class FieldableEdgeEntityBase extends EdgeEntityBase implements Fieldab
   /**
    * {@inheritdoc}
    */
-  public function getIterator() {
+  public function getIterator(): \Traversable {
     return new \ArrayIterator($this->getFields());
   }
 


### PR DESCRIPTION
Fixes for #692 