### PR TITLE
Fix for drupal check prophesize method deprecation

### DIFF
--- a/tests/src/Unit/Command/CreateEdgeRoleCommandTest.php
+++ b/tests/src/Unit/Command/CreateEdgeRoleCommandTest.php
@@ -26,6 +26,7 @@ namespace Drupal\Tests\apigee_edge\Unit\Command {
   use Drupal\Core\Logger\LogMessageParserInterface;
   use Drupal\Tests\UnitTestCase;
   use Prophecy\Argument;
+  use Prophecy\Prophet;
   use Symfony\Component\Console\Formatter\OutputFormatterInterface;
   use Symfony\Component\Console\Input\InputInterface;
   use Symfony\Component\Console\Output\OutputInterface;
@@ -94,6 +95,13 @@ namespace Drupal\Tests\apigee_edge\Unit\Command {
     private $outputFormatter;
 
     /**
+     * The Prophet class.
+     *
+     * @var \Prophecy\Prophet
+     */
+    private $prophet;
+
+    /**
      * {@inheritdoc}
      */
     protected function setUp(): void {
@@ -102,17 +110,18 @@ namespace Drupal\Tests\apigee_edge\Unit\Command {
       }
 
       parent::setUp();
-      $this->cliService = $this->prophesize(CliServiceInterface::class);
-      $this->logMessageParser = $this->prophesize(LogMessageParserInterface::class);
-      $this->loggerChannelFactory = $this->prophesize(LoggerChannelFactoryInterface::class);
+      $this->prophet = new Prophet();
+      $this->cliService = $this->prophet->prophesize(CliServiceInterface::class);
+      $this->logMessageParser = $this->prophet->prophesize(LogMessageParserInterface::class);
+      $this->loggerChannelFactory = $this->prophet->prophesize(LoggerChannelFactoryInterface::class);
       $this->createEdgeRoleCommand = new CreateEdgeRoleCommand($this->cliService->reveal(),
         $this->logMessageParser->reveal(), $this->loggerChannelFactory->reveal());
 
-      $this->input = $this->prophesize(InputInterface::class);
-      $this->output = $this->prophesize(OutputInterface::class);
-      $this->io = $this->prophesize(DrupalStyle::class);
+      $this->input = $this->prophet->prophesize(InputInterface::class);
+      $this->output = $this->prophet->prophesize(OutputInterface::class);
+      $this->io = $this->prophet->prophesize(DrupalStyle::class);
 
-      $this->outputFormatter = $this->prophesize(OutputFormatterInterface::class)->reveal();
+      $this->outputFormatter = $this->prophet->prophesize(OutputFormatterInterface::class)->reveal();
       $this->output->getFormatter()->willReturn($this->outputFormatter);
       $this->output->getVerbosity()->willReturn(OutputInterface::VERBOSITY_DEBUG);
     }

--- a/tests/src/Unit/Command/Util/ApigeeEdgeManagementCliServiceTest.php
+++ b/tests/src/Unit/Command/Util/ApigeeEdgeManagementCliServiceTest.php
@@ -30,6 +30,7 @@ use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
+use Prophecy\Prophet;
 use Psr\Http\Message\RequestInterface;
 use Symfony\Component\Console\Style\StyleInterface;
 
@@ -83,11 +84,20 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
   protected $httpClient;
 
   /**
+   * The Prophet class.
+   *
+   * @var \Prophecy\Prophet
+   */
+  private $prophet;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
     parent::setUp();
-    $this->httpClient = $this->prophesize(Client::class);
+
+    $this->prophet = new Prophet();
+    $this->httpClient = $this->prophet->prophesize(Client::class);
   }
 
   /**
@@ -95,7 +105,7 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
    */
   public function testCreateEdgeRoleForDrupalCustomRoleAndBaseUrl() {
     // Output to user should show role created and permissions set.
-    $io = $this->prophesize(StyleInterface::class);
+    $io = $this->prophet->prophesize(StyleInterface::class);
     $io->success(Argument::exact('Connected to Edge org ' . $this->org . '.'))->shouldBeCalledTimes(1);
     $io->success(Argument::containingString('Role ' . $this->roleName . ' is configured.'))->shouldBeCalledTimes(1);
     $io->text(Argument::containingString('Role ' . $this->roleName . ' does not exist. Creating role.'))->shouldBeCalledTimes(1);
@@ -103,7 +113,7 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
     $io->text(Argument::containingString('/'))->shouldBeCalledTimes(12);
 
     // Org should exist.
-    $response_org = $this->prophesize(Response::class);
+    $response_org = $this->prophet->prophesize(Response::class);
     $response_org->getBody()
       ->shouldBeCalledTimes(1)
       ->willReturn('{ "name": "' . $this->org . '" }');
@@ -113,8 +123,8 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
       ->willReturn($response_org->reveal());
 
     // The role should not exist yet in system.
-    $request_role = $this->prophesize(RequestInterface::class);
-    $response_role = $this->prophesize(Response::class);
+    $request_role = $this->prophet->prophesize(RequestInterface::class);
+    $response_role = $this->prophet->prophesize(Response::class);
     $response_role->getStatusCode()->willReturn(404);
     $exception = new ClientException('Forbidden', $request_role->reveal(), $response_role->reveal());
     $this->httpClient
@@ -140,7 +150,7 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
    */
   public function testCreateEdgeRoleForDrupalDefaultRoleAndBaseUrl() {
     // Output to user should show role created and permissions set.
-    $io = $this->prophesize(StyleInterface::class);
+    $io = $this->prophet->prophesize(StyleInterface::class);
     $io->success(Argument::exact('Connected to Edge org ' . $this->org . '.'))->shouldBeCalledTimes(1);
     $io->success(Argument::containingString('Role ' . ApigeeEdgeManagementCliServiceInterface::DEFAULT_ROLE_NAME . ' is configured.'))->shouldBeCalledTimes(1);
     $io->text(Argument::containingString('Role ' . ApigeeEdgeManagementCliServiceInterface::DEFAULT_ROLE_NAME . ' does not exist'))->shouldBeCalledTimes(1);
@@ -148,7 +158,7 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
     $io->text(Argument::containingString('/'))->shouldBeCalledTimes(12);
 
     // Org should exist.
-    $response_org = $this->prophesize(Response::class);
+    $response_org = $this->prophet->prophesize(Response::class);
     $response_org->getBody()
       ->shouldBeCalledTimes(1)
       ->willReturn('{ "name": "' . $this->org . '" }');
@@ -158,8 +168,8 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
       ->willReturn($response_org->reveal());
 
     // The role should not exist yet in system.
-    $request_role = $this->prophesize(RequestInterface::class);
-    $response_role = $this->prophesize(Response::class);
+    $request_role = $this->prophet->prophesize(RequestInterface::class);
+    $response_role = $this->prophet->prophesize(Response::class);
     $response_role->getStatusCode()->willReturn(404);
     $exception = new ClientException('Forbidden', $request_role->reveal(), $response_role->reveal());
     $this->httpClient
@@ -185,14 +195,14 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
    */
   public function testCreateEdgeRoleForDrupalWhenRoleExistsTestWithForceFlag() {
     // Expected to output error if role does not exist.
-    $io = $this->prophesize(StyleInterface::class);
+    $io = $this->prophet->prophesize(StyleInterface::class);
     $io->success(Argument::exact('Connected to Edge org ' . $this->org . '.'))->shouldBeCalledTimes(1);
     $io->text(Argument::containingString('Setting permissions on role ' . $this->roleName . '.'))->shouldBeCalledTimes(1);
     $io->text(Argument::containingString('/'))->shouldBeCalledTimes(12);
     $io->success(Argument::containingString('Role ' . $this->roleName . ' is configured.'))->shouldBeCalledTimes(1);
 
     // Return organization info.
-    $response_org = $this->prophesize(Response::class);
+    $response_org = $this->prophet->prophesize(Response::class);
     $response_org->getBody()
       ->shouldBeCalledTimes(1)
       ->willReturn('{ "name": "' . $this->org . '" }');
@@ -202,7 +212,7 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
       ->willReturn($response_org->reveal());
 
     // Return existing role.
-    $response_user_role = $this->prophesize(Response::class);
+    $response_user_role = $this->prophet->prophesize(Response::class);
     $response_user_role->getBody()->willReturn('{ "name": "' . $this->roleName . '" }');
     $this->httpClient
       ->get(Argument::exact($this->baseUrl . '/o/' . $this->org . '/userroles/' . $this->roleName), Argument::type('array'))
@@ -227,13 +237,13 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
    */
   public function testCreateEdgeRoleForDrupalWhenRoleExistsTestNoForceFlag() {
     // Expected to output error if role does not exist.
-    $io = $this->prophesize(StyleInterface::class);
+    $io = $this->prophet->prophesize(StyleInterface::class);
     $io->success(Argument::exact('Connected to Edge org ' . $this->org . '.'))->shouldBeCalledTimes(1);
     $io->error(Argument::containingString('Role ' . $this->roleName . ' already exists.'))->shouldBeCalledTimes(1);
     $io->note(Argument::containingString('Run with --force option'))->shouldBeCalled();
 
     // Return organization info.
-    $response_org = $this->prophesize(Response::class);
+    $response_org = $this->prophet->prophesize(Response::class);
     $response_org->getBody()
       ->shouldBeCalledTimes(1)
       ->willReturn('{ "name": "' . $this->org . '" }');
@@ -243,7 +253,7 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
       ->willReturn($response_org->reveal());
 
     // Return existing role.
-    $response_user_role = $this->prophesize(Response::class);
+    $response_user_role = $this->prophet->prophesize(Response::class);
     $response_user_role->getBody()->willReturn('{ "name": "' . $this->roleName . '" }');
     $this->httpClient
       ->get(Argument::exact($this->baseUrl . '/o/' . $this->org . '/userroles/' . $this->roleName), Argument::type('array'))
@@ -259,13 +269,13 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
   public function testIsValidEdgeCredentialsBadEndpoint() {
     // Mimic a invalid response for the call to get org details.
     $body = "<h1>not json</h1>";
-    $response = $this->prophesize(Response::class);
+    $response = $this->prophet->prophesize(Response::class);
     $response->getBody()
       ->shouldBeCalledTimes(1)
       ->willReturn($body);
 
     // The user should see an error message.
-    $io = $this->prophesize(StyleInterface::class);
+    $io = $this->prophet->prophesize(StyleInterface::class);
     $io->error(Argument::containingString('Unable to parse response from GET'))
       ->shouldBeCalledTimes(1);
     $this->httpClient
@@ -284,8 +294,8 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
    */
   public function testIsValidEdgeCredentialsUnauthorized() {
     // Invalid password returns unauthorized 403.
-    $request_role = $this->prophesize(RequestInterface::class);
-    $response_role = $this->prophesize(Response::class);
+    $request_role = $this->prophet->prophesize(RequestInterface::class);
+    $response_role = $this->prophet->prophesize(Response::class);
     $response_role->getStatusCode()->willReturn(403);
     $exception = new ClientException('Unauthorized', $request_role->reveal(), $response_role->reveal());
     $this->httpClient
@@ -294,7 +304,7 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
       ->shouldBeCalledTimes(1);
 
     // The user should see an error message.
-    $io = $this->prophesize(StyleInterface::class);
+    $io = $this->prophet->prophesize(StyleInterface::class);
     $io->error(Argument::containingString('Error connecting to Apigee Edge'))
       ->shouldBeCalledTimes(1);
     $io->note(Argument::containingString('may not have the orgadmin role for Apigee Edge org'))
@@ -310,7 +320,7 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
    */
   public function testIsValidEdgeCredentialsValid() {
     // Org should exist.
-    $response_org = $this->prophesize(Response::class);
+    $response_org = $this->prophet->prophesize(Response::class);
     $response_org->getBody()
       ->shouldBeCalledTimes(1)
       ->willReturn('{ "name": "' . $this->org . '" }');
@@ -320,7 +330,7 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
       ->willReturn($response_org->reveal());
 
     // Errors should not be called.
-    $io = $this->prophesize(StyleInterface::class);
+    $io = $this->prophet->prophesize(StyleInterface::class);
     $io->error(Argument::type('string'))
       ->shouldNotBeCalled();
     $io->section(Argument::type('string'))
@@ -342,7 +352,7 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
    */
   public function testDoesRoleExistTrue() {
     // Return existing role.
-    $response_user_role = $this->prophesize(Response::class);
+    $response_user_role = $this->prophet->prophesize(Response::class);
     $response_user_role->getBody()->willReturn('{ "name": "' . $this->roleName . '" }');
     $this->httpClient
       ->get(Argument::exact($this->baseUrl . '/o/' . $this->org . '/userroles/' . $this->roleName), Argument::type('array'))
@@ -361,8 +371,8 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
    */
   public function testDoesRoleExistNotTrue() {
     // The role should not exist in system.
-    $request_role = $this->prophesize(RequestInterface::class);
-    $response_role = $this->prophesize(Response::class);
+    $request_role = $this->prophet->prophesize(RequestInterface::class);
+    $response_role = $this->prophet->prophesize(Response::class);
     $response_role->getStatusCode()->willReturn(404);
     $exception = new ClientException('Forbidden', $request_role->reveal(), $response_role->reveal());
     $this->httpClient
@@ -381,8 +391,8 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
    */
   public function testDoesRoleExistServerErrorThrown() {
     // Http client throws exception if network or server error happens.
-    $request = $this->prophesize(RequestInterface::class);
-    $response = $this->prophesize(Response::class);
+    $request = $this->prophet->prophesize(RequestInterface::class);
+    $response = $this->prophet->prophesize(Response::class);
     $response->getStatusCode()->willReturn(500);
     $exception = new ServerException('Server error.', $request->reveal(), $response->reveal());
     $this->expectException(ServerException::class);
@@ -399,12 +409,12 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
    */
   public function testHandleHttpClientExceptions0Code() {
     // Error message should output to user.
-    $io = $this->prophesize(StyleInterface::class);
+    $io = $this->prophet->prophesize(StyleInterface::class);
     $io->error(Argument::containingString('Error connecting to Apigee Edge'))->shouldBeCalledTimes(1);
     $io->note(Argument::containingString('Your system may not be able to connect'))->shouldBeCalledTimes(1);
 
     // Create network error.
-    $exception = $this->prophesize(TransferException::class);
+    $exception = $this->prophet->prophesize(TransferException::class);
 
     $apigee_edge_management_cli_service = new ApigeeEdgeManagementCliService($this->httpClient->reveal());
     $apigee_edge_management_cli_service->handleHttpClientExceptions($exception->reveal(), $io->reveal(), [$this, 'mockDt'], 'http://api.apigee.com/test', $this->org, $this->email);
@@ -415,13 +425,13 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
    */
   public function testHandleHttpClientExceptions401Code() {
     // Server returns 401 unauthorized.
-    $request = $this->prophesize(RequestInterface::class);
-    $response = $this->prophesize(Response::class);
+    $request = $this->prophet->prophesize(RequestInterface::class);
+    $response = $this->prophet->prophesize(Response::class);
     $response->getStatusCode()->willReturn(401);
     $exception = new ClientException('Unauthorized', $request->reveal(), $response->reveal());
 
     // Expect user friendly message displayed about error.
-    $io = $this->prophesize(StyleInterface::class);
+    $io = $this->prophet->prophesize(StyleInterface::class);
     $io->error(Argument::containingString('Error connecting to Apigee Edge'))->shouldBeCalledTimes(1);
     $io->note(Argument::exact('Your username or password is invalid.'))->shouldBeCalledTimes(1);
 
@@ -434,13 +444,13 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
    */
   public function testHandleHttpClientExceptions403Code() {
     // Server returns 403 forbidden.
-    $request = $this->prophesize(RequestInterface::class);
-    $response = $this->prophesize(Response::class);
+    $request = $this->prophet->prophesize(RequestInterface::class);
+    $response = $this->prophet->prophesize(Response::class);
     $response->getStatusCode()->willReturn(403);
     $exception = new ClientException('Forbidden', $request->reveal(), $response->reveal());
 
     // Expect error messages.
-    $io = $this->prophesize(StyleInterface::class);
+    $io = $this->prophet->prophesize(StyleInterface::class);
     $io->error(Argument::containingString('Error connecting to Apigee Edge'))->shouldBeCalledTimes(1);
     $io->note(Argument::containingString('User ' . $this->email . ' may not have the orgadmin role'))->shouldBeCalledTimes(1);
 
@@ -453,13 +463,13 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
    */
   public function testHandleHttpClientExceptions302Code() {
     // Return a 302 redirection response, which Apigee API would not do.
-    $request = $this->prophesize(RequestInterface::class);
-    $response = $this->prophesize(Response::class);
+    $request = $this->prophet->prophesize(RequestInterface::class);
+    $response = $this->prophet->prophesize(Response::class);
     $response->getStatusCode()->willReturn(302);
     $exception = new ClientException('Forbidden', $request->reveal(), $response->reveal());
 
     // User should see error message.
-    $io = $this->prophesize(StyleInterface::class);
+    $io = $this->prophet->prophesize(StyleInterface::class);
     $io->error(Argument::containingString('Error connecting to Apigee Edge'))->shouldBeCalledTimes(1);
     $io->note(Argument::containingString('the url ' . $this->baseUrl . '/test' . ' does not seem to be a valid Apigee Edge endpoint.'))->shouldBeCalledTimes(1);
 
@@ -483,7 +493,7 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
     $method_set_default_permissions->setAccessible(TRUE);
 
     // Create input params.
-    $io = $this->prophesize(StyleInterface::class);
+    $io = $this->prophet->prophesize(StyleInterface::class);
     $args = [
       $io->reveal(),
       [$this, 'mockDt'],

--- a/tests/src/Unit/Commands/ApigeeEdgeCommandsTest.php
+++ b/tests/src/Unit/Commands/ApigeeEdgeCommandsTest.php
@@ -25,6 +25,7 @@ namespace Drupal\Tests\apigee_edge\Unit\Commands {
   use Drupal\Tests\UnitTestCase;
   use Drush\Style\DrushStyle;
   use Prophecy\Argument;
+  use Prophecy\Prophet;
   use ReflectionClass;
   use Symfony\Component\Console\Input\InputInterface;
 
@@ -57,18 +58,28 @@ namespace Drupal\Tests\apigee_edge\Unit\Commands {
     protected $io;
 
     /**
+     * The Prophet class.
+     *
+     * @var \Prophecy\Prophet
+     */
+    private $prophet;
+
+    /**
      * {@inheritdoc}
      */
     protected function setUp(): void {
       parent::setUp();
-      $this->cliService = $this->prophesize(CliServiceInterface::class);
+
+      $this->prophet = new Prophet();
+
+      $this->cliService = $this->prophet->prophesize(CliServiceInterface::class);
       $this->apigeeEdgeCommands = new ApigeeEdgeCommands($this->cliService->reveal());
 
       // Set io in DrushCommands to a mock.
       $apigee_edge_commands_reflection = new ReflectionClass($this->apigeeEdgeCommands);
       $reflection_io_property = $apigee_edge_commands_reflection->getProperty('io');
       $reflection_io_property->setAccessible(TRUE);
-      $this->io = $this->prophesize(DrushStyle::class);
+      $this->io = $this->prophet->prophesize(DrushStyle::class);
       $reflection_io_property->setValue($this->apigeeEdgeCommands, $this->io->reveal());
 
       $this->io->askHidden(Argument::type('string'), Argument::any())
@@ -110,10 +121,10 @@ namespace Drupal\Tests\apigee_edge\Unit\Commands {
      */
     public function testValidatePasswordParam() {
 
-      $command_data_input = $this->prophesize(InputInterface::class);
+      $command_data_input = $this->prophet->prophesize(InputInterface::class);
       $command_data_input->getOption('password')->willReturn('secret');
       $command_data_input->getArgument('email')->willReturn('email.example.com');
-      $command_data = $this->prophesize(CommandData::class);
+      $command_data = $this->prophet->prophesize(CommandData::class);
       $command_data->input()->willReturn($command_data_input->reveal());
 
       $this->apigeeEdgeCommands->validateCreateEdgeRole($command_data->reveal());
@@ -132,11 +143,11 @@ namespace Drupal\Tests\apigee_edge\Unit\Commands {
      */
     public function testValidatePasswordParamEmpty() {
 
-      $command_data_input = $this->prophesize(InputInterface::class);
+      $command_data_input = $this->prophet->prophesize(InputInterface::class);
       $command_data_input->getOption('password')->willReturn(NULL);
       $command_data_input->setOption(Argument::type('string'), Argument::type('string'))->willReturn();
       $command_data_input->getArgument('email')->willReturn('email.example.com');
-      $command_data = $this->prophesize(CommandData::class);
+      $command_data = $this->prophet->prophesize(CommandData::class);
       $command_data->input()->willReturn($command_data_input->reveal());
 
       $this->apigeeEdgeCommands->validateCreateEdgeRole($command_data->reveal());

--- a/tests/src/Unit/EventSubscriber/EdgeExceptionSubscriberTest.php
+++ b/tests/src/Unit/EventSubscriber/EdgeExceptionSubscriberTest.php
@@ -30,6 +30,7 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Tests\UnitTestCase;
 use Drupal\Core\Config\Config;
 use Prophecy\Argument;
+use Prophecy\Prophet;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -99,41 +100,49 @@ class EdgeExceptionSubscriberTest extends UnitTestCase {
   protected $getResponseForExceptionEvent;
 
   /**
+   * The Prophet class.
+   *
+   * @var \Prophecy\Prophet
+   */
+  private $prophet;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
     parent::setUp();
 
+    $this->prophet = new Prophet();
     $this->exception = new ApiException("API response error message.");
 
-    $this->logger = $this->prophesize(LoggerInterface::class);
+    $this->logger = $this->prophet->prophesize(LoggerInterface::class);
 
-    $this->messenger = $this->prophesize(MessengerInterface::class);
+    $this->messenger = $this->prophet->prophesize(MessengerInterface::class);
 
-    $response = $this->prophesize(Response::class);
+    $response = $this->prophet->prophesize(Response::class);
 
     $this->mainContentRenderers = ['html' => 'main_content_renderer.html'];
 
-    $htmlRenderer = $this->prophesize(HtmlRenderer::class);
+    $htmlRenderer = $this->prophet->prophesize(HtmlRenderer::class);
     $htmlRenderer->renderResponse(Argument::cetera())
       ->willReturn($response->reveal());
 
-    $errorPageController = $this->prophesize(ErrorPageController::class);
+    $errorPageController = $this->prophet->prophesize(ErrorPageController::class);
     $errorPageController->render()
       ->willReturn([]);
     $errorPageController->getPageTitle()
       ->willReturn('');
 
-    $this->classResolver = $this->prophesize(ClassResolverInterface::class);
+    $this->classResolver = $this->prophet->prophesize(ClassResolverInterface::class);
     $this->classResolver->getInstanceFromDefinition(Argument::is($this->mainContentRenderers['html']))
       ->willReturn($htmlRenderer->reveal());
     $this->classResolver->getInstanceFromDefinition(Argument::is(ErrorPageController::class))
       ->willReturn($errorPageController->reveal());
 
-    $this->routeMatch = $this->prophesize(RouteMatchInterface::class);
+    $this->routeMatch = $this->prophet->prophesize(RouteMatchInterface::class);
 
     // Drupal 9 / Symfony 4.x and up.
-    $this->getResponseForExceptionEvent = $this->prophesize(ExceptionEvent::class);
+    $this->getResponseForExceptionEvent = $this->prophet->prophesize(ExceptionEvent::class);
     $this->getResponseForExceptionEvent->getThrowable()
       ->willReturn($this->exception);
 
@@ -152,12 +161,12 @@ class EdgeExceptionSubscriberTest extends UnitTestCase {
   public function testOnExceptionErrorsOn() {
 
     // Config will return true when checked.
-    $config_error_page = $this->prophesize(Config::class);
+    $config_error_page = $this->prophet->prophesize(Config::class);
     $config_error_page
       ->get(Argument::is('error_page_debug_messages'))
       ->shouldBeCalledTimes(1)
       ->willReturn(TRUE);
-    $this->configFactory = $this->prophesize(ConfigFactoryInterface::class);
+    $this->configFactory = $this->prophet->prophesize(ConfigFactoryInterface::class);
     $this->configFactory
       ->get(Argument::is('apigee_edge.error_page'))
       ->willReturn($config_error_page->reveal());
@@ -187,12 +196,12 @@ class EdgeExceptionSubscriberTest extends UnitTestCase {
   public function testOnExceptionErrorsOff() {
 
     // Config will return false when checked.
-    $config_error_page = $this->prophesize(Config::class);
+    $config_error_page = $this->prophet->prophesize(Config::class);
     $config_error_page
       ->get(Argument::is('error_page_debug_messages'))
       ->shouldBeCalledTimes(1)
       ->willReturn(FALSE);
-    $this->configFactory = $this->prophesize(ConfigFactoryInterface::class);
+    $this->configFactory = $this->prophet->prophesize(ConfigFactoryInterface::class);
     $this->configFactory
       ->get(Argument::is('apigee_edge.error_page'))
       ->willReturn($config_error_page->reveal());


### PR DESCRIPTION
Fixes #754
In Phpunit 9.5 prophesize method is deprecated.  Prophecy library is used for prophesize method.