### PR TITLE
Fix error - Creation of dynamic property $testTokenData is deprecated

### DIFF
--- a/modules/apigee_edge_teams/tests/src/Functional/ApigeeX/ApigeeEdgeTeamsFunctionalTestBase.php
+++ b/modules/apigee_edge_teams/tests/src/Functional/ApigeeX/ApigeeEdgeTeamsFunctionalTestBase.php
@@ -35,10 +35,17 @@ abstract class ApigeeEdgeTeamsFunctionalTestBase extends ApigeeEdgeFunctionalTes
   ];
 
   /**
+   * Test token data.
+   *
+   * @var array
+   */
+  private $testTokenData = [];
+
+  /**
    * Stores pre-configured token storage service for testing.
    */
   protected function storeToken() {
-    // Storing the token for Appigeex Hybrid Org.
+    // Storing the token for Apigeex Hybrid Org.
     $this->testTokenData = [
       'access_token' => mb_strtolower($this->randomMachineName(32)),
       'token_type' => 'bearer',

--- a/tests/src/Kernel/ApigeeX/ApigeeEdgeKernelTestBase.php
+++ b/tests/src/Kernel/ApigeeX/ApigeeEdgeKernelTestBase.php
@@ -29,6 +29,13 @@ use Drupal\KernelTests\KernelTestBase;
 abstract class ApigeeEdgeKernelTestBase extends KernelTestBase {
 
   /**
+   * Test token data.
+   *
+   * @var array
+   */
+  private $testTokenData = [];
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
@@ -44,7 +51,7 @@ abstract class ApigeeEdgeKernelTestBase extends KernelTestBase {
    * Stores pre-configured token storage service for testing.
    */
   protected function storeToken() {
-    // Storing the token for Appigeex Hybrid Org.
+    // Storing the token for Apigeex Hybrid Org.
     $this->testTokenData = [
       'access_token' => mb_strtolower($this->randomMachineName(32)),
       'token_type' => 'bearer',


### PR DESCRIPTION
Fix error `Creation of dynamic property $testTokenData is deprecated` durning running Apigee X test cases.