### PR TITLE
Fix for deprecation : Drupal\Core\Database\Connection::tablePrefix() is deprecated in drupal:10.1.0

### DIFF
--- a/tests/modules/apigee_edge_test/src/Logger/ApigeeEdgeDebugToFileLogger.php
+++ b/tests/modules/apigee_edge_test/src/Logger/ApigeeEdgeDebugToFileLogger.php
@@ -71,8 +71,7 @@ final class ApigeeEdgeDebugToFileLogger extends SysLog {
       $log_path = \Drupal::service('file_system')->realpath('public://');
     }
     // Add test prefix to the log file.
-    // @phpstan-ignore-next-line
-    $log_path .= '/apigee_edge_debug-' . str_replace('test', '', $this->database->tablePrefix()) . '.log';
+    $log_path .= '/apigee_edge_debug-' . str_replace('test', '', $this->database->getPrefix()) . '.log';
     // Do not fail a test just because the fail is not writable.
     @error_log($entry . PHP_EOL, 3, $log_path);
   }

--- a/tests/modules/apigee_edge_test/src/Logger/SyslogToFileLogger.php
+++ b/tests/modules/apigee_edge_test/src/Logger/SyslogToFileLogger.php
@@ -61,9 +61,7 @@ final class SyslogToFileLogger extends SysLog {
       $log_path = \Drupal::service('file_system')->realpath('public://');
     }
     // Add test id as a suffix to the log file.
-    // @todo tablePrefix() is deprecated in Drupal 10.1
-    // @phpstan-ignore-next-line
-    $log_path .= '/syslog-' . str_replace('test', '', $this->database->tablePrefix()) . '.log';
+    $log_path .= '/syslog-' . str_replace('test', '', $this->database->getPrefix()) . '.log';
     // Do not fail a test just because the fail is not writable.
     @error_log($entry . PHP_EOL, 3, $log_path);
   }

--- a/tests/src/FunctionalJavascript/ApigeeEdgeFunctionalJavascriptTestBase.php
+++ b/tests/src/FunctionalJavascript/ApigeeEdgeFunctionalJavascriptTestBase.php
@@ -58,9 +58,7 @@ abstract class ApigeeEdgeFunctionalJavascriptTestBase extends WebDriverTestBase 
     }
     /** @var \Drupal\Core\Database\Connection $database */
     $database = $this->container->get('database');
-    // @todo tablePrefix() is deprecated in Drupal 10.1
-    // @phpstan-ignore-next-line
-    $test_id = str_replace('test', '', $database->tablePrefix());
+    $test_id = str_replace('test', '', $database->getPrefix());
     // Add table suffix (test id) to the file name and ensure the generated
     // file name is unique.
     $filename = \Drupal::service('file_system')


### PR DESCRIPTION
Closes #977 