### PR TITLE
Fix for deprecation notice - Creation of dynamic property $organization

### DIFF
--- a/src/Entity/Controller/OrganizationController.php
+++ b/src/Entity/Controller/OrganizationController.php
@@ -67,6 +67,13 @@ final class OrganizationController implements OrganizationControllerInterface {
   private $connector;
 
   /**
+   * Apigee organization details.
+   *
+   * @var \Apigee\Edge\Api\Management\Entity\Organization
+   */
+  private $organization;
+
+  /**
    * OrganizationController constructor.
    *
    * @param \Drupal\apigee_edge\SDKConnectorInterface $connector


### PR DESCRIPTION
Fixes #909 
Refer [php 8.2 doc ](https://php.watch/versions/8.2/dynamic-properties-deprecated)