### PR TITLE
Locked version mglaman/phpstan-drupal to 1.2.0

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -95,6 +95,7 @@ jobs:
         composer update --with-all-dependencies
         composer require --dev phpspec/prophecy-phpunit:^2
         composer require --dev drupal/classy:^1.0
+        composer require --dev mglaman/phpstan-drupal:1.2.0
         composer config --no-plugins allow-plugins.drupal/console-extend-plugin true
 
     # Install drupal using minimal installation profile and enable the module.


### PR DESCRIPTION
Temporary locked `mglaman/phpstan-drupal` version to 1.2.0, latest version of `mglaman/phpstan-drupal` is causing error durning Drupal-check.

`Error: Internal error: Internal error: Cannot create PHPStan\Type\UnionType with: Drupal\apigee_edge\SDKConnector, Drupal\apigee_edge_debug\SDKConnector|Drupal\apigee_edge_test\SDKConnector while analysing file`

We need to remove the locked version once we resolve the above issue.
Issue created [here](https://github.com/apigee/apigee-edge-drupal/issues/970) to rollback the changes.