### PR TITLE
Resolved the validation for monitized enabled org for enabling teams for ApigeeX and edge

### DIFF
--- a/modules/apigee_edge_teams/apigee_edge_teams.install
+++ b/modules/apigee_edge_teams/apigee_edge_teams.install
@@ -43,7 +43,7 @@ function apigee_edge_teams_requirements($phase) {
       $organization = $org_controller->load($sdk_connector->getOrganization());
       if ($organization && $org_controller->isOrganizationApigeeX()) {
         // AppGroup APIs are not supported in Apigee X / Hybrid orgs with monetization enabled.
-        if ($organization->getAddonsConfig() || TRUE === $organization->getAddonsConfig()->getMonetizationConfig()->getEnabled()) {
+        if ($organization->getAddonsConfig() && $organization->getAddonsConfig()->getMonetizationConfig() && TRUE === $organization->getAddonsConfig()->getMonetizationConfig()->getEnabled()) {
           $url = [
             ':url' => 'https://cloud.google.com/apigee/docs/api-platform/publish/organizing-client-app-ownership?hl=en#appgroups-limitations-and-known-issues',
           ];

--- a/modules/apigee_edge_teams/apigee_edge_teams.install
+++ b/modules/apigee_edge_teams/apigee_edge_teams.install
@@ -41,18 +41,36 @@ function apigee_edge_teams_requirements($phase) {
       $org_controller = \Drupal::service('apigee_edge.controller.organization');
       /* @var \Apigee\Edge\Api\Management\Entity\Organization $organization */
       $organization = $org_controller->load($sdk_connector->getOrganization());
-      if ($organization && !OrganizationFeatures::isCompaniesFeatureAvailable($organization) && OrganizationFeatures::isMonetizationEnabled($organization)) {
-        $url = [
-          ':url' => 'https://cloud.google.com/apigee/docs/api-platform/get-started/compare-apigee-products#unsupported-apis',
-        ];
-        $message = ($phase == 'runtime') ?
-          t("The Teams module functionality is not available for monetization enabled org on Apigee X / Hybrid and should be uninstalled, because <a href=':url' target='_blank'>AppGroup APIs are not supported in Apigee X / Hybrid orgs with monetization enabled</a>.", $url) :
-          t("The Teams module functionality is not available for monetization enabled org on Apigee X / Hybrid because <a href=':url' target='_blank'>AppGroup APIs are not supported in Apigee X / Hybrid orgs with monetization enabled</a>.", $url);
-        $requirements['apigee_edge_teams_not_supported'] = [
-          'title' => t('Apigee Edge Teams'),
-          'description' => $message,
-          'severity' => REQUIREMENT_ERROR,
-        ];
+      if ($organization && $org_controller->isOrganizationApigeeX()) {
+        // AppGroup APIs are not supported in Apigee X / Hybrid orgs with monetization enabled.
+        if ($organization->getAddonsConfig() || TRUE === $organization->getAddonsConfig()->getMonetizationConfig()->getEnabled()) {
+          $url = [
+            ':url' => 'https://cloud.google.com/apigee/docs/api-platform/get-started/compare-apigee-products#unsupported-apis',
+          ];
+          $message = ($phase == 'runtime') ?
+            t("The Teams module functionality is not available for monetization enabled org on Apigee X / Hybrid and should be uninstalled, because <a href=':url' target='_blank'>AppGroup APIs are not supported in Apigee X / Hybrid orgs with monetization enabled</a>.", $url) :
+            t("The Teams module functionality is not available for monetization enabled org on Apigee X / Hybrid because <a href=':url' target='_blank'>AppGroup APIs are not supported in Apigee X / Hybrid orgs with monetization enabled</a>.", $url);
+          $requirements['apigee_edge_teams_not_supported'] = [
+            'title' => t('Apigee Edge Teams'),
+            'description' => $message,
+            'severity' => REQUIREMENT_ERROR,
+          ];
+        }
+      } else {
+        // Edge company APIs are not supported in Apigee Hybrid orgs.
+        if ($organization && !OrganizationFeatures::isCompaniesFeatureAvailable($organization)) {
+          $url = [
+            ':url' => 'https://cloud.google.com/apigee/docs/api-platform/get-started/compare-apigee-products#unsupported-apis',
+          ];
+          $message = ($phase == 'runtime') ?
+            t("The Apigee Edge Teams module functionality is not available for your org and should be uninstalled, because <a href=':url' target='_blank'>Edge company APIs are not supported for Apigee Hybrid orgs</a>.", $url) :
+            t("The Apigee Edge Teams module functionality is not available for your org because <a href=':url' target='_blank'>Edge company APIs are not supported for Apigee Hybrid orgs</a>.", $url);
+          $requirements['apigee_edge_teams_not_supported'] = [
+            'title' => t('Apigee Edge Teams'),
+            'description' => $message,
+            'severity' => REQUIREMENT_ERROR,
+          ];
+        }
       }
     }
     catch (\Exception $exception) {

--- a/modules/apigee_edge_teams/apigee_edge_teams.install
+++ b/modules/apigee_edge_teams/apigee_edge_teams.install
@@ -45,7 +45,7 @@ function apigee_edge_teams_requirements($phase) {
         // AppGroup APIs are not supported in Apigee X / Hybrid orgs with monetization enabled.
         if ($organization->getAddonsConfig() || TRUE === $organization->getAddonsConfig()->getMonetizationConfig()->getEnabled()) {
           $url = [
-            ':url' => 'https://cloud.google.com/apigee/docs/api-platform/get-started/compare-apigee-products#unsupported-apis',
+            ':url' => 'https://cloud.google.com/apigee/docs/api-platform/publish/organizing-client-app-ownership?hl=en#appgroups-limitations-and-known-issues',
           ];
           $message = ($phase == 'runtime') ?
             t("The Teams module functionality is not available for monetization enabled org on Apigee X / Hybrid and should be uninstalled, because <a href=':url' target='_blank'>AppGroup APIs are not supported in Apigee X / Hybrid orgs with monetization enabled</a>.", $url) :

--- a/modules/apigee_edge_teams/apigee_edge_teams.install
+++ b/modules/apigee_edge_teams/apigee_edge_teams.install
@@ -56,21 +56,6 @@ function apigee_edge_teams_requirements($phase) {
             'severity' => REQUIREMENT_ERROR,
           ];
         }
-      } else {
-        // Edge company APIs are not supported in Apigee Hybrid orgs.
-        if ($organization && !OrganizationFeatures::isCompaniesFeatureAvailable($organization)) {
-          $url = [
-            ':url' => 'https://cloud.google.com/apigee/docs/api-platform/get-started/compare-apigee-products#unsupported-apis',
-          ];
-          $message = ($phase == 'runtime') ?
-            t("The Apigee Edge Teams module functionality is not available for your org and should be uninstalled, because <a href=':url' target='_blank'>Edge company APIs are not supported for Apigee Hybrid orgs</a>.", $url) :
-            t("The Apigee Edge Teams module functionality is not available for your org because <a href=':url' target='_blank'>Edge company APIs are not supported for Apigee Hybrid orgs</a>.", $url);
-          $requirements['apigee_edge_teams_not_supported'] = [
-            'title' => t('Apigee Edge Teams'),
-            'description' => $message,
-            'severity' => REQUIREMENT_ERROR,
-          ];
-        }
       }
     }
     catch (\Exception $exception) {

--- a/modules/apigee_edge_teams/apigee_edge_teams.services.yml
+++ b/modules/apigee_edge_teams/apigee_edge_teams.services.yml
@@ -121,6 +121,12 @@ services:
     tags:
       - { name: event_subscriber }
 
+  apigee_edge_teams.validate_apigeexteam_enabled:
+    class: Drupal\apigee_edge_teams\EventSubscriber\ValidateApigeeXTeamEnabledSubscriber
+    arguments: ['@apigee_edge.sdk_connector', '@apigee_edge.controller.organization', '@messenger']
+    tags:
+      - {name: event_subscriber}
+
   route.subscriber.apigee_edge_teams.team_app_by_name:
     class: Drupal\apigee_edge_teams\Routing\TeamAppByNameRouteAlterSubscriber
     tags:

--- a/modules/apigee_edge_teams/apigee_edge_teams.services.yml
+++ b/modules/apigee_edge_teams/apigee_edge_teams.services.yml
@@ -123,7 +123,7 @@ services:
 
   apigee_edge_teams.validate_apigeexteam_enabled:
     class: Drupal\apigee_edge_teams\EventSubscriber\ValidateApigeeXTeamEnabledSubscriber
-    arguments: ['@apigee_edge.sdk_connector', '@apigee_edge.controller.organization', '@messenger']
+    arguments: ['@current_user', '@apigee_edge.sdk_connector', '@apigee_edge.controller.organization', '@messenger']
     tags:
       - {name: event_subscriber}
 

--- a/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
+++ b/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * Copyright 2023 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_edge_teams\EventSubscriber;
+
+use Drupal\apigee_edge\Entity\Controller\OrganizationControllerInterface;
+use Drupal\apigee_edge\SDKConnectorInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Validates that Apigee X Team is enabled on Team list page.
+ */
+class ValidateApigeeXTeamEnabledSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The SDK connector service.
+   *
+   * @var \Drupal\apigee_edge\SDKConnectorInterface
+   */
+  private $connector;
+
+  /**
+   * The organization controller service.
+   *
+   * @var \Drupal\apigee_edge\Entity\Controller\OrganizationControllerInterface
+   */
+  protected $orgController;
+
+  /**
+   * The messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * ValidateApigeeXTeamEnabledSubscriber constructor.
+   *
+   * @param \Drupal\apigee_edge\SDKConnectorInterface $sdk_connector
+   *   The SDK connector service.
+   * @param \Drupal\apigee_edge\Entity\Controller\OrganizationControllerInterface $org_controller
+   *   The organization controller service.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
+   */
+  public function __construct(SDKConnectorInterface $sdk_connector, OrganizationControllerInterface $org_controller, MessengerInterface $messenger) {
+    $this->connector = $sdk_connector;
+    $this->orgController = $org_controller;
+    $this->messenger = $messenger;
+  }
+
+  /**
+   * If monetization enabled in Apigee X org alert the user.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\RequestEvent $event
+   *   The event.
+   */
+  public function validateApigeeXTeamEnabled(RequestEvent $event) {
+    /** @var \Symfony\Component\Routing\Route $current_route */
+    if (($current_route = $event->getRequest()->get('_route')) && ($current_route === 'entity.team.collection')) {
+      $organization = $this->orgController->load($this->connector->getOrganization());
+      if ($organization && $this->orgController->isOrganizationApigeeX()) {
+        if ($organization->getAddonsConfig() || TRUE === $organization->getAddonsConfig()->getMonetizationConfig()->getEnabled()) {
+          $this->messenger->addError('The Teams module functionality is not available for monetization enabled org on Apigee X / Hybrid and should be uninstalled');
+        }
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[KernelEvents::REQUEST][] = ['validateApigeeXTeamEnabled'];
+    return $events;
+  }
+
+}

--- a/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
+++ b/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
@@ -93,7 +93,7 @@ final class ValidateApigeeXTeamEnabledSubscriber implements EventSubscriberInter
         $organization = $this->orgController->load($this->connector->getOrganization());
         if ($organization && $this->orgController->isOrganizationApigeeX()) {
           if ($organization->getAddonsConfig() || TRUE === $organization->getAddonsConfig()->getMonetizationConfig()->getEnabled()) {
-            $this->messenger->addError('The Teams module functionality is not available for monetization enabled org on Apigee X / Hybrid and should be uninstalled.');
+            $this->messenger->addError($this->t('The Teams module functionality is not available for monetization enabled org on Apigee X / Hybrid and should be uninstalled.'));
           }
         }
       }

--- a/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
+++ b/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
@@ -75,12 +75,15 @@ final class ValidateApigeeXTeamEnabledSubscriber implements EventSubscriberInter
    *   The event.
    */
   public function validateApigeexTeamEnabled(RequestEvent $event) {
-    /** @var \Symfony\Component\Routing\Route $current_route */
-    if (($current_route = $event->getRequest()->get('_route')) && (strpos($current_route, 'entity.team') !== FALSE || strpos($current_route, 'settings.team') !== FALSE)) {
-      $organization = $this->orgController->load($this->connector->getOrganization());
-      if ($organization && $this->orgController->isOrganizationApigeeX()) {
-        if ($organization->getAddonsConfig() || TRUE === $organization->getAddonsConfig()->getMonetizationConfig()->getEnabled()) {
-          $this->messenger->addError('The Teams module functionality is not available for monetization enabled org on Apigee X / Hybrid and should be uninstalled.');
+    // Check only for html request.
+    if ($event->getRequest()->getRequestFormat() === 'html') {
+      /** @var \Symfony\Component\Routing\Route $current_route */
+      if (($current_route = $event->getRequest()->get('_route')) && (strpos($current_route, 'entity.team') !== FALSE || strpos($current_route, 'settings.team') !== FALSE)) {
+        $organization = $this->orgController->load($this->connector->getOrganization());
+        if ($organization && $this->orgController->isOrganizationApigeeX()) {
+          if ($organization->getAddonsConfig() || TRUE === $organization->getAddonsConfig()->getMonetizationConfig()->getEnabled()) {
+            $this->messenger->addError('The Teams module functionality is not available for monetization enabled org on Apigee X / Hybrid and should be uninstalled.');
+          }
         }
       }
     }

--- a/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
+++ b/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
@@ -76,7 +76,7 @@ class ValidateApigeeXTeamEnabledSubscriber implements EventSubscriberInterface {
    */
   public function validateApigeexTeamEnabled(RequestEvent $event) {
     /** @var \Symfony\Component\Routing\Route $current_route */
-    if (($current_route = $event->getRequest()->get('_route')) && (strpos($current_route, 'team') !== false)) {
+    if (($current_route = $event->getRequest()->get('_route')) && (strpos($current_route, 'team') !== FALSE)) {
       $organization = $this->orgController->load($this->connector->getOrganization());
       if ($organization && $this->orgController->isOrganizationApigeeX()) {
         if ($organization->getAddonsConfig() || TRUE === $organization->getAddonsConfig()->getMonetizationConfig()->getEnabled()) {

--- a/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
+++ b/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
@@ -23,6 +23,7 @@ use Drupal\apigee_edge\Entity\Controller\OrganizationControllerInterface;
 use Drupal\apigee_edge\SDKConnectorInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -31,6 +32,8 @@ use Symfony\Component\HttpKernel\KernelEvents;
  * Validates that Apigee X Team is enabled on every Team page request.
  */
 final class ValidateApigeeXTeamEnabledSubscriber implements EventSubscriberInterface {
+
+  use StringTranslationTrait;
 
   /**
    * The current user.

--- a/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
+++ b/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
@@ -29,28 +29,28 @@ use Symfony\Component\HttpKernel\KernelEvents;
 /**
  * Validates that Apigee X Team is enabled on every Team page request.
  */
-class ValidateApigeeXTeamEnabledSubscriber implements EventSubscriberInterface {
+final class ValidateApigeeXTeamEnabledSubscriber implements EventSubscriberInterface {
 
   /**
    * The SDK connector service.
    *
    * @var \Drupal\apigee_edge\SDKConnectorInterface
    */
-  private $connector;
+  private SDKConnectorInterface $connector;
 
   /**
    * The organization controller service.
    *
    * @var \Drupal\apigee_edge\Entity\Controller\OrganizationControllerInterface
    */
-  protected $orgController;
+  protected OrganizationControllerInterface $orgController;
 
   /**
    * The messenger service.
    *
    * @var \Drupal\Core\Messenger\MessengerInterface
    */
-  protected $messenger;
+  protected MessengerInterface $messenger;
 
   /**
    * ValidateApigeeXTeamEnabledSubscriber constructor.
@@ -76,11 +76,11 @@ class ValidateApigeeXTeamEnabledSubscriber implements EventSubscriberInterface {
    */
   public function validateApigeexTeamEnabled(RequestEvent $event) {
     /** @var \Symfony\Component\Routing\Route $current_route */
-    if (($current_route = $event->getRequest()->get('_route')) && (strpos($current_route, 'team') !== FALSE)) {
+    if (($current_route = $event->getRequest()->get('_route')) && (strpos($current_route, 'entity.team') !== FALSE || strpos($current_route, 'settings.team') !== FALSE)) {
       $organization = $this->orgController->load($this->connector->getOrganization());
       if ($organization && $this->orgController->isOrganizationApigeeX()) {
         if ($organization->getAddonsConfig() || TRUE === $organization->getAddonsConfig()->getMonetizationConfig()->getEnabled()) {
-          $this->messenger->addError('The Teams module functionality is not available for monetization enabled org on Apigee X / Hybrid and should be uninstalled');
+          $this->messenger->addError('The Teams module functionality is not available for monetization enabled org on Apigee X / Hybrid and should be uninstalled.');
         }
       }
     }

--- a/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
+++ b/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
@@ -27,7 +27,7 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
- * Validates that Apigee X Team is enabled on Team list page.
+ * Validates that Apigee X Team is enabled on every Team page request.
  */
 class ValidateApigeeXTeamEnabledSubscriber implements EventSubscriberInterface {
 
@@ -76,7 +76,7 @@ class ValidateApigeeXTeamEnabledSubscriber implements EventSubscriberInterface {
    */
   public function validateApigeexTeamEnabled(RequestEvent $event) {
     /** @var \Symfony\Component\Routing\Route $current_route */
-    if (($current_route = $event->getRequest()->get('_route')) && ($current_route === 'entity.team.collection')) {
+    if (($current_route = $event->getRequest()->get('_route')) && (strpos($current_route, 'team') !== false)) {
       $organization = $this->orgController->load($this->connector->getOrganization());
       if ($organization && $this->orgController->isOrganizationApigeeX()) {
         if ($organization->getAddonsConfig() || TRUE === $organization->getAddonsConfig()->getMonetizationConfig()->getEnabled()) {

--- a/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
+++ b/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
@@ -37,7 +37,7 @@ final class ValidateApigeeXTeamEnabledSubscriber implements EventSubscriberInter
    *
    * @var \Drupal\Core\Session\AccountInterface
    */
-  private $currentUser;
+  private AccountInterface $currentUser;
 
   /**
    * The SDK connector service.
@@ -87,7 +87,7 @@ final class ValidateApigeeXTeamEnabledSubscriber implements EventSubscriberInter
    */
   public function validateApigeexTeamEnabled(RequestEvent $event) {
     // Check only for html request and admin users.
-    if (($this->currentUser->id() == 1 || $this->currentUser->hasRole('administrator')) && $event->getRequest()->getRequestFormat() === 'html') {
+    if ($this->currentUser->hasPermission('administer modules') && $event->getRequest()->getRequestFormat() === 'html') {
       /** @var \Symfony\Component\Routing\Route $current_route */
       if (($current_route = $event->getRequest()->get('_route')) && (strpos($current_route, 'entity.team') !== FALSE || strpos($current_route, 'settings.team') !== FALSE)) {
         $organization = $this->orgController->load($this->connector->getOrganization());

--- a/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
+++ b/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
@@ -74,7 +74,7 @@ class ValidateApigeeXTeamEnabledSubscriber implements EventSubscriberInterface {
    * @param \Symfony\Component\HttpKernel\Event\RequestEvent $event
    *   The event.
    */
-  public function validateApigeeXTeamEnabled(RequestEvent $event) {
+  public function validateApigeexTeamEnabled(RequestEvent $event) {
     /** @var \Symfony\Component\Routing\Route $current_route */
     if (($current_route = $event->getRequest()->get('_route')) && ($current_route === 'entity.team.collection')) {
       $organization = $this->orgController->load($this->connector->getOrganization());
@@ -90,7 +90,7 @@ class ValidateApigeeXTeamEnabledSubscriber implements EventSubscriberInterface {
    * {@inheritdoc}
    */
   public static function getSubscribedEvents() {
-    $events[KernelEvents::REQUEST][] = ['validateApigeeXTeamEnabled'];
+    $events[KernelEvents::REQUEST][] = ['validateApigeexTeamEnabled'];
     return $events;
   }
 

--- a/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
+++ b/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
@@ -85,7 +85,7 @@ final class ValidateApigeeXTeamEnabledSubscriber implements EventSubscriberInter
    * @param \Symfony\Component\HttpKernel\Event\RequestEvent $event
    *   The event.
    */
-  public function validateApigeexTeamEnabled(RequestEvent $event) {
+  public function validateApigeexTeamEnabled(RequestEvent $event): void {
     // Check only for html request and admin users.
     if ($this->currentUser->hasPermission('administer modules') && $event->getRequest()->getRequestFormat() === 'html') {
       /** @var \Symfony\Component\Routing\Route $current_route */
@@ -103,7 +103,7 @@ final class ValidateApigeeXTeamEnabledSubscriber implements EventSubscriberInter
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     $events[KernelEvents::REQUEST][] = ['validateApigeexTeamEnabled'];
     return $events;
   }

--- a/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
+++ b/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
@@ -92,7 +92,7 @@ final class ValidateApigeeXTeamEnabledSubscriber implements EventSubscriberInter
       if (($current_route = $event->getRequest()->get('_route')) && (strpos($current_route, 'entity.team') !== FALSE || strpos($current_route, 'settings.team') !== FALSE)) {
         $organization = $this->orgController->load($this->connector->getOrganization());
         if ($organization && $this->orgController->isOrganizationApigeeX()) {
-          if ($organization->getAddonsConfig() || TRUE === $organization->getAddonsConfig()->getMonetizationConfig()->getEnabled()) {
+          if ($organization->getAddonsConfig() && $organization->getAddonsConfig()->getMonetizationConfig() && TRUE === $organization->getAddonsConfig()->getMonetizationConfig()->getEnabled()) {
             $this->messenger->addError($this->t('The Teams module functionality is not available for monetization enabled org on Apigee X / Hybrid and should be uninstalled.'));
           }
         }


### PR DESCRIPTION
Closes #936 
Resolved the dead code for validating for Apigee X with Monetization enabled org while enabling Teams module, 
also added error message on all Teams related pages if the module is already enabled (_In case organisation switched from Edge to X_).