### PR TITLE
Fix Drush si profile installation error due to missing Apigee configuration

### DIFF
--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -1293,14 +1293,16 @@ function apigee_edge_user_presave(UserInterface $account) {
   // :\"basic\",\"organization\":\"ORGANIZATION\",\"username\":\"USERNAME\"
   // ,\"password\":\"PASSWORD"}' --key-type=apigee_auth -y`
   // to create a key after drush si.
-  $state = \Drupal::state();
-  if ($state->get('is_non_interactive')) {
-    // Clear the state.
-    $state->set('is_non_interactive', FALSE);
+  /** @var \Drupal\apigee_edge\SDKConnectorInterface $sdk_connector */
+  $sdk_connector = \Drupal::service('apigee_edge.sdk_connector');
+  try {
+    $sdk_connector->testConnection();
+  }
+  catch (\Exception $exception) {
     $context = [
       '@developer' => $account->getEmail()
     ];
-    $logger->warning("Could not create developer entity: @developer on Apigee Edge/X. Missing Apigee server configuration.", $context);
+    $logger->warning("Could not create developer entity: @developer on Apigee Edge/X, because there was no connection to Apigee Edge.", $context);
     return;
   }
 

--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -1283,12 +1283,32 @@ function apigee_edge_user_presave(UserInterface $account) {
     return;
   }
 
+  /** @var \Drupal\Core\Logger\LoggerChannelInterface $logger */
+  $logger = \Drupal::service('logger.channel.apigee_edge');
+
+  // If installation is through drush si, then avoid creating developer
+  // entity on Apigee because Apigee config is empty.
+  // since drush si cannot set default values for the form.
+  // Use `drush key-save apigee_edge_connection_default '{\"auth_type\"
+  // :\"basic\",\"organization\":\"ORGANIZATION\",\"username\":\"USERNAME\"
+  // ,\"password\":\"PASSWORD"}' --key-type=apigee_auth -y`
+  // to create a key after drush si.
+  $state = \Drupal::state();
+  if ($state->get('is_non_interactive')) {
+    // Clear the state.
+    $state->set('is_non_interactive', FALSE);
+    $context = [
+      '@developer' => $account->getEmail()
+    ];
+    $logger->warning("Could not create developer entity: @developer on Apigee Edge/X. Missing Apigee server configuration.", $context);
+    return;
+  }
+
   /** @var \Drupal\apigee_edge\UserDeveloperConverterInterface $user_developer */
   $user_developer = \Drupal::service('apigee_edge.converter.user_developer');
   /** @var \Drupal\apigee_edge\FieldAttributeConverterInterface $field_to_attribute */
   $field_to_attribute = \Drupal::service('apigee_edge.converter.field_attribute');
-  /** @var \Drupal\Core\Logger\LoggerChannelInterface $logger */
-  $logger = \Drupal::service('logger.channel.apigee_edge');
+
   try {
     /** @var \Drupal\apigee_edge\Entity\Developer $developer */
     $result = $user_developer->convertUser($account);

--- a/tests/src/Functional/DeveloperAppFieldTest.php
+++ b/tests/src/Functional/DeveloperAppFieldTest.php
@@ -154,11 +154,15 @@ class DeveloperAppFieldTest extends ApigeeEdgeFunctionalTestBase {
       strtolower($this->randomMachineName()) => [
         'type' => 'float',
         'data' => [
-          ['value' => M_PI],
-          ['value' => M_E],
-          ['value' => M_EULER],
+          ['value' => round(M_PI, 5)],
+          ['value' => round(M_E, 5)],
+          ['value' => round(M_EULER, 5)],
         ],
-        'encoded' => implode(',', [M_PI, M_E, M_EULER]),
+        'encoded' => implode(',', [
+          round(M_PI, 5),
+          round(M_E, 5),
+          round(M_EULER, 5)
+        ]),
       ],
       strtolower($this->randomMachineName()) => [
         'type' => 'integer',
@@ -179,15 +183,15 @@ class DeveloperAppFieldTest extends ApigeeEdgeFunctionalTestBase {
         'type' => 'list_float',
         'settings' => [
           'settings[allowed_values]' => implode(PHP_EOL, [
-            M_PI,
-            M_E,
-            M_EULER,
+            round(M_PI, 5),
+            round(M_E, 5),
+            round(M_EULER, 5),
           ]),
         ],
         'data' => [
-          ['value' => M_PI],
+          ['value' => round(M_PI, 5)],
         ],
-        'encoded' => (string) M_PI,
+        'encoded' => (string) round(M_PI, 5),
       ],
       strtolower($this->randomMachineName()) => [
         'type' => 'list_integer',

--- a/tests/src/Functional/DeveloperAppFieldTest.php
+++ b/tests/src/Functional/DeveloperAppFieldTest.php
@@ -154,14 +154,14 @@ class DeveloperAppFieldTest extends ApigeeEdgeFunctionalTestBase {
       strtolower($this->randomMachineName()) => [
         'type' => 'float',
         'data' => [
-          ['value' => round(M_PI, 5)],
-          ['value' => round(M_E, 5)],
-          ['value' => round(M_EULER, 5)],
+          ['value' => round(M_PI, 10)],
+          ['value' => round(M_E, 10)],
+          ['value' => round(M_EULER, 10)],
         ],
         'encoded' => implode(',', [
-          round(M_PI, 5),
-          round(M_E, 5),
-          round(M_EULER, 5)
+          round(M_PI, 10),
+          round(M_E, 10),
+          round(M_EULER, 10)
         ]),
       ],
       strtolower($this->randomMachineName()) => [
@@ -183,15 +183,15 @@ class DeveloperAppFieldTest extends ApigeeEdgeFunctionalTestBase {
         'type' => 'list_float',
         'settings' => [
           'settings[allowed_values]' => implode(PHP_EOL, [
-            round(M_PI, 5),
-            round(M_E, 5),
-            round(M_EULER, 5),
+            round(M_PI, 10),
+            round(M_E, 10),
+            round(M_EULER, 10),
           ]),
         ],
         'data' => [
-          ['value' => round(M_PI, 5)],
+          ['value' => round(M_PI, 10)],
         ],
-        'encoded' => (string) round(M_PI, 5),
+        'encoded' => (string) round(M_PI, 10),
       ],
       strtolower($this->randomMachineName()) => [
         'type' => 'list_integer',


### PR DESCRIPTION
Fix #731

Fix error `Could not create a developer entity` while installation through `Drush si`. Due to missing Apigee edge config since `drush si` cannot set default values for the form.