### PR TITLE
Version bump for PHP 8.3, Apigee PHP Client 4.x & Drupal 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
     "type": "drupal-module",
     "description": "Apigee for Drupal.",
     "require": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+        "php": "~8.3.0",
         "ext-json": "*",
-        "apigee/apigee-client-php": "~3.0.7",
-        "drupal/core": "^10.2",
+        "apigee/apigee-client-php": "4.x-dev",
+        "drupal/core": "^11.1",
         "drupal/entity": "^1.0",
         "drupal/key": "^1.8",
         "php-http/guzzle7-adapter": "^1.0"
@@ -16,7 +16,7 @@
         "apigee/apigee-mock-client-php": "^1.1.2",
         "drupal/drupal-extension": "^4.2.1 || ~5",
         "cweagans/composer-patches": "^1.6",
-        "drupal/core-dev": "^10.2",
+        "drupal/core-dev": "^11.1",
         "drush/drush": "^12.4.3",
         "mglaman/drupal-check": "1.3",
         "phpmd/phpmd": "^2.8.2",


### PR DESCRIPTION
Version bump for PHP 8.3, Apigee PHP Client 4.x & Drupal 11.