### PR TITLE
Expiry date hence changed to now and developer renamed to members

### DIFF
--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -1186,11 +1186,11 @@ function template_preprocess_app_credential(array &$variables) {
       /** @var \DateTimeInterface $value */
       if ($value !== -1) {
         $time_diff = \Drupal::time()->getRequestTime() - intval($value / 1000);
-        if ($time_diff > 0) {
+        if ($time_diff >= 0) {
           $value = t('@time ago', ['@time' => $dateFormatter->formatTimeDiffSince(intval($value / 1000))]);
         }
         else {
-          $value = t('@time hence', ['@time' => $dateFormatter->formatTimeDiffUntil(intval($value / 1000))]);
+          $value = t('@time from now', ['@time' => $dateFormatter->formatTimeDiffUntil(intval($value / 1000))]);
         }
       }
       else {

--- a/modules/apigee_edge_teams/src/Entity/Form/TeamAppEditForm.php
+++ b/modules/apigee_edge_teams/src/Entity/Form/TeamAppEditForm.php
@@ -113,12 +113,12 @@ class TeamAppEditForm extends AppEditForm {
     // Hide the Delete button.
     $actions['delete']['#access'] = FALSE;
     // Cancel button to redirect the user to team app listing page.
-    $actions['cancel'] = array (
+    $actions['cancel'] = [
       '#type' => 'link',
       '#title' => $this->t('Cancel'),
       '#attributes' => ['class' => ['btn btn-outline-primary']],
       '#url' => $this->entity->toUrl('collection-by-team'),
-    );
+    ];
     return $actions;
   }
 

--- a/modules/apigee_edge_teams/src/Form/AddTeamMembersForm.php
+++ b/modules/apigee_edge_teams/src/Form/AddTeamMembersForm.php
@@ -95,8 +95,8 @@ class AddTeamMembersForm extends TeamMembersFormBase {
     $role_options = $this->getRoleOptions();
 
     $form['developers'] = [
-      '#title' => $this->t('Members'),
-      '#description' => $this->t('Enter the email of one or more members, separated by commas, to invite them to the @team.', [
+      '#title' => $this->t('Email address(es)'),
+      '#description' => $this->t('Enter the email of one or more developers, separated by commas, to invite them to the @team.', [
         '@team' => mb_strtolower($this->team->getEntityType()->getSingularLabel()),
       ]),
       '#type' => 'textarea',
@@ -118,7 +118,7 @@ class AddTeamMembersForm extends TeamMembersFormBase {
     ];
 
     $form['team_roles']['description'] = [
-      '#markup' => $this->t('Assign one or more roles to <em>all members</em> that you selected in %team_label @team.', [
+      '#markup' => $this->t('Assign one or more roles to <em>all developers</em> that you selected in %team_label @team.', [
         '%team_label' => $this->team->label(),
         '@team' => mb_strtolower($this->team->getEntityType()->getSingularLabel()),
       ]),

--- a/modules/apigee_edge_teams/src/Form/AddTeamMembersForm.php
+++ b/modules/apigee_edge_teams/src/Form/AddTeamMembersForm.php
@@ -95,8 +95,8 @@ class AddTeamMembersForm extends TeamMembersFormBase {
     $role_options = $this->getRoleOptions();
 
     $form['developers'] = [
-      '#title' => $this->t('Developers'),
-      '#description' => $this->t('Enter the email of one or more developers to invite them to the @team, separated by comma.', [
+      '#title' => $this->t('Members'),
+      '#description' => $this->t('Enter the email of one or more members, separated by commas, to invite them to the @team.', [
         '@team' => mb_strtolower($this->team->getEntityType()->getSingularLabel()),
       ]),
       '#type' => 'textarea',
@@ -118,7 +118,7 @@ class AddTeamMembersForm extends TeamMembersFormBase {
     ];
 
     $form['team_roles']['description'] = [
-      '#markup' => $this->t('Assign one or more roles to <em>all developers</em> that you selected in %team_label @team.', [
+      '#markup' => $this->t('Assign one or more roles to <em>all members</em> that you selected in %team_label @team.', [
         '%team_label' => $this->team->label(),
         '@team' => mb_strtolower($this->team->getEntityType()->getSingularLabel()),
       ]),

--- a/tests/src/Functional/DeveloperAppUITest.php
+++ b/tests/src/Functional/DeveloperAppUITest.php
@@ -268,7 +268,7 @@ class DeveloperAppUITest extends ApigeeEdgeFunctionalTestBase {
     $this->assertSession()->pageTextContains($name);
     $this->clickLink($name);
     // Result depends on how fast the response was.
-    $this->assertSession()->pageTextMatches('/1 week (2|3) days hence/');
+    $this->assertSession()->pageTextMatches('/1 week (2|3) days from now/');
 
     // Change credential lifetime to 0 (Never) days from 10.
     $this->drupalGet($url);


### PR DESCRIPTION
- App key expiry date format 'hence' replaced with 'now'. 
- In invite team member page, the title `Developers` replaced with `Email address(es)` as the members of an Apigee edge/X are not necessarily `developers`.
- 
b/289746352