### PR TITLE
Fix for Deprecated function: json_decode(): Passing null to parameter #1

### DIFF
--- a/src/Plugin/EdgeKeyTypeBase.php
+++ b/src/Plugin/EdgeKeyTypeBase.php
@@ -43,6 +43,7 @@ abstract class EdgeKeyTypeBase extends KeyTypeBase implements EdgeKeyTypeInterfa
    * {@inheritdoc}
    */
   public function unserialize($value) {
+    $value = $value ?? '';
     return Json::decode($value);
   }
 


### PR DESCRIPTION
Closes #694 