### PR TITLE
Skipping Functional and FunctionalJavascript test for Hybrid Org

### DIFF
--- a/tests/src/Functional/ApigeeEdgeFunctionalTestBase.php
+++ b/tests/src/Functional/ApigeeEdgeFunctionalTestBase.php
@@ -19,6 +19,7 @@
 
 namespace Drupal\Tests\apigee_edge\Functional;
 
+use Drupal\apigee_edge\Plugin\EdgeKeyTypeInterface;
 use Drupal\Tests\apigee_edge\Traits\ApigeeEdgeFunctionalTestTrait;
 use Drupal\Tests\BrowserTestBase;
 
@@ -40,6 +41,11 @@ abstract class ApigeeEdgeFunctionalTestBase extends BrowserTestBase {
    * {@inheritdoc}
    */
   protected function setUp(): void {
+    // Skipping the test if instance type is Public.
+    $instance_type = getenv('APIGEE_EDGE_INSTANCE_TYPE');
+    if (!empty($instance_type) && $instance_type === EdgeKeyTypeInterface::INSTANCE_TYPE_HYBRID) {
+      $this->markTestSkipped('This test suite is expecting a PUBLIC instance type.');
+    }
     parent::setUp();
     $this->initTestEnv();
   }

--- a/tests/src/FunctionalJavascript/ApigeeEdgeFunctionalJavascriptTestBase.php
+++ b/tests/src/FunctionalJavascript/ApigeeEdgeFunctionalJavascriptTestBase.php
@@ -19,6 +19,7 @@
 
 namespace Drupal\Tests\apigee_edge\FunctionalJavascript;
 
+use Drupal\apigee_edge\Plugin\EdgeKeyTypeInterface;
 use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
 use Drupal\Tests\apigee_edge\Traits\ApigeeEdgeFunctionalTestTrait;
 
@@ -40,6 +41,11 @@ abstract class ApigeeEdgeFunctionalJavascriptTestBase extends WebDriverTestBase 
    * {@inheritdoc}
    */
   protected function setUp(): void {
+    // Skipping the test if instance type is Public.
+    $instance_type = getenv('APIGEE_EDGE_INSTANCE_TYPE');
+    if (!empty($instance_type) && $instance_type === EdgeKeyTypeInterface::INSTANCE_TYPE_HYBRID) {
+      $this->markTestSkipped('This test suite is expecting a PUBLIC instance type.');
+    }
     parent::setUp();
     $this->initTestEnv();
   }


### PR DESCRIPTION
Added check to skip test if the org is Hybrid for Apigee Edge Functional and FunctionalJavascript test cases.