### PR TITLE
Fix error thrown when inviting team member

### DIFF
--- a/modules/apigee_edge_teams/src/TeamInvitationNotifierEmail.php
+++ b/modules/apigee_edge_teams/src/TeamInvitationNotifierEmail.php
@@ -77,7 +77,7 @@ class TeamInvitationNotifierEmail implements TeamInvitationNotifierInterface {
 
     // Send email notification.
     $message = $this->mailManager->mail('apigee_edge_teams', 'team_invitation_created', $email, $langcode, $params);
-    return $message['result'];
+    return $message['result'] ?? FALSE;
   }
 
 }


### PR DESCRIPTION
Closes #715 

This error is thrown when the mail response returns the NULL value.
Reference : https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Mail%21MailManager.php/class/MailManager/8.2.x#:~:text=send%27%5D))%20%7B%0A%20%20%20%20%20%20%20%20%24-,message,-%5B%27result%27