### PR TITLE
JsonAPI requires UUID for getting the entity information

### DIFF
--- a/src/Entity/ApiProduct.php
+++ b/src/Entity/ApiProduct.php
@@ -36,10 +36,6 @@ use Apigee\Edge\Structure\AttributesProperty;
  *     singular = "@count API",
  *     plural = "@count APIs",
  *   ),
- *   entity_keys = {
- *    "id" = "id",
- *    "uuid" = "uuid"
- *   },
  *   config_with_labels = "apigee_edge.api_product_settings",
  *   handlers = {
  *     "storage" = "\Drupal\apigee_edge\Entity\Storage\ApiProductStorage",

--- a/src/Entity/ApiProduct.php
+++ b/src/Entity/ApiProduct.php
@@ -36,6 +36,10 @@ use Apigee\Edge\Structure\AttributesProperty;
  *     singular = "@count API",
  *     plural = "@count APIs",
  *   ),
+ *   entity_keys = {
+ *    "id" = "id",
+ *    "uuid" = "uuid"
+ *   },
  *   config_with_labels = "apigee_edge.api_product_settings",
  *   handlers = {
  *     "storage" = "\Drupal\apigee_edge\Entity\Storage\ApiProductStorage",
@@ -76,6 +80,15 @@ class ApiProduct extends EdgeEntityBase implements ApiProductInterface {
    */
   public function id(): ?string {
     return parent::id();
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * We are sending id as uuid for getting api products while using JSONAPI.
+   */
+  public function uuid(): ?string {
+    return $this->id();
   }
 
   /**


### PR DESCRIPTION
Fix #878
This PR resolves `Internal Server Error` -
`"Parameter \"entity\" for route \"jsonapi.api_product--api_product.individual\" must match \"[^/]++\" (\"\" given) to generate a corresponding URL.` due to missing uuid().