### PR TITLE
Fix for dev dependencies error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "bex/behat-screenshot": "^1.2",
         "cweagans/composer-patches": "^1.6",
         "drupal/core-dev": "^9.3",
-        "drupal/drupal-extension": "master-dev",
         "drush/drush": "^9.0 || ^10.0",
         "mglaman/drupal-check": "1.3",
         "phpmd/phpmd": "^2.8.2",


### PR DESCRIPTION
Fixes #757 
"drupal/drupal-extension" was added when moving from travis to circle ci (https://github.com/apigee/apigee-edge-drupal/commit/4020919d08122aaff496036523abef0c8c2aa7d2) also later behat.yml was removed. As currently we are using Github action we don't need this library and can be safely removed.