### PR TITLE
Drop PHP 7 support again

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -29,7 +29,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "7.4"
           - "8.0"
           - "8.1"
         drupal-core:

--- a/apigee_edge.info.yml
+++ b/apigee_edge.info.yml
@@ -16,4 +16,4 @@ dependencies:
 
 configure: apigee_edge.settings
 
-php: "7.1"
+php: 8.0

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "drupal-module",
     "description": "Apigee Edge for Drupal.",
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "apigee/apigee-client-php": "^2.0.16",
         "drupal/core": "^9.4",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "drupal-module",
     "description": "Apigee Edge for Drupal.",
     "require": {
-        "php": "^8.0",
+        "php": "~8.0.0 || ~8.1.0",
         "ext-json": "*",
         "apigee/apigee-client-php": "^2.0.16",
         "drupal/core": "^9.4",


### PR DESCRIPTION
and clearly specify supported PHP versions.

This is a follow up on #796 connected to my comment: https://github.com/apigee/apigee-edge-drupal/issues/#issuecomment-1460226645