### PR TITLE
Sort API Product listings on App

### DIFF
--- a/modules/apigee_edge_teams/src/Entity/Form/TeamAppFormTrait.php
+++ b/modules/apigee_edge_teams/src/Entity/Form/TeamAppFormTrait.php
@@ -221,8 +221,10 @@ trait TeamAppFormTrait {
         return $this->getTeamMemberApiProductAccessHandler()->access($api_product, 'assign', $team);
       };
     }
+    $apiProducts = $this->getEntityTypeManager()->getStorage('api_product')->loadMultiple();
+    ksort($apiProducts);
 
-    return array_filter($this->getEntityTypeManager()->getStorage('api_product')->loadMultiple(), $filter);
+    return array_filter($apiProducts, $filter);
   }
 
   /**

--- a/src/Entity/Form/DeveloperAppEditForm.php
+++ b/src/Entity/Form/DeveloperAppEditForm.php
@@ -93,9 +93,12 @@ class DeveloperAppEditForm extends AppEditForm {
       return [];
     }
 
+    $apiProducts = $this->entityTypeManager->getStorage('api_product')->loadMultiple();
+    ksort($apiProducts);
+
     // Here because we know the owner (developer) of the app and it can not
     // be changed we can limit the visible API products.
-    return array_filter($this->entityTypeManager->getStorage('api_product')->loadMultiple(), function (ApiProductInterface $product) use ($app) {
+    return array_filter($apiProducts, function (ApiProductInterface $product) use ($app) {
       return $product->access('assign', $app->getOwner());
     });
   }

--- a/src/Entity/Form/DeveloperAppFormTrait.php
+++ b/src/Entity/Form/DeveloperAppFormTrait.php
@@ -128,8 +128,10 @@ trait DeveloperAppFormTrait {
     $email = $form_state->getValue('owner') ?? $form['owner']['#value'] ?? $form['owner']['#default_value'];
     /** @var \Drupal\user\UserInterface|null $account */
     $account = user_load_by_mail($email);
+    $apiProducts = \Drupal::entityTypeManager()->getStorage('api_product')->loadMultiple();
+    ksort($apiProducts);
 
-    return array_filter(\Drupal::entityTypeManager()->getStorage('api_product')->loadMultiple(), function (ApiProductInterface $product) use ($account) {
+    return array_filter($apiProducts, function (ApiProductInterface $product) use ($account) {
       return $product->access('assign', $account);
     });
   }


### PR DESCRIPTION
Closes #811 

Fix - API Product sort issue when creating, editing team apps and developer apps.
API Products now sorted in ascending order.