### PR TITLE
Fix error-Creation of dynamic property Drupal\apigee_edge_teams\Entity\TeamApp::$_referringItem is deprecated

### DIFF
--- a/modules/apigee_edge_teams/src/Entity/TeamApp.php
+++ b/modules/apigee_edge_teams/src/Entity/TeamApp.php
@@ -83,6 +83,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
  *   field_ui_base_route = "apigee_edge_teams.settings.team_app",
  * )
  */
+#[\AllowDynamicProperties]
 class TeamApp extends App implements TeamAppInterface {
 
   /**


### PR DESCRIPTION
Closes #991 