### PR TITLE
Resolved the validation for monitized enabled org for enabling teams for ApigeeX and edge for 2x

### DIFF
--- a/modules/apigee_edge_teams/apigee_edge_teams.install
+++ b/modules/apigee_edge_teams/apigee_edge_teams.install
@@ -41,18 +41,21 @@ function apigee_edge_teams_requirements($phase) {
       $org_controller = \Drupal::service('apigee_edge.controller.organization');
       /* @var \Apigee\Edge\Api\Management\Entity\Organization $organization */
       $organization = $org_controller->load($sdk_connector->getOrganization());
-      if ($organization && !OrganizationFeatures::isCompaniesFeatureAvailable($organization) && OrganizationFeatures::isMonetizationEnabled($organization)) {
-        $url = [
-          ':url' => 'https://cloud.google.com/apigee/docs/api-platform/get-started/compare-apigee-products#unsupported-apis',
-        ];
-        $message = ($phase == 'runtime') ?
-          t("The Teams module functionality is not available for monetization enabled org on Apigee X / Hybrid and should be uninstalled, because <a href=':url' target='_blank'>AppGroup APIs are not supported in Apigee X / Hybrid orgs with monetization enabled</a>.", $url) :
-          t("The Teams module functionality is not available for monetization enabled org on Apigee X / Hybrid because <a href=':url' target='_blank'>AppGroup APIs are not supported in Apigee X / Hybrid orgs with monetization enabled</a>.", $url);
-        $requirements['apigee_edge_teams_not_supported'] = [
-          'title' => t('Apigee Edge Teams'),
-          'description' => $message,
-          'severity' => REQUIREMENT_ERROR,
-        ];
+      if ($organization && $org_controller->isOrganizationApigeeX()) {
+        // AppGroup APIs are not supported in Apigee X / Hybrid orgs with monetization enabled.
+        if ($organization->getAddonsConfig() && $organization->getAddonsConfig()->getMonetizationConfig() && TRUE === $organization->getAddonsConfig()->getMonetizationConfig()->getEnabled()) {
+          $url = [
+            ':url' => 'https://cloud.google.com/apigee/docs/api-platform/publish/organizing-client-app-ownership?hl=en#appgroups-limitations-and-known-issues',
+          ];
+          $message = ($phase == 'runtime') ?
+            t("The Teams module functionality is not available for monetization enabled org on Apigee X / Hybrid and should be uninstalled, because <a href=':url' target='_blank'>AppGroup APIs are not supported in Apigee X / Hybrid orgs with monetization enabled</a>.", $url) :
+            t("The Teams module functionality is not available for monetization enabled org on Apigee X / Hybrid because <a href=':url' target='_blank'>AppGroup APIs are not supported in Apigee X / Hybrid orgs with monetization enabled</a>.", $url);
+          $requirements['apigee_edge_teams_not_supported'] = [
+            'title' => t('Apigee Edge Teams'),
+            'description' => $message,
+            'severity' => REQUIREMENT_ERROR,
+          ];
+        }
       }
     }
     catch (\Exception $exception) {

--- a/modules/apigee_edge_teams/apigee_edge_teams.services.yml
+++ b/modules/apigee_edge_teams/apigee_edge_teams.services.yml
@@ -121,6 +121,12 @@ services:
     tags:
       - { name: event_subscriber }
 
+  apigee_edge_teams.validate_apigeexteam_enabled:
+    class: Drupal\apigee_edge_teams\EventSubscriber\ValidateApigeeXTeamEnabledSubscriber
+    arguments: ['@current_user', '@apigee_edge.sdk_connector', '@apigee_edge.controller.organization', '@messenger']
+    tags:
+      - {name: event_subscriber}
+
   route.subscriber.apigee_edge_teams.team_app_by_name:
     class: Drupal\apigee_edge_teams\Routing\TeamAppByNameRouteAlterSubscriber
     tags:

--- a/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
+++ b/modules/apigee_edge_teams/src/EventSubscriber/ValidateApigeeXTeamEnabledSubscriber.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * Copyright 2023 Google Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License version 2 as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+namespace Drupal\apigee_edge_teams\EventSubscriber;
+
+use Drupal\apigee_edge\Entity\Controller\OrganizationControllerInterface;
+use Drupal\apigee_edge\SDKConnectorInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Validates that Apigee X Team is enabled on every Team page request.
+ */
+final class ValidateApigeeXTeamEnabledSubscriber implements EventSubscriberInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  private AccountInterface $currentUser;
+
+  /**
+   * The SDK connector service.
+   *
+   * @var \Drupal\apigee_edge\SDKConnectorInterface
+   */
+  private SDKConnectorInterface $connector;
+
+  /**
+   * The organization controller service.
+   *
+   * @var \Drupal\apigee_edge\Entity\Controller\OrganizationControllerInterface
+   */
+  protected OrganizationControllerInterface $orgController;
+
+  /**
+   * The messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected MessengerInterface $messenger;
+
+  /**
+   * ValidateApigeeXTeamEnabledSubscriber constructor.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   * @param \Drupal\apigee_edge\SDKConnectorInterface $sdk_connector
+   *   The SDK connector service.
+   * @param \Drupal\apigee_edge\Entity\Controller\OrganizationControllerInterface $org_controller
+   *   The organization controller service.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
+   */
+  public function __construct(AccountInterface $current_user, SDKConnectorInterface $sdk_connector, OrganizationControllerInterface $org_controller, MessengerInterface $messenger) {
+    $this->currentUser = $current_user;
+    $this->connector = $sdk_connector;
+    $this->orgController = $org_controller;
+    $this->messenger = $messenger;
+  }
+
+  /**
+   * If monetization enabled in Apigee X org alert the user.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\RequestEvent $event
+   *   The event.
+   */
+  public function validateApigeexTeamEnabled(RequestEvent $event): void {
+    // Check only for html request and admin users.
+    if ($this->currentUser->hasPermission('administer modules') && $event->getRequest()->getRequestFormat() === 'html') {
+      /** @var \Symfony\Component\Routing\Route $current_route */
+      if (($current_route = $event->getRequest()->get('_route')) && (strpos($current_route, 'entity.team') !== FALSE || strpos($current_route, 'settings.team') !== FALSE)) {
+        $organization = $this->orgController->load($this->connector->getOrganization());
+        if ($organization && $this->orgController->isOrganizationApigeeX()) {
+          if ($organization->getAddonsConfig() && $organization->getAddonsConfig()->getMonetizationConfig() && TRUE === $organization->getAddonsConfig()->getMonetizationConfig()->getEnabled()) {
+            $this->messenger->addError($this->t('The Teams module functionality is not available for monetization enabled org on Apigee X / Hybrid and should be uninstalled.'));
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    $events[KernelEvents::REQUEST][] = ['validateApigeexTeamEnabled'];
+    return $events;
+  }
+
+}


### PR DESCRIPTION
Closes #936 for 2x branch
Resolved the dead code for validating for Apigee X with Monetization enabled org while enabling Teams module, 
also added error message on all Teams related pages if the module is already enabled (_In case organisation switched from Edge to X_).