### PR TITLE
Using "min" option without setting the "allowEmptyString" is deprecated

### DIFF
--- a/tests/modules/apigee_edge_test/src/Entity/OverriddenDeveloperApp.php
+++ b/tests/modules/apigee_edge_test/src/Entity/OverriddenDeveloperApp.php
@@ -39,6 +39,7 @@ final class OverriddenDeveloperApp extends DeveloperApp {
       'Length' => [
         'min' => 1,
         'max' => 30,
+        'allowEmptyString' => True
       ],
     ]);
 

--- a/tests/modules/apigee_edge_test/src/Entity/OverriddenDeveloperApp.php
+++ b/tests/modules/apigee_edge_test/src/Entity/OverriddenDeveloperApp.php
@@ -39,7 +39,7 @@ final class OverriddenDeveloperApp extends DeveloperApp {
       'Length' => [
         'min' => 1,
         'max' => 30,
-        'allowEmptyString' => True
+        'allowEmptyString' => TRUE
       ],
     ]);
 


### PR DESCRIPTION
Fixes #759 
Using the "Symfony\Component\Validator\Constraints\Length" constraint with the "min" option without setting the "allowEmptyString" one is deprecated and defaults to true.