### PR TITLE
Fix to show teams more that 100

### DIFF
--- a/modules/apigee_edge_teams/src/Entity/TeamPermissionProvider.php
+++ b/modules/apigee_edge_teams/src/Entity/TeamPermissionProvider.php
@@ -75,6 +75,17 @@ final class TeamPermissionProvider implements EntityPermissionProviderInterface 
       ]),
     ];
 
+    $permissions["view extensive team list"] = [
+      'title' => $this->t('View extensive @type list', [
+        '@type' => $plural_label,
+      ]),
+      'description' => $this->t('The permission will have performance impact,
+        should give only to the users who are facing known limiation
+        of listing 100 @type.', [
+        '@type' => $plural_label,
+      ]),
+    ];
+
     foreach ($permissions as $name => $permission) {
       $permissions[$name]['provider'] = $entity_type->getProvider();
       // TranslatableMarkup objects don't sort properly.

--- a/modules/apigee_edge_teams/src/Entity/TeamPermissionProvider.php
+++ b/modules/apigee_edge_teams/src/Entity/TeamPermissionProvider.php
@@ -79,9 +79,8 @@ final class TeamPermissionProvider implements EntityPermissionProviderInterface 
       'title' => $this->t('View extensive @type list', [
         '@type' => $plural_label,
       ]),
-      'description' => $this->t('The permission will have performance impact,
-        should give only to the users who are facing known limitations
-        of listing 100 @type.', [
+      'description' => $this->t('This permission will have performance impact.
+        This permission should be given to users who belong to more than 100 @type.', [
           '@type' => $plural_label,
         ]),
     ];

--- a/modules/apigee_edge_teams/src/Entity/TeamPermissionProvider.php
+++ b/modules/apigee_edge_teams/src/Entity/TeamPermissionProvider.php
@@ -84,7 +84,7 @@ final class TeamPermissionProvider implements EntityPermissionProviderInterface 
         of listing 100 @type.', [
           '@type' => $plural_label,
         ]),
-      ];
+    ];
 
     foreach ($permissions as $name => $permission) {
       $permissions[$name]['provider'] = $entity_type->getProvider();

--- a/modules/apigee_edge_teams/src/Entity/TeamPermissionProvider.php
+++ b/modules/apigee_edge_teams/src/Entity/TeamPermissionProvider.php
@@ -82,9 +82,9 @@ final class TeamPermissionProvider implements EntityPermissionProviderInterface 
       'description' => $this->t('The permission will have performance impact,
         should give only to the users who are facing known limiation
         of listing 100 @type.', [
-        '@type' => $plural_label,
-      ]),
-    ];
+          '@type' => $plural_label,
+        ]),
+      ];
 
     foreach ($permissions as $name => $permission) {
       $permissions[$name]['provider'] = $entity_type->getProvider();

--- a/modules/apigee_edge_teams/src/Entity/TeamPermissionProvider.php
+++ b/modules/apigee_edge_teams/src/Entity/TeamPermissionProvider.php
@@ -80,7 +80,7 @@ final class TeamPermissionProvider implements EntityPermissionProviderInterface 
         '@type' => $plural_label,
       ]),
       'description' => $this->t('The permission will have performance impact,
-        should give only to the users who are facing known limiation
+        should give only to the users who are facing known limitations
         of listing 100 @type.', [
           '@type' => $plural_label,
         ]),

--- a/modules/apigee_edge_teams/src/TeamPermissionHandler.php
+++ b/modules/apigee_edge_teams/src/TeamPermissionHandler.php
@@ -164,7 +164,7 @@ final class TeamPermissionHandler implements TeamPermissionHandlerInterface {
     else {
       // Check if current developer is a member of the team and has the permision
       // to view more than 100 teams.
-      if ($account->hasPermission('view extensive team list')) {
+      if ($account->hasPermission('view extensive team list') && (count($developer_team_ids) > 100)) {
         $team_members = $this->teamMembershipManager->getMembers($team->id());
         if (in_array($account->getEmail(), $team_members)) {
           $developer_team_access = TRUE;

--- a/modules/apigee_edge_teams/src/TeamPermissionHandler.php
+++ b/modules/apigee_edge_teams/src/TeamPermissionHandler.php
@@ -148,6 +148,7 @@ final class TeamPermissionHandler implements TeamPermissionHandlerInterface {
       throw new InvalidArgumentException('Anonymous user can not be member of a team.');
     }
 
+    $developer_team_access = FALSE;
     $permissions = [];
     try {
       $developer_team_ids = $this->teamMembershipManager->getTeams($account->getEmail());
@@ -158,6 +159,20 @@ final class TeamPermissionHandler implements TeamPermissionHandlerInterface {
     // Only add team membership based permissions to the list if the developer
     // is still member of the team in Apigee Edge.
     if (in_array($team->id(), $developer_team_ids)) {
+      $developer_team_access = TRUE;
+    }
+    else {
+      // Check if current developer is a member of the team and has the permision
+      // to view more than 100 teams.
+      if ($account->hasPermission('view extensive team list')) {
+        $team_members = $this->teamMembershipManager->getMembers($team->id());
+        if (in_array($account->getEmail(), $team_members)) {
+          $developer_team_access = TRUE;
+        }
+      }
+    }
+
+    if ($developer_team_access === TRUE) {
       /** @var \Drupal\apigee_edge_teams\Entity\TeamRoleInterface $member_role */
       $member_role = $this->entityTypeManager->getStorage('team_role')->load(TeamRoleInterface::TEAM_MEMBER_ROLE);
       $permissions += $member_role->getPermissions();


### PR DESCRIPTION
Fixes #743

Added permission 'View extensive teams list ' to show all the teams that the developer is part of. 
Create a role for all those developers who have more than 100 teams and assign the new permission to the role so that the other developers are not affected. 

Note : This permission will have performance impact. This permission should be given to users who belong to more than 100 teams.
