### PR TITLE
Fix for deprecation Calling InfoParserDynamic::__construct() without the $app_root argument is deprecated

### DIFF
--- a/tests/src/Kernel/UserAgentTest.php
+++ b/tests/src/Kernel/UserAgentTest.php
@@ -70,7 +70,7 @@ class UserAgentTest extends KernelTestBase {
    */
   public function testUserAgentWithoutMonetization() {
     // apigee_edge module info.
-    $infoParser = new InfoParser();
+    $infoParser = new InfoParser($this->root);
     $this->edgeModuleInfo = $infoParser->parse(\Drupal::service('module_handler')->getModule('apigee_edge')->getPathname());
     if (!isset($this->edgeModuleInfo['version'])) {
       $this->edgeModuleInfo['version'] = '2.x-dev';


### PR DESCRIPTION
Closes #974 