### PR TITLE
Deprecate classes that is dependent on drupal/console

### DIFF
--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -19,6 +19,8 @@
 
 namespace Drupal\apigee_edge\Command;
 
+@trigger_error('The ' . __NAMESPACE__ . '\CommandBase is deprecated in 3.0.4 and will be removed. See https://github.com/apigee/apigee-edge-drupal/issues/984', E_USER_DEPRECATED);
+
 use Drupal\apigee_edge\CliServiceInterface;
 use Drupal\Console\Core\Command\Command;
 use Drupal\Console\Core\Command\Shared\CommandTrait;
@@ -32,6 +34,10 @@ use Symfony\Component\Console\Style\StyleInterface;
 
 /**
  * Class CommandBase for shared functionality.
+ * 
+ * @deprecated in 3.0.4 and will be removed.
+ *
+ * @see https://github.com/apigee/apigee-edge-drupal/issues/984
  */
 abstract class CommandBase extends Command {
 

--- a/src/Command/CommandBase.php
+++ b/src/Command/CommandBase.php
@@ -19,7 +19,7 @@
 
 namespace Drupal\apigee_edge\Command;
 
-@trigger_error('The ' . __NAMESPACE__ . '\CommandBase is deprecated in 3.0.4 and will be removed. See https://github.com/apigee/apigee-edge-drupal/issues/984', E_USER_DEPRECATED);
+@trigger_error('The ' . __NAMESPACE__ . '\CommandBase is deprecated in apigee_edge:3.0.4 and is removed from apigee_edge:3.1.0. Drupal/console is not compatible with Drupal 10. See https://github.com/apigee/apigee-edge-drupal/issues/984', E_USER_DEPRECATED);
 
 use Drupal\apigee_edge\CliServiceInterface;
 use Drupal\Console\Core\Command\Command;
@@ -34,8 +34,9 @@ use Symfony\Component\Console\Style\StyleInterface;
 
 /**
  * Class CommandBase for shared functionality.
- * 
- * @deprecated in 3.0.4 and will be removed.
+ *
+ * @deprecated in apigee_edge:3.0.4 and is removed from apigee_edge:3.1.0.
+ *  Drupal/console is not compatible with Drupal 10.
  *
  * @see https://github.com/apigee/apigee-edge-drupal/issues/984
  */

--- a/src/Command/CreateEdgeRoleCommand.php
+++ b/src/Command/CreateEdgeRoleCommand.php
@@ -31,6 +31,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  *     extension="apigee_edge",
  *     extensionType="module"
  * )
+ * 
+ * @deprecated in 3.0.3 and will be removed.
+ *
+ * @see https://github.com/apigee/apigee-edge-drupal/issues/984
  */
 class CreateEdgeRoleCommand extends CommandBase {
 

--- a/src/Command/CreateEdgeRoleCommand.php
+++ b/src/Command/CreateEdgeRoleCommand.php
@@ -31,11 +31,11 @@ use Symfony\Component\Console\Output\OutputInterface;
  *     extension="apigee_edge",
  *     extensionType="module"
  * )
- * 
- * @deprecated in 3.0.3 and will be removed.
+ *
+ * @deprecated in apigee_edge:3.0.4 and is removed from apigee_edge:3.1.0.
+ *  Drupal/console is not compatible with Drupal 10.
  *
  * @see https://github.com/apigee/apigee-edge-drupal/issues/984
- * 
  * @phpstan-ignore-next-line
  */
 class CreateEdgeRoleCommand extends CommandBase {

--- a/src/Command/CreateEdgeRoleCommand.php
+++ b/src/Command/CreateEdgeRoleCommand.php
@@ -35,6 +35,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @deprecated in 3.0.3 and will be removed.
  *
  * @see https://github.com/apigee/apigee-edge-drupal/issues/984
+ * 
+ * @phpstan-ignore-next-line
  */
 class CreateEdgeRoleCommand extends CommandBase {
 

--- a/src/Command/DeveloperSyncCommand.php
+++ b/src/Command/DeveloperSyncCommand.php
@@ -29,11 +29,11 @@ use Symfony\Component\Console\Output\OutputInterface;
  *     extension="apigee_edge",
  *     extensionType="module"
  * )
- * 
- * @deprecated in 3.0.3 and will be removed.
+ *
+ * @deprecated in apigee_edge:3.0.4 and is removed from apigee_edge:3.1.0.
+ *  Drupal/console is not compatible with Drupal 10.
  *
  * @see https://github.com/apigee/apigee-edge-drupal/issues/984
- * 
  * @phpstan-ignore-next-line
  */
 class DeveloperSyncCommand extends CommandBase {

--- a/src/Command/DeveloperSyncCommand.php
+++ b/src/Command/DeveloperSyncCommand.php
@@ -33,6 +33,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @deprecated in 3.0.3 and will be removed.
  *
  * @see https://github.com/apigee/apigee-edge-drupal/issues/984
+ * 
+ * @phpstan-ignore-next-line
  */
 class DeveloperSyncCommand extends CommandBase {
 

--- a/src/Command/DeveloperSyncCommand.php
+++ b/src/Command/DeveloperSyncCommand.php
@@ -29,6 +29,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  *     extension="apigee_edge",
  *     extensionType="module"
  * )
+ * 
+ * @deprecated in 3.0.3 and will be removed.
+ *
+ * @see https://github.com/apigee/apigee-edge-drupal/issues/984
  */
 class DeveloperSyncCommand extends CommandBase {
 

--- a/src/Command/DrupalConsoleLog.php
+++ b/src/Command/DrupalConsoleLog.php
@@ -27,8 +27,9 @@ use Psr\Log\LogLevel;
 
 /**
  * Redirects Drupal logging messages to Drupal Console log.
- * 
- * @deprecated in 3.0.3 and will be removed.
+ *
+ * @deprecated in apigee_edge:3.0.4 and is removed from apigee_edge:3.1.0.
+ *  Drupal/console is not compatible with Drupal 10.
  *
  * @see https://github.com/apigee/apigee-edge-drupal/issues/984
  */

--- a/src/Command/DrupalConsoleLog.php
+++ b/src/Command/DrupalConsoleLog.php
@@ -27,6 +27,10 @@ use Psr\Log\LogLevel;
 
 /**
  * Redirects Drupal logging messages to Drupal Console log.
+ * 
+ * @deprecated in 3.0.3 and will be removed.
+ *
+ * @see https://github.com/apigee/apigee-edge-drupal/issues/984
  */
 class DrupalConsoleLog implements LoggerInterface {
 

--- a/tests/src/Unit/Command/CreateEdgeRoleCommandTest.php
+++ b/tests/src/Unit/Command/CreateEdgeRoleCommandTest.php
@@ -35,6 +35,8 @@ namespace Drupal\Tests\apigee_edge\Unit\Command {
    * Test ApigeeEdgeCommands class.
    *
    * @group apigee_edge
+   * 
+   * @phpstan-ignore-next-line
    */
   class CreateEdgeRoleCommandTest extends UnitTestCase {
 

--- a/tests/src/Unit/Command/CreateEdgeRoleCommandTest.php
+++ b/tests/src/Unit/Command/CreateEdgeRoleCommandTest.php
@@ -36,7 +36,7 @@ namespace Drupal\Tests\apigee_edge\Unit\Command {
    *
    * @group apigee_edge
    * 
-   * @phpstan-ignore-next-line
+   * @group legacy
    */
   class CreateEdgeRoleCommandTest extends UnitTestCase {
 

--- a/tests/src/Unit/Command/CreateEdgeRoleCommandTest.php
+++ b/tests/src/Unit/Command/CreateEdgeRoleCommandTest.php
@@ -35,7 +35,7 @@ namespace Drupal\Tests\apigee_edge\Unit\Command {
    * Test ApigeeEdgeCommands class.
    *
    * @group apigee_edge
-   * 
+   *
    * @group legacy
    */
   class CreateEdgeRoleCommandTest extends UnitTestCase {


### PR DESCRIPTION
Closes #984.
Deprecated the classes that dependent on drupal/console as drupal/console is not compatible with Drupal 10 and throws error.