### PR TITLE
Fix for deprecation notice - Creation of dynamic property $_serviceId

### DIFF
--- a/modules/apigee_edge_debug/src/SDKConnector.php
+++ b/modules/apigee_edge_debug/src/SDKConnector.php
@@ -54,6 +54,13 @@ class SDKConnector extends OriginalSDKConnector implements SDKConnectorInterface
   private $innerService;
 
   /**
+   * The service ID.
+   *
+   * @var string
+   */
+  public $_serviceId;
+
+  /**
    * Constructs a new SDKConnector.
    *
    * @param \Drupal\apigee_edge\SDKConnectorInterface $inner_service

--- a/tests/modules/apigee_edge_test/src/SDKConnector.php
+++ b/tests/modules/apigee_edge_test/src/SDKConnector.php
@@ -56,6 +56,13 @@ final class SDKConnector extends DecoratedSDKConnector implements SDKConnectorIn
   private $logger;
 
   /**
+   * The service ID.
+   *
+   * @var string
+   */
+  public $_serviceId;
+
+  /**
    * Constructs a new SDKConnector.
    *
    * @param \Drupal\apigee_edge\SDKConnectorInterface $inner_service

--- a/tests/modules/apigee_edge_test/src/UserDeveloperConverter.php
+++ b/tests/modules/apigee_edge_test/src/UserDeveloperConverter.php
@@ -44,6 +44,13 @@ final class UserDeveloperConverter extends DecoratedUserDeveloperConverter {
   private $innerService;
 
   /**
+   * The service ID.
+   *
+   * @var string
+   */
+  public $_serviceId;
+
+  /**
    * UserToDeveloper constructor.
    *
    * @param \Drupal\apigee_edge\UserDeveloperConverterInterface $inner_service


### PR DESCRIPTION
Fixes #910 
Refer [php 8.2 doc](https://php.watch/versions/8.2/dynamic-properties-deprecated)