### PR TITLE
Fixes Drupal 11 compatibility issues

### DIFF
--- a/apigee_edge.info.yml
+++ b/apigee_edge.info.yml
@@ -3,7 +3,7 @@ description: Apigee Drupal integration.
 package: Apigee
 
 type: module
-core_version_requirement: ^10
+core_version_requirement: ^10.3 || ^11
 
 dependencies:
   - drupal:file
@@ -16,4 +16,4 @@ dependencies:
 
 configure: apigee_edge.settings
 
-php: 8.1
+php: 8.3

--- a/modules/apigee_edge_actions/apigee_edge_actions.info.yml
+++ b/modules/apigee_edge_actions/apigee_edge_actions.info.yml
@@ -2,7 +2,7 @@ name: Apigee Edge Actions
 description: Rules integration for Apigee Edge.
 package: Apigee (Experimental)
 type: module
-core_version_requirement: ^10
+core_version_requirement: ^10.3 || ^11
 configure: entity.rules_reaction_rule.collection
 dependencies:
   - apigee_edge:apigee_edge

--- a/modules/apigee_edge_actions/modules/apigee_edge_actions_debug/apigee_edge_actions_debug.info.yml
+++ b/modules/apigee_edge_actions/modules/apigee_edge_actions_debug/apigee_edge_actions_debug.info.yml
@@ -2,6 +2,6 @@ name: Apigee Edge Actions Debug
 description: Logs debug information for Apigee Edge Actions.
 package: Apigee (Experimental)
 type: module
-core_version_requirement: ^10
+core_version_requirement: ^10.3 || ^11
 dependencies:
   - apigee_edge_actions:apigee_edge_actions

--- a/modules/apigee_edge_actions/modules/apigee_edge_actions_examples/apigee_edge_actions_examples.info.yml
+++ b/modules/apigee_edge_actions/modules/apigee_edge_actions_examples/apigee_edge_actions_examples.info.yml
@@ -2,7 +2,7 @@ name: Apigee Edge Actions Examples
 description: Example rules for Apigee Edge.
 package: Apigee (Experimental)
 type: module
-core_version_requirement: ^10
+core_version_requirement: ^10.3 || ^11
 configure: entity.rules_reaction_rule.collection
 dependencies:
   - apigee_edge_actions:apigee_edge_actions

--- a/modules/apigee_edge_apiproduct_rbac/apigee_edge_apiproduct_rbac.info.yml
+++ b/modules/apigee_edge_apiproduct_rbac/apigee_edge_apiproduct_rbac.info.yml
@@ -3,11 +3,11 @@ description: Role based access control over view operation on API products.
 package: Apigee
 
 type: module
-core_version_requirement: ^10
+core_version_requirement: ^10.3 || ^11
 
 dependencies:
   - apigee_edge:apigee_edge
 
 configure: apigee_edge.settings.developer.api_product_access
 
-php: "8.1"
+php: "8.3"

--- a/modules/apigee_edge_apiproduct_rbac/apigee_edge_apiproduct_rbac.libraries.yml
+++ b/modules/apigee_edge_apiproduct_rbac/apigee_edge_apiproduct_rbac.libraries.yml
@@ -1,4 +1,4 @@
-admin:
+apigee_edge_apiproduct_rbac.admin:
   version: 1.1
   css:
     theme:

--- a/modules/apigee_edge_apiproduct_rbac/apigee_edge_apiproduct_rbac.module
+++ b/modules/apigee_edge_apiproduct_rbac/apigee_edge_apiproduct_rbac.module
@@ -233,7 +233,7 @@ function apigee_edge_apiproduct_rbac_form_apigee_edge_api_product_access_control
     '#value' => $product_names,
   ];
 
-  $form['#attached']['library'][] = 'apigee_edge_apiproduct_rbac/admin';
+  $form['#attached']['library'][] = 'apigee_edge_apiproduct_rbac/apigee_edge_apiproduct_rbac.admin';
   $form['#submit'][] = 'apigee_edge_apiproduct_rbac_form_apigee_edge_api_product_access_control_form_submit';
 }
 

--- a/modules/apigee_edge_debug/apigee_edge_debug.info.yml
+++ b/modules/apigee_edge_debug/apigee_edge_debug.info.yml
@@ -3,11 +3,11 @@ description: Debug helper for Apigee Edge Drupal integration.
 package: Apigee
 
 type: module
-core_version_requirement: ^10
+core_version_requirement: ^10.3 || ^11
 
 dependencies:
   - apigee_edge:apigee_edge
 
 configure: apigee_edge_debug.settings
 
-php: "8.1"
+php: "8.3"

--- a/modules/apigee_edge_teams/apigee_edge_teams.info.yml
+++ b/modules/apigee_edge_teams/apigee_edge_teams.info.yml
@@ -3,7 +3,7 @@ description: Provides shared app functionality by allowing developers to be orga
 package: Apigee
 
 type: module
-core_version_requirement: ^10
+core_version_requirement: ^10.3 || ^11
 
 dependencies:
   - apigee_edge:apigee_edge
@@ -12,4 +12,4 @@ dependencies:
 
 configure: apigee_edge_teams.settings.team
 
-php: "8.1"
+php: "8.3"

--- a/modules/apigee_edge_teams/config/optional/views.view.team_invitations.yml
+++ b/modules/apigee_edge_teams/config/optional/views.view.team_invitations.yml
@@ -662,7 +662,6 @@ display:
           default_argument_type: fixed
           default_argument_options:
             argument: ''
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true
@@ -767,7 +766,6 @@ display:
           default_argument_type: user
           default_argument_options:
             user: false
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true

--- a/modules/apigee_edge_teams/src/TeamPermissionHandler.php
+++ b/modules/apigee_edge_teams/src/TeamPermissionHandler.php
@@ -299,7 +299,7 @@ final class TeamPermissionHandler implements TeamPermissionHandlerInterface {
   protected function getModuleNames(): array {
     $modules = [];
     foreach (array_keys($this->moduleHandler->getModuleList()) as $module) {
-      $modules[$module] = $this->moduleHandler->getName($module);
+      $modules[$module] = \Drupal::service('extension.list.module')->getName($module);
     }
     asort($modules);
     return $modules;

--- a/src/Element/ApigeeEntityListElement.php
+++ b/src/Element/ApigeeEntityListElement.php
@@ -22,15 +22,15 @@ namespace Drupal\apigee_edge\Element;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\Render\Element\RenderElement;
+use Drupal\Core\Render\Element\RenderElementBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides an element for listing Apigee entities.
  *
- * @RenderElement("apigee_entity_list")
+ * @RenderElementBase("apigee_entity_list")
  */
-class ApigeeEntityListElement extends RenderElement implements ContainerFactoryPluginInterface {
+class ApigeeEntityListElement extends RenderElementBase implements ContainerFactoryPluginInterface {
 
   /**
    * The entity type manager.

--- a/src/Element/ApigeeSecret.php
+++ b/src/Element/ApigeeSecret.php
@@ -20,14 +20,14 @@
 
 namespace Drupal\apigee_edge\Element;
 
-use Drupal\Core\Render\Element\RenderElement;
+use Drupal\Core\Render\Element\RenderElementBase;
 
 /**
  * Provides a secret element.
  *
- * @RenderElement("apigee_secret")
+ * @RenderElementBase("apigee_secret")
  */
-class ApigeeSecret extends RenderElement {
+class ApigeeSecret extends RenderElementBase {
 
   /**
    * {@inheritdoc}

--- a/src/Element/AppCredentialElement.php
+++ b/src/Element/AppCredentialElement.php
@@ -20,14 +20,14 @@
 
 namespace Drupal\apigee_edge\Element;
 
-use Drupal\Core\Render\Element\RenderElement;
+use Drupal\Core\Render\Element\RenderElementBase;
 
 /**
  * Provides an app credential element.
  *
- * @RenderElement("app_credential")
+ * @RenderElementBase("app_credential")
  */
-class AppCredentialElement extends RenderElement {
+class AppCredentialElement extends RenderElementBase {
 
   /**
    * {@inheritdoc}

--- a/src/Element/AppCredentialProductListElement.php
+++ b/src/Element/AppCredentialProductListElement.php
@@ -20,14 +20,14 @@
 
 namespace Drupal\apigee_edge\Element;
 
-use Drupal\Core\Render\Element\RenderElement;
+use Drupal\Core\Render\Element\RenderElementBase;
 
 /**
  * Provides a product listing element for app credentials.
  *
- * @RenderElement("app_credential_product_list")
+ * @RenderElementBase("app_credential_product_list")
  */
-class AppCredentialProductListElement extends RenderElement {
+class AppCredentialProductListElement extends RenderElementBase {
 
   /**
    * {@inheritdoc}

--- a/src/Element/StatusPropertyElement.php
+++ b/src/Element/StatusPropertyElement.php
@@ -19,14 +19,14 @@
 
 namespace Drupal\apigee_edge\Element;
 
-use Drupal\Core\Render\Element\RenderElement;
+use Drupal\Core\Render\Element\RenderElementBase;
 
 /**
  * Provides a status property element.
  *
- * @RenderElement("status_property")
+ * @RenderElementBase("status_property")
  */
-class StatusPropertyElement extends RenderElement {
+class StatusPropertyElement extends RenderElementBase {
 
   /**
    * Indicator status configuration id: OK.

--- a/src/Entity/FieldableEdgeEntityBase.php
+++ b/src/Entity/FieldableEdgeEntityBase.php
@@ -78,7 +78,7 @@ abstract class FieldableEdgeEntityBase extends EdgeEntityBase implements Fieldab
   /**
    * {@inheritdoc}
    */
-  public function __sleep() {
+  public function __sleep(): array {
     $this->fields = [];
     $this->fieldDefinitions = NULL;
     return parent::__sleep();

--- a/src/Entity/ListBuilder/AppListBuilder.php
+++ b/src/Entity/ListBuilder/AppListBuilder.php
@@ -290,7 +290,7 @@ class AppListBuilder extends EdgeEntityListBuilder {
       $url = Url::fromUserInput($this->requestStack->getCurrentRequest()->getRequestUri(), $link_options);
       $link = Link::fromTextAndUrl($this->t('<span class="ui-icon-triangle-1-e ui-icon"></span><span class="text">Show details</span>'), $url);
       $build['warning-toggle'] = $link->toRenderable();
-      $rows[$info_row_css_id]['data']['status']['data'] = $this->renderer->renderPlain($build);
+      $rows[$info_row_css_id]['data']['status']['data'] = $this->renderer->renderInIsolation($build);
       $row['data']['info'] = [
         'colspan' => count($this->buildHeader()),
       ];

--- a/src/MemoryCacheFactory.php
+++ b/src/MemoryCacheFactory.php
@@ -20,6 +20,7 @@
 
 namespace Drupal\apigee_edge;
 
+use Drupal\Component\Datetime\Time;
 use Drupal\Core\Cache\MemoryCache\MemoryCache;
 use Drupal\Core\Cache\MemoryCache\MemoryCacheInterface;
 
@@ -65,7 +66,7 @@ final class MemoryCacheFactory implements MemoryCacheFactoryInterface {
   public function get($bin): MemoryCacheInterface {
     $bin = "{$this->prefix}_{$bin}";
     if (!isset($this->bins[$bin])) {
-      $this->bins[$bin] = new MemoryCache();
+      $this->bins[$bin] = new MemoryCache(new Time());
     }
     return $this->bins[$bin];
   }

--- a/src/OauthTokenFileStorage.php
+++ b/src/OauthTokenFileStorage.php
@@ -22,7 +22,7 @@ namespace Drupal\apigee_edge;
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\File\Exception\FileException;
-Use Drupal\Core\File\FileExists;
+use Drupal\Core\File\FileExists;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\apigee_edge\Exception\OauthTokenStorageException;

--- a/src/OauthTokenFileStorage.php
+++ b/src/OauthTokenFileStorage.php
@@ -22,6 +22,7 @@ namespace Drupal\apigee_edge;
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\File\Exception\FileException;
+Use Drupal\Core\File\FileExists;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\apigee_edge\Exception\OauthTokenStorageException;
@@ -172,7 +173,7 @@ final class OauthTokenFileStorage implements OauthTokenStorageInterface {
     try {
       $this->checkRequirements();
       // Write the obfuscated token data to a private file.
-      $this->fileSystem->saveData(base64_encode(Json::encode($data)), $this->tokenFilePath, FileSystemInterface::EXISTS_REPLACE);
+      $this->fileSystem->saveData(base64_encode(Json::encode($data)), $this->tokenFilePath, FileExists::Replace);
     }
     catch (FileException $e) {
       $this->logger->critical('Error saving OAuth token file.');

--- a/src/Plugin/KeyProvider/PrivateFileKeyProvider.php
+++ b/src/Plugin/KeyProvider/PrivateFileKeyProvider.php
@@ -20,6 +20,7 @@
 namespace Drupal\apigee_edge\Plugin\KeyProvider;
 
 use Drupal\Core\File\Exception\FileException;
+Use Drupal\Core\File\FileExists;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Utility\Error;
@@ -143,7 +144,7 @@ class PrivateFileKeyProvider extends KeyProviderRequirementsBase implements KeyP
     try {
       // Save the token data.
       return $this->getFileSystem()
-        ->saveData($key_value, $file_uri, FileSystemInterface::EXISTS_REPLACE);
+        ->saveData($key_value, $file_uri, FileExists::Replace);
     }
     catch (FileException $e) {
       return FALSE;

--- a/src/Plugin/KeyProvider/PrivateFileKeyProvider.php
+++ b/src/Plugin/KeyProvider/PrivateFileKeyProvider.php
@@ -20,7 +20,7 @@
 namespace Drupal\apigee_edge\Plugin\KeyProvider;
 
 use Drupal\Core\File\Exception\FileException;
-Use Drupal\Core\File\FileExists;
+use Drupal\Core\File\FileExists;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Utility\Error;

--- a/tests/modules/apigee_edge_test/apigee_edge_test.info.yml
+++ b/tests/modules/apigee_edge_test/apigee_edge_test.info.yml
@@ -1,7 +1,7 @@
 name: 'Apigee Edge Testing'
 type: module
 description: 'Support module for the Apigee Edge tests.'
-core_version_requirement: ^10
+core_version_requirement: ^10.3 || ^11
 package: Testing
 
 dependencies:

--- a/tests/modules/apigee_edge_test_app_keys/apigee_edge_test_app_keys.info.yml
+++ b/tests/modules/apigee_edge_test_app_keys/apigee_edge_test_app_keys.info.yml
@@ -1,7 +1,7 @@
 name: 'Apigee Edge Testing: App keys'
 type: module
 description: 'Support module for the Apigee Edge tests: Mocks app key generation via a 3rd party service.'
-core_version_requirement: ^10
+core_version_requirement: ^10.3 || ^11
 package: Testing
 
 dependencies:

--- a/tests/modules/apigee_mock_api_client/apigee_mock_api_client.info.yml
+++ b/tests/modules/apigee_mock_api_client/apigee_mock_api_client.info.yml
@@ -3,9 +3,9 @@ description: Helpers and an API middleware used for testing.
 package: Apigee
 
 type: module
-core_version_requirement: ^10
+core_version_requirement: ^10.3 || ^11
 
 dependencies:
   - apigee_edge:apigee_edge
 
-php: "8.0"
+php: "8.3"

--- a/tests/src/Kernel/OauthTokenFileStorageTest.php
+++ b/tests/src/Kernel/OauthTokenFileStorageTest.php
@@ -21,7 +21,7 @@ namespace Drupal\Tests\apigee_edge\Kernel;
 
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
-Use Drupal\Core\File\FileExists;
+use Drupal\Core\File\FileExists;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\apigee_edge\Exception\OauthTokenStorageException;

--- a/tests/src/Kernel/OauthTokenFileStorageTest.php
+++ b/tests/src/Kernel/OauthTokenFileStorageTest.php
@@ -21,6 +21,7 @@ namespace Drupal\Tests\apigee_edge\Kernel;
 
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
+Use Drupal\Core\File\FileExists;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\apigee_edge\Exception\OauthTokenStorageException;
@@ -183,7 +184,7 @@ class OauthTokenFileStorageTest extends KernelTestBase {
     $stored_token['access_token'] = mb_strtolower($this->randomMachineName(32));
     \Drupal::service('file_system')->saveData(
       base64_encode(Json::encode($stored_token)),
-      $this->tokenFileUri(), FileSystemInterface::EXISTS_REPLACE);
+      $this->tokenFileUri(), FileExists::Replace);
 
     // Make sure the cached version is still returned.
     $this->assertSame($access_token, $storage->getAccessToken());


### PR DESCRIPTION
Fixes #1080 

Deprecation fixed are as follows

1. getName() is deprecated - https://www.drupal.org/node/3310017
2. class RenderElement is deprecated - https://www.drupal.org/node/3436275
3. renderPlain() is deprecated - https://www.drupal.org/node/3407994
4. class constant EXISTS_REPLACE is deprecated - https://www.drupal.org/node/3426517
5. The Views setting default_argument_skip_url has been removed - https://www.drupal.org/comment/reply/3382316