### PR TITLE
Make sure that cron runner starts executing the job

### DIFF
--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -1588,7 +1588,7 @@ function apigee_edge_cron() {
   // The reason of this is to avoid race conditions.
   for ($i = 0; $i < 100; $i++) {
     if (($job = $executor->select())) {
-      $executor->cast($job);
+      $executor->call($job);
     }
     else {
       break;


### PR DESCRIPTION
This is a follow up on #808 and #802.

@ycecube was right in 802, 808 is not enough. By examining the call stack difference between `drush queue:run apigee_edge_job` and `drush cron` after Background sync is initiated, I believe there is a typo on the `hook_cron()` implementation that prevents the execution of those queue items that are created by a job. 

