### PR TITLE
Fix for watchdog_exception() deprecation

### DIFF
--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -869,9 +869,9 @@ function apigee_edge_form_user_form_api_connection_validate(array $form, FormSta
       '@user_email' => $form_state->getValue('mail'),
       '@message' => (string) $exception,
     ];
-    // @todo watchdog_exception() function has been deprecated for Drupal 10.1 https://www.drupal.org/node/2932520
-    // @phpstan-ignore-next-line
-    watchdog_exception('apigee_edge', $exception, 'Could not create/update Drupal user: @user_email, because there was no connection to Apigee Edge. @message %function (line %line of %file). <pre>@backtrace_string</pre>', $context);
+
+    $logger = \Drupal::logger('apigee_edge');
+    Error::logException($logger, $exception, 'Could not create/update Drupal user: @user_email, because there was no connection to Apigee Edge. @message %function (line %line of %file). <pre>@backtrace_string</pre>', $context);
     $form_state->setError($form, t('User registration is temporarily unavailable. Try again later or contact the site administrator.'));
   }
 }
@@ -950,9 +950,8 @@ function apigee_edge_form_user_register_form_developer_email_validate(array $for
       $sendNotifications->set($account->getEmail(), $result);
     }
     catch (TempStoreException $e) {
-      // @todo watchdog_exception() function has been deprecated for Drupal 10.1 https://www.drupal.org/node/2932520
-      // @phpstan-ignore-next-line
-      watchdog_exception(__FUNCTION__, $e);
+      $logger = \Drupal::logger(__FUNCTION__);
+      Error::logException($logger, $e);
     }
   }
 }

--- a/src/Form/AppAnalyticsFormBase.php
+++ b/src/Form/AppAnalyticsFormBase.php
@@ -32,6 +32,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\UrlGeneratorInterface;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Url;
+use Drupal\Core\Utility\Error;
 use League\Period\Period;
 use Moment\MomentException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -379,9 +380,9 @@ abstract class AppAnalyticsFormBase extends FormBase {
     catch (\Exception $e) {
       $this->messenger()
         ->addError($this->t('Unable to retrieve analytics data. Please try again.'));
-      // @todo watchdog_exception() function has been deprecated for Drupal 10.1 https://www.drupal.org/node/2932520
-      // @phpstan-ignore-next-line
-      watchdog_exception('apigee_edge', $e);
+
+      $logger = \Drupal::logger('apigee_edge');
+      Error::logException($logger, $e);
     }
 
     $date_time_zone = new \DateTimeZone(date_default_timezone_get());

--- a/src/JobExecutor.php
+++ b/src/JobExecutor.php
@@ -22,8 +22,8 @@ namespace Drupal\apigee_edge;
 use Drupal\apigee_edge\Job\Job;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Database\Connection;
-use Drupal\Core\Utility\Error;
 use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\Utility\Error;
 
 /**
  * Job executor service.

--- a/src/JobExecutor.php
+++ b/src/JobExecutor.php
@@ -22,6 +22,7 @@ namespace Drupal\apigee_edge;
 use Drupal\apigee_edge\Job\Job;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Database\Connection;
+use Drupal\Core\Utility\Error;
 use Drupal\Core\Queue\QueueFactory;
 
 /**
@@ -151,9 +152,8 @@ class JobExecutor implements JobExecutorInterface {
       $job->setStatus($result ? Job::IDLE : Job::FINISHED);
     }
     catch (\Exception $ex) {
-      // @todo watchdog_exception() function has been deprecated for Drupal 10.1 https://www.drupal.org/node/2932520
-      // @phpstan-ignore-next-line
-      watchdog_exception('apigee_edge_job', $ex);
+      $logger = \Drupal::logger('apigee_edge_job');
+      Error::logException($logger, $ex);
       $job->recordException($ex);
       $job->setStatus($job->shouldRetry($ex) && $job->consumeRetry() ? Job::RESCHEDULED : Job::FAILED);
     }

--- a/src/KeyEntityFormEnhancer.php
+++ b/src/KeyEntityFormEnhancer.php
@@ -40,6 +40,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerTrait;
 use Drupal\Core\Render\Element\StatusMessages;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Utility\Error;
 use Drupal\key\Form\KeyFormBase;
 use Drupal\key\KeyInterface;
 use Drupal\key\Plugin\KeyProviderSettableValueInterface;
@@ -349,9 +350,8 @@ final class KeyEntityFormEnhancer {
       drupal_flush_all_caches();
     }
     catch (\Exception $exception) {
-      // @todo watchdog_exception() function has been deprecated for Drupal 10.1 https://www.drupal.org/node/2932520
-      // @phpstan-ignore-next-line
-      watchdog_exception('apigee_edge', $exception);
+      $logger = \Drupal::logger('apigee_edge');
+      Error::logException($logger, $exception);
 
       $form_state->setError($form, $this->t('@suggestion Error message: %response', [
         '@suggestion' => $this->createSuggestion($exception, $test_key),

--- a/src/Plugin/Field/FieldType/ApigeeEdgeDeveloperIdFieldItem.php
+++ b/src/Plugin/Field/FieldType/ApigeeEdgeDeveloperIdFieldItem.php
@@ -23,6 +23,7 @@ namespace Drupal\apigee_edge\Plugin\Field\FieldType;
 use Drupal\apigee_edge\Entity\Developer;
 use Drupal\Core\Field\FieldItemList;
 use Drupal\Core\TypedData\ComputedItemListTrait;
+use Drupal\Core\Utility\Error;
 
 /**
  * Definition of Apigee Edge Developer ID computed field for User entity.
@@ -52,9 +53,8 @@ class ApigeeEdgeDeveloperIdFieldItem extends FieldItemList {
       $this->list[0] = $this->createItem(0, $value);
     }
     catch (\Exception $exception) {
-      // @todo watchdog_exception() function has been deprecated for Drupal 10.1 https://www.drupal.org/node/2932520
-      // @phpstan-ignore-next-line
-      watchdog_exception('apigee_edge', $exception);
+      $logger = \Drupal::logger('apigee_edge');
+      Error::logException($logger, $exception);
     }
   }
 

--- a/tests/modules/apigee_edge_test_app_keys/apigee_edge_test_app_keys.module
+++ b/tests/modules/apigee_edge_test_app_keys/apigee_edge_test_app_keys.module
@@ -8,6 +8,7 @@
 use Apigee\Edge\Exception\ApiException;
 use Drupal\Component\Utility\Random;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Utility\Error;
 
 /**
  * Implements hook_entity_insert().
@@ -36,15 +37,13 @@ function apigee_edge_test_app_keys_developer_app_insert(EntityInterface $entity)
         $dacc->create("{$prefix}-{$random->name()}", "{$prefix}-{$random->name()}");
       }
       catch (ApiException $e) {
-        // @todo watchdog_exception() function has been deprecated for Drupal 10.1 https://www.drupal.org/node/2932520
-        // @phpstan-ignore-next-line
-        watchdog_exception('apigee_edge', $e, 'Unable to create new API key on Apigee Edge for @app app. !message', ['@app' => $entity->id()]);
+        $logger = \Drupal::logger('apigee_edge');
+        Error::logException($logger, $e, 'Unable to create new API key on Apigee Edge for @app app. !message', ['@app' => $entity->id()]);
       }
     }
     catch (ApiException $e) {
-      // @todo watchdog_exception() function has been deprecated for Drupal 10.1 https://www.drupal.org/node/2932520
-      // @phpstan-ignore-next-line
-      watchdog_exception('apigee_edge', $e, 'Unable to delete auto-generated key of @app app on Apigee Edge. !message', ['@app' => $entity->id()]);
+      $logger = \Drupal::logger('apigee_edge');
+      Error::logException($logger, $e, 'Unable to delete auto-generated key of @app app on Apigee Edge. !message', ['@app' => $entity->id()]);
     }
   }
 }

--- a/tests/modules/apigee_edge_test_app_keys/src/EventSubscriber/OverrideAppKeysOnGenerate.php
+++ b/tests/modules/apigee_edge_test_app_keys/src/EventSubscriber/OverrideAppKeysOnGenerate.php
@@ -25,6 +25,7 @@ use Apigee\Edge\Structure\CredentialProduct;
 use Drupal\apigee_edge\Entity\Controller\DeveloperAppCredentialControllerFactoryInterface;
 use Drupal\apigee_edge\Event\AppCredentialGenerateEvent;
 use Drupal\Component\Utility\Random;
+use Drupal\Core\Utility\Error;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -89,29 +90,25 @@ class OverrideAppKeysOnGenerate implements EventSubscriberInterface {
           $credential_controller->addProducts($new_consumer_key, $products);
         }
         catch (ApiException $e) {
-          // @todo watchdog_exception() function has been deprecated for Drupal 10.1 https://www.drupal.org/node/2932520
-          // @phpstan-ignore-next-line
-          watchdog_exception('apigee_edge', $e, 'Unable to assign API products to the newly generated API key on Apigee Edge for @app app. !message', ['@app' => "{$event->getOwnerId()}:{$event->getAppName()}"]);
+          $logger = \Drupal::logger('apigee_edge');
+          Error::logException($logger, $e, 'Unable to assign API products to the newly generated API key on Apigee Edge for @app app. !message', ['@app' => "{$event->getOwnerId()}:{$event->getAppName()}"]);
           try {
             $credential_controller->delete($new_consumer_key);
           }
           catch (ApiException $e) {
-            // @todo watchdog_exception() function has been deprecated for Drupal 10.1 https://www.drupal.org/node/2932520
-            // @phpstan-ignore-next-line
-            watchdog_exception('apigee_edge', $e, 'Unable to delete newly generated API key after API product re-association has failed on Apigee Edge for @app app. !message', ['@app' => "{$event->getOwnerId()}:{$event->getAppName()}"]);
+            $logger = \Drupal::logger('apigee_edge');
+            Error::logException($logger, $e, 'Unable to delete newly generated API key after API product re-association has failed on Apigee Edge for @app app. !message', ['@app' => "{$event->getOwnerId()}:{$event->getAppName()}"]);
           }
         }
       }
       catch (ApiException $e) {
-        // @todo watchdog_exception() function has been deprecated for Drupal 10.1 https://www.drupal.org/node/2932520
-        // @phpstan-ignore-next-line
-        watchdog_exception('apigee_edge', $e, 'Unable to create new API key on Apigee Edge for @app app. !message', ['@app' => "{$event->getOwnerId()}:{$event->getAppName()}"]);
+        $logger = \Drupal::logger('apigee_edge');
+        Error::logException($logger, $e, 'Unable to create new API key on Apigee Edge for @app app. !message', ['@app' => "{$event->getOwnerId()}:{$event->getAppName()}"]);
       }
     }
     catch (ApiException $e) {
-      // @todo watchdog_exception() function has been deprecated for Drupal 10.1 https://www.drupal.org/node/2932520
-      // @phpstan-ignore-next-line
-      watchdog_exception('apigee_edge', $e, 'Unable to delete auto-generated key of @app app on Apigee Edge. !message', ['@app' => "{$event->getOwnerId()}:{$event->getAppName()}"]);
+      $logger = \Drupal::logger('apigee_edge');
+      Error::logException($logger, $e, 'Unable to delete auto-generated key of @app app on Apigee Edge. !message', ['@app' => "{$event->getOwnerId()}:{$event->getAppName()}"]);
     }
   }
 

--- a/tests/src/Kernel/ApigeeEdgeKernelTestTrait.php
+++ b/tests/src/Kernel/ApigeeEdgeKernelTestTrait.php
@@ -20,6 +20,8 @@
 
 namespace Drupal\Tests\apigee_edge\Kernel;
 
+use Drupal\Core\Utility\Error;
+
 /**
  * Provides common functionality for the Apigee Edge kernel test classes.
  */
@@ -35,9 +37,9 @@ trait ApigeeEdgeKernelTestTrait {
    */
   protected function logException(\Exception $exception, string $suffix = '') {
     $ro = new \ReflectionObject($this);
-    // @todo watchdog_exception() function has been deprecated for Drupal 10.1 https://www.drupal.org/node/2932520
-    // @phpstan-ignore-next-line
-    watchdog_exception("{$ro->getShortName()}{$suffix}", $exception);
+
+    $logger = \Drupal::logger("{$ro->getShortName()}{$suffix}");
+    Error::logException($logger, $exception);
   }
 
 }

--- a/tests/src/Kernel/Util/ApigeeEdgeManagementCliServiceTest.php
+++ b/tests/src/Kernel/Util/ApigeeEdgeManagementCliServiceTest.php
@@ -22,6 +22,7 @@ namespace Drupal\Tests\apigee_edge\Kernel\Util;
 use Apigee\Edge\Exception\ClientErrorException;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\DependencyInjection\ServiceModifierInterface;
+use Drupal\Core\Utility\Error;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\apigee_mock_api_client\Traits\ApigeeMockApiClientHelperTrait;
 
@@ -145,9 +146,8 @@ class ApigeeEdgeManagementCliServiceTest extends KernelTestBase implements Servi
       }
     }
     catch (\Exception $exception) {
-      // @todo watchdog_exception() function has been deprecated for Drupal 10.1 https://www.drupal.org/node/2932520
-      // @phpstan-ignore-next-line
-      watchdog_exception('apigee_edge', $exception);
+      $logger = \Drupal::logger('apigee_edge');
+      Error::logException($logger, $exception);
     }
 
     parent::tearDown();

--- a/tests/src/Traits/ApigeeEdgeFunctionalTestTrait.php
+++ b/tests/src/Traits/ApigeeEdgeFunctionalTestTrait.php
@@ -23,6 +23,7 @@ use Apigee\Edge\Api\Management\Controller\DeveloperAppCredentialController as Ed
 use Drupal\apigee_edge\Entity\ApiProduct;
 use Drupal\apigee_edge\Entity\Developer;
 use Drupal\apigee_edge\Entity\DeveloperApp;
+use Drupal\Core\Utility\Error;
 use Drupal\Tests\apigee_mock_api_client\Traits\ApigeeMockApiClientHelperTrait;
 use Drupal\user\Entity\User;
 use Drupal\user\UserInterface;
@@ -299,9 +300,8 @@ trait ApigeeEdgeFunctionalTestTrait {
    */
   protected function logException(\Exception $exception, string $suffix = '') {
     $ro = new \ReflectionObject($this);
-    // @todo watchdog_exception() function has been deprecated for Drupal 10.1 https://www.drupal.org/node/2932520
-    // @phpstan-ignore-next-line
-    watchdog_exception("{$ro->getShortName()}{$suffix}", $exception);
+    $logger = \Drupal::logger("{$ro->getShortName()}{$suffix}");
+    Error::logException($logger, $exception);
   }
 
   /**


### PR DESCRIPTION
Fixes #872 
watchdog_exception() is deprecated in drupal:10.1
Implemented Error::logException as per the document https://www.drupal.org/node/2932520