### PR TITLE
Sort API products on app forms by API product display name

### DIFF
--- a/modules/apigee_edge_teams/src/Entity/Form/TeamAppFormTrait.php
+++ b/modules/apigee_edge_teams/src/Entity/Form/TeamAppFormTrait.php
@@ -221,10 +221,8 @@ trait TeamAppFormTrait {
         return $this->getTeamMemberApiProductAccessHandler()->access($api_product, 'assign', $team);
       };
     }
-    $apiProducts = $this->getEntityTypeManager()->getStorage('api_product')->loadMultiple();
-    ksort($apiProducts);
 
-    return array_filter($apiProducts, $filter);
+    return array_filter($this->getEntityTypeManager()->getStorage('api_product')->loadMultiple(), $filter);
   }
 
   /**

--- a/src/Entity/Form/AppCreateForm.php
+++ b/src/Entity/Form/AppCreateForm.php
@@ -121,9 +121,12 @@ abstract class AppCreateForm extends AppForm {
     $app_settings = $this->config('apigee_edge.common_app_settings');
     $user_select = (bool) $app_settings->get('user_select');
 
-    $api_products_options = array_map(function (ApiProductInterface $product) {
+    $api_products = $this->apiProductList($form, $form_state);
+    $api_products_options = array_map(static function (ApiProductInterface $product) {
       return $product->label();
-    }, $this->apiProductList($form, $form_state));
+    }, usort($api_products, static function (ApiProductInterface $a, ApiProductInterface $b) {
+      return strnatcmp(strtolower($a->getDisplayName()), strtolower($b->getDisplayName()));
+    }));
 
     $multiple = $app_settings->get('multiple_products');
     $default_products = $app_settings->get('default_products') ?: [];

--- a/src/Entity/Form/AppEditForm.php
+++ b/src/Entity/Form/AppEditForm.php
@@ -107,7 +107,12 @@ abstract class AppEditForm extends AppForm {
 
     // If "Let user select the product(s)" is enabled.
     if ($app_settings->get('user_select')) {
-      $available_products_by_user = $this->apiProductList($form, $form_state);
+      $api_products = $this->apiProductList($form, $form_state);
+      $available_products_by_user = array_map(static function (ApiProductInterface $product) {
+        return $product->label();
+      }, usort($api_products, static function (ApiProductInterface $a, ApiProductInterface $b) {
+        return strnatcmp(strtolower($a->getDisplayName()), strtolower($b->getDisplayName()));
+      }));
 
       $form['credential'] = [
         '#type' => 'container',

--- a/src/Entity/Form/DeveloperAppEditForm.php
+++ b/src/Entity/Form/DeveloperAppEditForm.php
@@ -93,12 +93,9 @@ class DeveloperAppEditForm extends AppEditForm {
       return [];
     }
 
-    $apiProducts = $this->entityTypeManager->getStorage('api_product')->loadMultiple();
-    ksort($apiProducts);
-
     // Here because we know the owner (developer) of the app and it can not
     // be changed we can limit the visible API products.
-    return array_filter($apiProducts, function (ApiProductInterface $product) use ($app) {
+    return array_filter($this->entityTypeManager->getStorage('api_product')->loadMultiple(), function (ApiProductInterface $product) use ($app) {
       return $product->access('assign', $app->getOwner());
     });
   }

--- a/src/Entity/Form/DeveloperAppFormTrait.php
+++ b/src/Entity/Form/DeveloperAppFormTrait.php
@@ -128,10 +128,8 @@ trait DeveloperAppFormTrait {
     $email = $form_state->getValue('owner') ?? $form['owner']['#value'] ?? $form['owner']['#default_value'];
     /** @var \Drupal\user\UserInterface|null $account */
     $account = user_load_by_mail($email);
-    $apiProducts = \Drupal::entityTypeManager()->getStorage('api_product')->loadMultiple();
-    ksort($apiProducts);
 
-    return array_filter($apiProducts, function (ApiProductInterface $product) use ($account) {
+    return array_filter(\Drupal::entityTypeManager()->getStorage('api_product')->loadMultiple(), function (ApiProductInterface $product) use ($account) {
       return $product->access('assign', $account);
     });
   }


### PR DESCRIPTION
This PR rolls back the change that was made in #812 and properly fixes #811.

End users do not want to see API products sorted by their `machine name` rather by their `display name` (which is their customer facing naming).

This implementation also ensures that sorting happens where it is actually needed.

Before:

![image](https://user-images.githubusercontent.com/1755573/223732000-b4a33cb3-f373-4571-9503-06b2c47969a0.png)
![image](https://user-images.githubusercontent.com/1755573/223732146-1b81c5fa-8540-44c8-8496-00ad21457641.png)

After:

![image](https://user-images.githubusercontent.com/1755573/223732225-db56e759-2683-430c-aa2a-c2afce6adf97.png)
![image](https://user-images.githubusercontent.com/1755573/223732350-9ea42414-3846-4370-a248-36657bd3abb5.png)


The difference is noticeable but I'd like to explain why `Zero product` was on the top before... because its machine name was `An API product`.