### PR TITLE
Fix PHPCS and test case fail issue

### DIFF
--- a/modules/apigee_edge_actions/tests/src/Kernel/Plugin/RulesEvent/EdgeEntityAddMemberEventTest.php
+++ b/modules/apigee_edge_actions/tests/src/Kernel/Plugin/RulesEvent/EdgeEntityAddMemberEventTest.php
@@ -56,6 +56,15 @@ class EdgeEntityAddMemberEventTest extends ApigeeEdgeActionsRulesKernelTestBase 
     $this->installEntitySchema('team_member_role');
 
     $this->addOrganizationMatchedResponse();
+
+    // Setting teams cache to 900 to make sure null value is not returned in getCacheMaxAge().
+    $config_factory = \Drupal::configFactory();
+    $config = $config_factory->getEditable('apigee_edge_teams.team_settings');
+
+    if (null === $config->get('cache_expiration')) {
+      $config->set('cache_expiration', 900);
+      $config->save(TRUE);
+    }
   }
 
   /**

--- a/modules/apigee_edge_actions/tests/src/Kernel/Plugin/RulesEvent/EdgeEntityAddMemberEventTest.php
+++ b/modules/apigee_edge_actions/tests/src/Kernel/Plugin/RulesEvent/EdgeEntityAddMemberEventTest.php
@@ -61,7 +61,7 @@ class EdgeEntityAddMemberEventTest extends ApigeeEdgeActionsRulesKernelTestBase 
     $config_factory = \Drupal::configFactory();
     $config = $config_factory->getEditable('apigee_edge_teams.team_settings');
 
-    if (null === $config->get('cache_expiration')) {
+    if (NULL === $config->get('cache_expiration')) {
       $config->set('cache_expiration', 900);
       $config->save(TRUE);
     }

--- a/modules/apigee_edge_actions/tests/src/Kernel/Plugin/RulesEvent/EdgeEntityRemoveMemberEventTest.php
+++ b/modules/apigee_edge_actions/tests/src/Kernel/Plugin/RulesEvent/EdgeEntityRemoveMemberEventTest.php
@@ -60,7 +60,7 @@ class EdgeEntityRemoveMemberEventTest extends ApigeeEdgeActionsRulesKernelTestBa
     $config_factory = \Drupal::configFactory();
     $config = $config_factory->getEditable('apigee_edge_teams.team_settings');
 
-    if (null === $config->get('cache_expiration')) {
+    if (NULL === $config->get('cache_expiration')) {
       $config->set('cache_expiration', 900);
       $config->save(TRUE);
     }

--- a/modules/apigee_edge_actions/tests/src/Kernel/Plugin/RulesEvent/EdgeEntityRemoveMemberEventTest.php
+++ b/modules/apigee_edge_actions/tests/src/Kernel/Plugin/RulesEvent/EdgeEntityRemoveMemberEventTest.php
@@ -55,6 +55,15 @@ class EdgeEntityRemoveMemberEventTest extends ApigeeEdgeActionsRulesKernelTestBa
     $this->installEntitySchema('team_member_role');
 
     $this->addOrganizationMatchedResponse();
+
+    // Setting teams cache to 900 to make sure null value is not returned in getCacheMaxAge().
+    $config_factory = \Drupal::configFactory();
+    $config = $config_factory->getEditable('apigee_edge_teams.team_settings');
+
+    if (null === $config->get('cache_expiration')) {
+      $config->set('cache_expiration', 900);
+      $config->save(TRUE);
+    }
   }
 
   /**

--- a/modules/apigee_edge_teams/src/Entity/Team.php
+++ b/modules/apigee_edge_teams/src/Entity/Team.php
@@ -391,7 +391,7 @@ class Team extends AttributesAwareFieldableEdgeEntityBase implements TeamInterfa
    * {@inheritdoc}
    */
   public function getCacheMaxAge(): int {
-    return \Drupal::config('apigee_edge.team_settings')->get('cache_expiration');
+    return \Drupal::config('apigee_edge_teams.team_settings')->get('cache_expiration');
   }
 
 }

--- a/modules/apigee_edge_teams/src/Entity/TeamApp.php
+++ b/modules/apigee_edge_teams/src/Entity/TeamApp.php
@@ -228,7 +228,7 @@ class TeamApp extends App implements TeamAppInterface {
    * {@inheritdoc}
    */
   public function getCacheMaxAge(): int {
-    return \Drupal::config('apigee_edge.team_app_settings')->get('cache_expiration');
+    return \Drupal::config('apigee_edge_teams.team_app_settings')->get('cache_expiration');
   }
 
 }

--- a/src/Entity/ApiProduct.php
+++ b/src/Entity/ApiProduct.php
@@ -334,4 +334,5 @@ class ApiProduct extends EdgeEntityBase implements ApiProductInterface {
   public function getCacheMaxAge(): int {
     return \Drupal::config('apigee_edge.api_product_settings')->get('cache_expiration');
   }
+
 }

--- a/src/Entity/DeveloperApp.php
+++ b/src/Entity/DeveloperApp.php
@@ -296,4 +296,5 @@ class DeveloperApp extends App implements DeveloperAppInterface {
   public function getCacheMaxAge(): int {
     return \Drupal::config('apigee_edge.developer_app_settings')->get('cache_expiration');
   }
+
 }


### PR DESCRIPTION
Fixes `PHPCS` and test cases fail due to returning null value in getCacheMaxAge() for teams.
Closes #916 

Originally issue PR #917