### PR TITLE
If the team is not available on ApigeeX avoid null value exception while get-AppGroup

### DIFF
--- a/src/Entity/Developer.php
+++ b/src/Entity/Developer.php
@@ -289,8 +289,11 @@ class Developer extends EdgeEntityBase implements DeveloperInterface {
     /** @var \Drupal\apigee_edge_teams\Entity\TeamMemberRoleInterface $team_member_roles */
 
     $developerTeam = array_reduce($team_member_role_storage->loadByDeveloper($user), function ($carry, TeamMemberRole $team_role) {
+      // If team is not available, avoid null value exception.
+      if ($team_role->getTeam() !== NULL) {
         $carry[$team_role->getTeam()->id()] = $team_role->getTeam()->id();
         return $carry;
+      }
     },
     []);
 


### PR DESCRIPTION
To avoid Null value Exception while getting the `AppGroup` from `ApigeeX` if the team is not available.