### PR TITLE
Post create team redirection and changed internal name as machine name

### DIFF
--- a/modules/apigee_edge_teams/src/Entity/Form/TeamForm.php
+++ b/modules/apigee_edge_teams/src/Entity/Form/TeamForm.php
@@ -188,11 +188,11 @@ class TeamForm extends FieldableEdgeEntityForm implements EdgeEntityFormInterfac
     $team = $this->entity;
 
     $form['name'] = [
-      '#title' => $this->t('Internal name'),
+      '#title' => $this->t('Machine name'),
       '#type' => 'machine_name',
       '#machine_name' => [
         'source' => ['displayName', 'widget', 0, 'value'],
-        'label' => $this->t('Internal name'),
+        'label' => $this->t('Machine name'),
         'exists' => [$this, 'exists'],
       ],
       '#field_prefix' => $team->isNew() ? $this->team_prefix : "",
@@ -308,7 +308,8 @@ class TeamForm extends FieldableEdgeEntityForm implements EdgeEntityFormInterfac
       }
 
     }
-    $form_state->setRedirectUrl($team->toUrl('collection'));
+    // Redirecting user to team view page to manage the team members and apps.
+    $form_state->setRedirectUrl($team->toUrl('canonical'));
 
     return $result;
   }

--- a/src/Entity/Form/AppForm.php
+++ b/src/Entity/Form/AppForm.php
@@ -73,10 +73,10 @@ abstract class AppForm extends FieldableEdgeEntityForm {
       '#type' => 'machine_name',
       '#machine_name' => [
         'source' => ['displayName', 'widget', 0, 'value'],
-        'label' => $this->t('Internal name'),
+        'label' => $this->t('Machine name'),
         'exists' => [$this, 'appExists'],
       ],
-      '#title' => $this->t('Internal name'),
+      '#title' => $this->t('Machine name'),
       // It should/can not be changed if app is not new.
       '#disabled' => !$app->isNew(),
       '#default_value' => $app->getName(),


### PR DESCRIPTION
- Changed `Internal name` as `Machine name` 
- Following the team creation, user is redirected to manage the members and apps for that team.

b/289746352