### PR TITLE
Removing TeamInvitationQueryAccessSubscriber for AppGroup member edit/add

### DIFF
--- a/modules/apigee_edge_teams/apigee_edge_teams.services.yml
+++ b/modules/apigee_edge_teams/apigee_edge_teams.services.yml
@@ -117,7 +117,7 @@ services:
 
   apigee_edge_teams.team_invitation_query_access_subscriber:
     class: Drupal\apigee_edge_teams\EventSubscriber\TeamInvitationQueryAccessSubscriber
-    arguments: ['@entity_type.manager']
+    arguments: ['@apigee_edge.controller.organization', '@entity_type.manager']
     tags:
       - { name: event_subscriber }
 

--- a/modules/apigee_edge_teams/src/EventSubscriber/TeamInvitationQueryAccessSubscriber.php
+++ b/modules/apigee_edge_teams/src/EventSubscriber/TeamInvitationQueryAccessSubscriber.php
@@ -20,6 +20,7 @@
 
 namespace Drupal\apigee_edge_teams\EventSubscriber;
 
+use Drupal\apigee_edge\Entity\Controller\OrganizationControllerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\entity\QueryAccess\QueryAccessEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -28,6 +29,13 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * Subscribes to query access events for team_invitation.
  */
 class TeamInvitationQueryAccessSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The organization controller service.
+   *
+   * @var \Drupal\apigee_edge\Entity\Controller\OrganizationControllerInterface
+   */
+  private $orgController;
 
   /**
    * The entity type manager service.
@@ -39,10 +47,13 @@ class TeamInvitationQueryAccessSubscriber implements EventSubscriberInterface {
   /**
    * TeamInvitationQueryAccessSubscriber constructor.
    *
+   * @param \Drupal\apigee_edge\Entity\Controller\OrganizationControllerInterface $org_controller
+   *   The organization controller service.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager service.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(OrganizationControllerInterface $org_controller, EntityTypeManagerInterface $entity_type_manager) {
+    $this->orgController = $org_controller;
     $this->entityTypeManager = $entity_type_manager;
   }
 
@@ -62,6 +73,10 @@ class TeamInvitationQueryAccessSubscriber implements EventSubscriberInterface {
    *   The event.
    */
   public function onQueryAccess(QueryAccessEvent $event) {
+    // AppGroup members information is stored in Database tables.
+    if ($this->orgController->isOrganizationApigeeX()) {
+      return;
+    }
     // Add a condition to check for a valid team.
     // We query team from storage instead of check for a null team field because
     // the team might have been deleted on the remote server.

--- a/modules/apigee_edge_teams/tests/src/Functional/ApigeeX/TeamInvitationsTest.php
+++ b/modules/apigee_edge_teams/tests/src/Functional/ApigeeX/TeamInvitationsTest.php
@@ -159,20 +159,13 @@ class TeamInvitationsTest extends ApigeeEdgeTeamsFunctionalTestBase {
       $this->teamB->decorated(),
     ];
 
-    $inCache = FALSE;
     foreach ($teams as $team) {
-      if (!$inCache) {
-        $this->queueAppGroupResponse($team->decorated());
-      }
+      $this->queueAppGroupResponse($team->decorated());
       $this->drupalGet(Url::fromRoute('entity.team.add_members', [
         'team' => $team->id(),
       ]));
 
       $this->assertSession()->pageTextContains('Invite members');
-
-      $this->queueAppGroupsResponse($appgroups);
-      $this->queueAppGroupsResponse($appgroups);
-      $this->queueDevsInCompanyResponse([]);
       $this->submitForm([
         'developers' => $this->accountUser->getEmail(),
       ], 'Invite members');
@@ -184,7 +177,6 @@ class TeamInvitationsTest extends ApigeeEdgeTeamsFunctionalTestBase {
       ]);
 
       $this->assertSession()->pageTextContains($successMessage);
-      $inCache = TRUE;
     }
   }
 


### PR DESCRIPTION
#1028 
To prevent unnecessary API calls to AppGroup/Teams listing we are returning the `TeamInvitationQueryAccessSubscriber` for Apigee-X organization because we are storing member information in database tables and no need to query Teams from Apigee.