### PR TITLE
Added UUID in entity_keys for JSONAPI to get the link attribute

### DIFF
--- a/src/Entity/ApiProduct.php
+++ b/src/Entity/ApiProduct.php
@@ -36,6 +36,9 @@ use Apigee\Edge\Structure\AttributesProperty;
  *     singular = "@count API",
  *     plural = "@count APIs",
  *   ),
+ *   entity_keys = {
+ *    "uuid" = "uuid"
+ *   },
  *   config_with_labels = "apigee_edge.api_product_settings",
  *   handlers = {
  *     "storage" = "\Drupal\apigee_edge\Entity\Storage\ApiProductStorage",


### PR DESCRIPTION
Fix #878 
Fix missing link attribute in JSONAPI `api_product` listing.