### PR TITLE
Updated Team sync command inside apigee_edge command

### DIFF
--- a/modules/apigee_edge_teams/src/Commands/ApigeeEdgeCommands.php
+++ b/modules/apigee_edge_teams/src/Commands/ApigeeEdgeCommands.php
@@ -49,9 +49,9 @@ class ApigeeEdgeCommands extends DrushCommands {
   /**
    * Team Member synchronization.
    *
-   * @command apigee-edge-teams:sync
+   * @command apigee-edge:teams-sync
    *
-   * @usage drush apigee-edge-teams:sync
+   * @usage drush apigee-edge:teams-sync
    *   Starts the team member synchronization.
    */
   public function sync() {


### PR DESCRIPTION
Closes #951 

Note : Update the same in the Drupal docs here https://www.drupal.org/docs/contributed-modules/apigee-edge/migrate-teams-members-from-apigee-to-drupal-portal#s-migrate-teams-members-from-apigee-using-the-cli