### PR TITLE
Get AppGroup team members from DB

### DIFF
--- a/modules/apigee_edge_actions/src/TeamMembershipManager.php
+++ b/modules/apigee_edge_actions/src/TeamMembershipManager.php
@@ -151,8 +151,8 @@ class TeamMembershipManager implements TeamMembershipManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function getTeams(string $developer): array {
-    return $this->inner->getTeams($developer);
+  public function getTeams(string $developer, string $team = NULL): array {
+    return $this->inner->getTeams($developer, $team);
   }
 
   /**

--- a/modules/apigee_edge_actions/src/TeamMembershipManager.php
+++ b/modules/apigee_edge_actions/src/TeamMembershipManager.php
@@ -156,6 +156,13 @@ class TeamMembershipManager implements TeamMembershipManagerInterface {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function syncAppGroupMembers(string $team): array {
+    return $this->inner->syncAppGroupMembers($team);
+  }
+
+  /**
    * Helper to dispatch event.
    *
    * @param string $event

--- a/modules/apigee_edge_teams/src/Access/ManageTeamMembersAccess.php
+++ b/modules/apigee_edge_teams/src/Access/ManageTeamMembersAccess.php
@@ -86,7 +86,8 @@ final class ManageTeamMembersAccess implements AccessInterface {
     // If the developer parameter is available in the route make sure it is
     // member of the team.
     if ($developer !== NULL) {
-      if (!in_array($team->id(), $this->teamMembershipManager->getTeams($developer->getEmail()))) {
+      // Argument #2 in getTeams() is required for checking the AppGroup members and not required for Edge.
+      if (!in_array($team->id(), $this->teamMembershipManager->getTeams($developer->getEmail(), $team->id()))) {
         return AccessResultForbidden::forbidden("The {$developer->getEmail()} developer is not member of the {$team->id()} team.");
       }
     }

--- a/modules/apigee_edge_teams/src/Entity/Form/TeamAppFormTrait.php
+++ b/modules/apigee_edge_teams/src/Entity/Form/TeamAppFormTrait.php
@@ -182,7 +182,8 @@ trait TeamAppFormTrait {
       '#weight' => -100,
     ];
 
-    if (!in_array($this->getTeamName($form, $form_state), $this->getTeamMembershipMananger()->getTeams(\Drupal::currentUser()->getEmail()))) {
+    // Argument #2 in getTeams() is required for checking the AppGroup members and not required for Edge.
+    if (!in_array($this->getTeamName($form, $form_state), $this->getTeamMembershipMananger()->getTeams(\Drupal::currentUser()->getEmail(), $this->getTeamName($form, $form_state)))) {
       $element['#message_list']['warning'][] = t('You are not member of this @team. You may see @api_products here that a @team member can not see.', [
         '@team' => mb_strtolower($this->getEntityTypeManager()->getDefinition('team')->getSingularLabel()),
         '@api_products' => $this->getEntityTypeManager()->getDefinition('api_product')->getPluralLabel(),
@@ -210,7 +211,8 @@ trait TeamAppFormTrait {
     // be visible that visibility is matching with the configured
     // non_member_team_apps_visible_api_products config key value.
     // @see nonMemberApiProductAccessWarningElement()
-    if (!in_array($team_name, $this->getTeamMembershipMananger()->getTeams(\Drupal::currentUser()->getEmail()))) {
+    // Argument #2 in getTeams() is required for checking the AppGroup members and not required for Edge.
+    if (!in_array($team_name, $this->getTeamMembershipMananger()->getTeams(\Drupal::currentUser()->getEmail(), $team_name))) {
       $filter = function (ApiProductInterface $api_product) use ($team) {
         $visibility = $api_product->getAttributeValue('access') ?? 'public';
         return in_array($visibility, $this->getConfigObject('apigee_edge_teams.team_settings')->get('non_member_team_apps_visible_api_products'));

--- a/modules/apigee_edge_teams/src/Entity/Storage/TeamMemberRoleStorage.php
+++ b/modules/apigee_edge_teams/src/Entity/Storage/TeamMemberRoleStorage.php
@@ -159,18 +159,15 @@ class TeamMemberRoleStorage extends SqlContentEntityStorage implements TeamMembe
     if ($account->isAnonymous()) {
       throw new InvalidArgumentException('Anonymous user can not be member of a team.');
     }
-    // Skipping for ApigeeX Org.
-    // TODO : Save AppGroup teams in the cache when new member is added to the team.
-    if (!$this->orgController->isOrganizationApigeeX()) {
-      try {
-        $developer_team_ids = $this->teamMembershipManager->getTeams($account->getEmail());
-      }
-      catch (\Exception $e) {
-        $developer_team_ids = [];
-      }
-      if (!in_array($team->id(), $developer_team_ids)) {
-        throw new InvalidArgumentException("{$account->getEmail()} is not member of {$team->id()} team.");
-      }
+    try {
+      // Argument #2 in getTeams() is required for checking the AppGroup members and not required for Edge.
+      $developer_team_ids = $this->teamMembershipManager->getTeams($account->getEmail(), $team->id());
+    }
+    catch (\Exception $e) {
+      $developer_team_ids = [];
+    }
+    if (!in_array($team->id(), $developer_team_ids)) {
+      throw new InvalidArgumentException("{$account->getEmail()} is not member of {$team->id()} team.");
     }
     // Indicates whether a new team member role entity had to be created
     // or not.
@@ -229,7 +226,8 @@ class TeamMemberRoleStorage extends SqlContentEntityStorage implements TeamMembe
       throw new InvalidArgumentException('Anonymous user can not be member of a team.');
     }
     try {
-      $developer_team_ids = $this->teamMembershipManager->getTeams($account->getEmail());
+      // Argument #2 in getTeams() is required for checking the AppGroup members and not required for Edge.
+      $developer_team_ids = $this->teamMembershipManager->getTeams($account->getEmail(), $team->id());
     }
     catch (\Exception $e) {
       $developer_team_ids = [];

--- a/modules/apigee_edge_teams/src/Entity/Storage/TeamMemberRoleStorage.php
+++ b/modules/apigee_edge_teams/src/Entity/Storage/TeamMemberRoleStorage.php
@@ -159,15 +159,20 @@ class TeamMemberRoleStorage extends SqlContentEntityStorage implements TeamMembe
     if ($account->isAnonymous()) {
       throw new InvalidArgumentException('Anonymous user can not be member of a team.');
     }
-    try {
-      // Argument #2 in getTeams() is required for checking the AppGroup members and not required for Edge.
-      $developer_team_ids = $this->teamMembershipManager->getTeams($account->getEmail(), $team->id());
-    }
-    catch (\Exception $e) {
-      $developer_team_ids = [];
-    }
-    if (!in_array($team->id(), $developer_team_ids)) {
-      throw new InvalidArgumentException("{$account->getEmail()} is not member of {$team->id()} team.");
+    // TODO : Implement this check for ApigeeX.
+    // DB is empty durning Team syncronization for 1st time, so $developer_team_ids
+    // is always empty which cause issue for member update in DB.
+    if (!$this->orgController->isOrganizationApigeeX()) {
+      try {
+        // Argument #2 in getTeams() is required for checking the AppGroup members and not required for Edge.
+        $developer_team_ids = $this->teamMembershipManager->getTeams($account->getEmail(), $team->id());
+      }
+      catch (\Exception $e) {
+        $developer_team_ids = [];
+      }
+      if (!in_array($team->id(), $developer_team_ids)) {
+        throw new InvalidArgumentException("{$account->getEmail()} is not member of {$team->id()} team.");
+      }
     }
     // Indicates whether a new team member role entity had to be created
     // or not.

--- a/modules/apigee_edge_teams/src/Entity/TeamAccessHandler.php
+++ b/modules/apigee_edge_teams/src/Entity/TeamAccessHandler.php
@@ -112,7 +112,8 @@ final class TeamAccessHandler extends EntityAccessControlHandler implements Enti
           $developer = $this->developerStorage->load($account->getEmail());
           // Checking for ApigeeX organization.
           if ($this->orgController->isOrganizationApigeeX()) {
-            $developer_team_ids = $developer->getAppGroups($account);
+            // Argument #2 in getTeams() is required for checking the AppGroup members and not required for Edge.
+            $developer_team_ids = $this->teamMembershipManager->getTeams($account->getEmail(), $entity->id());
           }
           else {
             $developer_team_ids = $developer->getCompanies();

--- a/modules/apigee_edge_teams/src/TeamMemberApiProductAccessHandler.php
+++ b/modules/apigee_edge_teams/src/TeamMemberApiProductAccessHandler.php
@@ -107,7 +107,8 @@ final class TeamMemberApiProductAccessHandler implements TeamMemberApiProductAcc
     }
     else {
       try {
-        $developer_team_ids = $this->teamMembershipManager->getTeams($account->getEmail());
+        // Argument #2 in getTeams() is required for checking the AppGroup members and not required for Edge.
+        $developer_team_ids = $this->teamMembershipManager->getTeams($account->getEmail(), $team->id());
       }
       catch (\Exception $e) {
         $developer_team_ids = [];

--- a/modules/apigee_edge_teams/src/TeamMembershipManagerInterface.php
+++ b/modules/apigee_edge_teams/src/TeamMembershipManagerInterface.php
@@ -76,6 +76,8 @@ interface TeamMembershipManagerInterface {
    *
    * @param string $developer
    *   Developer email address.
+   * @param string|null $team
+   *   Name of a team.
    *
    * @return string[]
    *   Array of team names.
@@ -83,6 +85,6 @@ interface TeamMembershipManagerInterface {
    * @throws \Drupal\apigee_edge\Exception\DeveloperDoesNotExistException
    *   If developer not found with id.
    */
-  public function getTeams(string $developer): array;
+  public function getTeams(string $developer, ?string $team = NULL): array;
 
 }

--- a/modules/apigee_edge_teams/src/TeamPermissionHandler.php
+++ b/modules/apigee_edge_teams/src/TeamPermissionHandler.php
@@ -151,7 +151,8 @@ final class TeamPermissionHandler implements TeamPermissionHandlerInterface {
     $developer_team_access = FALSE;
     $permissions = [];
     try {
-      $developer_team_ids = $this->teamMembershipManager->getTeams($account->getEmail());
+      // Argument #2 in getTeams() is required for checking the AppGroup members and not required for Edge.
+      $developer_team_ids = $this->teamMembershipManager->getTeams($account->getEmail(), $team->id());
     }
     catch (\Exception $e) {
       $developer_team_ids = [];

--- a/src/Entity/Developer.php
+++ b/src/Entity/Developer.php
@@ -270,36 +270,6 @@ class Developer extends EdgeEntityBase implements DeveloperInterface {
   }
 
   /**
-   * Returns a list of teams from team_member_role entity for specific developer.
-   *
-   * @param Drupal\Core\Session\AccountInterface $account
-   *   The team which members gets listed.
-   *
-   * @return array
-   *   Render array.
-   */
-  public function getAppGroups(AccountInterface $account): array {
-    // TODO : Save it to the local cache so we can serve it from there
-    // next time.
-    // Load team_member_role object.
-    $team_member_role_storage = \Drupal::entityTypeManager()->getStorage('team_member_role');
-
-    /** @var \Drupal\user\UserInterface $user */
-    $user = user_load_by_mail($account->getEmail());
-    /** @var \Drupal\apigee_edge_teams\Entity\TeamMemberRoleInterface $team_member_roles */
-    $developerTeam = array_reduce($team_member_role_storage->loadByDeveloper($user), function ($carry, TeamMemberRole $team_role) {
-      // If team is not available, avoid null value exception.
-      if ($team_role->getTeam() !== NULL) {
-        $carry[$team_role->getTeam()->id()] = $team_role->getTeam()->id();
-      }
-      return $carry;
-    },
-    []);
-
-    return array_keys($developerTeam);
-  }
-
-  /**
    * {@inheritdoc}
    */
   public function getCompanies(): array {

--- a/src/Entity/DeveloperCompaniesCache.php
+++ b/src/Entity/DeveloperCompaniesCache.php
@@ -48,33 +48,9 @@ final class DeveloperCompaniesCache implements DeveloperCompaniesCacheInterface 
   /**
    * {@inheritdoc}
    */
-  public function getAppGroups(string $id): ?array {
-    $item = $this->backend->get($id);
-    return $item ? $item->data : NULL;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function getCompanies(string $id): ?array {
     $item = $this->backend->get($id);
     return $item ? $item->data : NULL;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function saveAppGroups(array $developers): void {
-    /** @var \Apigee\Edge\Api\Management\Entity\DeveloperInterface $developer */
-    foreach ($developers as $developer) {
-      $tags = array_merge([
-        "developer:{$developer->getDeveloperId()}",
-        "developer:{$developer->getEmail()}",
-      ], array_map(function (string $company) {
-        return "company:{$company}";
-      }, $developer->getAppGroups()));
-      $this->backend->set($developer->id(), $developer->getAppGroups(), CacheBackendInterface::CACHE_PERMANENT, $tags);
-    }
   }
 
   /**

--- a/src/Entity/DeveloperCompaniesCacheInterface.php
+++ b/src/Entity/DeveloperCompaniesCacheInterface.php
@@ -42,25 +42,6 @@ interface DeveloperCompaniesCacheInterface {
   public function getCompanies(string $id): ?array;
 
   /**
-   * Returns appgroups of a developer.
-   *
-   * @param string $id
-   *   Developer id.
-   *
-   * @return string[]|null
-   *   Array of appgroup names or NULL if information is not yet available.
-   */
-  public function getAppGroups(string $id): ?array;
-
-  /**
-   * Saves developers' appgroups to cache.
-   *
-   * @param \Apigee\Edge\Api\Management\Entity\DeveloperInterface[] $developers
-   *   Developer entities.
-   */
-  public function saveAppGroups(array $developers): void;
-
-  /**
    * Saves developers' companies to cache.
    *
    * @param \Apigee\Edge\Api\Management\Entity\DeveloperInterface[] $developers


### PR DESCRIPTION
Getting the team members from Drupal database tables and also fix the multiple recurring api call to `/team/{teamname}`


Closes #830 as we are loading data from database and not from cache for Team member and for loading teams we are using cache already.