### PR TITLE
Access checking must not happen in the view layer

### DIFF
--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -1064,9 +1064,6 @@ function template_preprocess_app_credential_product_list(array &$variables) {
   $variables['#api_product_entities'] = $allProducts = ApiProduct::loadMultiple($cred_product_ids);
   $variables += ['content' => []];
   foreach ($cred_products as $product) {
-    if (!$allProducts[$product->getApiproduct()]->access('view label')) {
-      continue;
-    }
     $value = '';
     $indicator_status = '';
     switch ($product->getStatus()) {


### PR DESCRIPTION
In addition, API products that are assigned to an app must be always displayed.

(They are also visible on the app edit form even if the current app owner does not have access to them.)