### PR TITLE
JsonAPI requires UUID for getting the entity information

### DIFF
--- a/src/Entity/ApiProduct.php
+++ b/src/Entity/ApiProduct.php
@@ -80,6 +80,15 @@ class ApiProduct extends EdgeEntityBase implements ApiProductInterface {
 
   /**
    * {@inheritdoc}
+   *
+   * We are sending id as uuid for getting api products while using JSONAPI.
+   */
+  public function uuid(): ?string {
+    return $this->id();
+  }
+
+  /**
+   * {@inheritdoc}
    */
   protected function drupalEntityId(): ?string {
     return $this->getName();


### PR DESCRIPTION
Fix #878 for 3.x branch

This PR resolves `Internal Server Error` -
`"Parameter \"entity\" for route \"jsonapi.api_product--api_product.indivaidual\" must match \"[^/]++\" (\"\" given) to generate a corresponding URL.` due to missing uuid().