### PR TITLE
Using the "Twig_Loader_Chain" class is deprecated

### DIFF
--- a/tests/modules/apigee_mock_api_client/apigee_mock_api_client.services.yml
+++ b/tests/modules/apigee_mock_api_client/apigee_mock_api_client.services.yml
@@ -35,7 +35,7 @@ services:
     arguments: ['@apigee_mock_api_client_twig_json.loader']
 
   apigee_mock_api_client_twig_json.loader:
-    class: \Twig_Loader_Chain
+    class: Twig\Loader\ChainLoader
     public: false
     tags:
       - { name: service_collector, tag: apigee_mock_api_client_twig.loader, call: addLoader, required: TRUE }


### PR DESCRIPTION
Using the "Twig_Loader_Chain" class is deprecated since Twig version 2.7, use "Twig\Loader\ChainLoader" instead.

Closes #762 