### PR TITLE
Nitpick - label change Credential to Key Status

### DIFF
--- a/modules/apigee_edge_teams/tests/src/Functional/UiTest.php
+++ b/modules/apigee_edge_teams/tests/src/Functional/UiTest.php
@@ -192,7 +192,6 @@ class UiTest extends ApigeeEdgeTeamsFunctionalTestBase {
       'field_email[0][value]' => $this->fields['email']['data_edited'],
     ], 'Save team');
 
-    $this->clickLink($team_modified_display_name);
     $this->assertSession()->pageTextContains($team_modified_display_name);
     $this->assertSession()->pageTextContains($this->fields['integer']['data_edited']);
     $this->assertSession()->pageTextContains($this->fields['email']['data_edited']);

--- a/modules/apigee_edge_teams/tests/src/Functional/UiTest.php
+++ b/modules/apigee_edge_teams/tests/src/Functional/UiTest.php
@@ -178,7 +178,6 @@ class UiTest extends ApigeeEdgeTeamsFunctionalTestBase {
 
     // The team's display name and field values are visible on the canonical
     // page.
-    $this->clickLink($team_display_name);
     $this->assertSession()->pageTextContains($team_display_name);
     $this->assertSession()->pageTextContains($this->fields['integer']['data']);
     $this->assertSession()->pageTextContains($this->fields['email']['data']);

--- a/src/Entity/Form/AppEditForm.php
+++ b/src/Entity/Form/AppEditForm.php
@@ -124,7 +124,7 @@ abstract class AppEditForm extends AppForm {
 
         $form['credential'][$credential->getConsumerKey()] = [
           '#type' => 'fieldset',
-          '#title' => $rendered_credential_status . $this->t('Credential'),
+          '#title' => $this->t('Key Status:') . $rendered_credential_status,
           '#collapsible' => FALSE,
         ];
 


### PR DESCRIPTION
Nitpick - label change for better readability.
Test case changes - after creating team redirecting to canonical (redirection changed in PR https://github.com/apigee/apigee-edge-drupal/pull/885)