### PR TITLE
Renaming title and descriptions in module info file from Apigee Edge to Apigee

### DIFF
--- a/apigee_edge.info.yml
+++ b/apigee_edge.info.yml
@@ -1,5 +1,5 @@
-name: Apigee Edge
-description: Apigee Edge Drupal integration.
+name: Apigee
+description: Apigee Drupal integration.
 package: Apigee
 
 type: module

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "drupal/apigee_edge",
     "license": "GPL-2.0-or-later",
     "type": "drupal-module",
-    "description": "Apigee Edge for Drupal.",
+    "description": "Apigee for Drupal.",
     "require": {
         "php": "~8.1.0 || ~8.2.0",
         "ext-json": "*",

--- a/tests/src/Kernel/UserAgentTest.php
+++ b/tests/src/Kernel/UserAgentTest.php
@@ -82,7 +82,7 @@ class UserAgentTest extends KernelTestBase {
     \Drupal::moduleHandler()->invokeAll('apigee_edge_user_agent_string_alter', [&$user_agent_parts]);
     $userAgentPrefix = implode('; ', $user_agent_parts);
 
-    $this->assertSame($userAgentPrefix, 'Apigee Edge/2.x-dev;' . ' Drupal/' . \Drupal::VERSION);
+    $this->assertSame($userAgentPrefix, 'Apigee/2.x-dev;' . ' Drupal/' . \Drupal::VERSION);
   }
 
 }

--- a/tests/src/Kernel/UserAgentTest.php
+++ b/tests/src/Kernel/UserAgentTest.php
@@ -73,7 +73,7 @@ class UserAgentTest extends KernelTestBase {
     $infoParser = new InfoParser($this->root);
     $this->edgeModuleInfo = $infoParser->parse(\Drupal::service('module_handler')->getModule('apigee_edge')->getPathname());
     if (!isset($this->edgeModuleInfo['version'])) {
-      $this->edgeModuleInfo['version'] = '2.x-dev';
+      $this->edgeModuleInfo['version'] = '3.x-dev';
     }
 
     $user_agent_parts[] = $this->edgeModuleInfo['name'] . '/' . $this->edgeModuleInfo['version'];
@@ -82,7 +82,7 @@ class UserAgentTest extends KernelTestBase {
     \Drupal::moduleHandler()->invokeAll('apigee_edge_user_agent_string_alter', [&$user_agent_parts]);
     $userAgentPrefix = implode('; ', $user_agent_parts);
 
-    $this->assertSame($userAgentPrefix, 'Apigee/2.x-dev;' . ' Drupal/' . \Drupal::VERSION);
+    $this->assertSame($userAgentPrefix, 'Apigee/3.x-dev;' . ' Drupal/' . \Drupal::VERSION);
   }
 
 }


### PR DESCRIPTION
#998 
Renaming title and descriptions in module info and composer file from `Apigee Edge` to `Apigee`.