### PR TITLE
Fix for jQuery.once() is deprecated in Drupal 9.3

### DIFF
--- a/apigee_edge.libraries.yml
+++ b/apigee_edge.libraries.yml
@@ -37,7 +37,7 @@ apigee_edge.components:
       css/apigee_edge.components.css: {}
 
 apigee_edge.app_listing:
-  version: 1.0
+  version: 1.1
   css:
     theme:
       css/apigee_edge.app_listing.css: {}

--- a/js/apigee_edge.app_listing.js
+++ b/js/apigee_edge.app_listing.js
@@ -19,7 +19,7 @@
  * @file
  * Javascript functions related to the app listing.
  */
-(function ($, Drupal) {
+(function ($, Drupal, once) {
 
   'use strict';
 
@@ -31,7 +31,7 @@
 
   Drupal.apigeeEdgeAppListing = {
     tableToggle: function (context, settings) {
-      $('.toggle--warning').once('tableToggle').on('click', function (event) {
+      $(once('tableToggle', '.toggle--warning')).on('click', function (event) {
         event.preventDefault();
         var targetURL = $(this).attr('href');
         var targetID = '#' + targetURL.substr(targetURL.indexOf('#') + 1);
@@ -50,4 +50,4 @@
 
     }
   };
-})(jQuery, Drupal);
+})(jQuery, Drupal, once);


### PR DESCRIPTION
Fixed in #782 by @VladimirAus but created a separate PR for better tracking.
Fixes #850