### PR TITLE
Fix error while creating select field in D10.2 and removed the unnecessary patch 3042467-50.patch

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -98,7 +98,7 @@ jobs:
         composer require wikimedia/composer-merge-plugin
         composer config --json extra.merge-plugin.require '["modules/contrib/apigee_edge/composer.json"]'
         composer config platform.php ${{ matrix.php-version }}
-        composer config --json extra.patches."drupal/core" '{ "TypeError: FieldTypePluginManager::createFieldItem() called in FieldStorageConfig.php": "https://www.drupal.org/files/issues/2024-05-27/field-typeerror-3450175-3.patch", "Support entities that are neither content nor config entities": "https://www.drupal.org/files/issues/2020-12-02/3042467-50.patch", "Add a method to access the original property": "https://www.drupal.org/files/issues/2023-07-22/2839195-105.patch"}'
+        composer config --json extra.patches."drupal/core" '{ "Support entities that are neither content nor config entities": "https://www.drupal.org/files/issues/2020-12-02/3042467-50.patch", "Add a method to access the original property": "https://www.drupal.org/files/issues/2023-07-22/2839195-105.patch"}'
         composer update --with-all-dependencies
         composer require --dev phpspec/prophecy-phpunit:^2
         composer require --dev drupal/classy:^1.0

--- a/src/Entity/AttributesAwareFieldableEdgeEntityBase.php
+++ b/src/Entity/AttributesAwareFieldableEdgeEntityBase.php
@@ -73,7 +73,7 @@ abstract class AttributesAwareFieldableEdgeEntityBase extends FieldableEdgeEntit
     $definition = $this->getFieldDefinition($field_name);
     // No field found with this name.
     if ($definition === NULL) {
-      return NULL;
+      throw new InvalidArgumentException(sprintf('"%s" field does not exist on "s" entity.', $field_name, get_class($this)));
     }
     // Ignore base fields, because their value should be stored in entity
     // properties.


### PR DESCRIPTION
Closes #1075

This PR removes the unnecessary patch added in workflow and resolves the error issue by throwing `InvalidArgumentException` exception instead of `return NULL;`

- Rolled back patch which was added [here](https://github.com/apigee/apigee-edge-drupal/pull/1058)
- Close Drupal [patch](https://www.drupal.org/project/drupal/issues/3450175), which is not an issue.