### PR TITLE
Version bump of vendors for Drupal 11 installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,21 +7,21 @@
         "php": "~8.3.0",
         "ext-json": "*",
         "apigee/apigee-client-php": "4.x-dev",
-        "drupal/core": "^11.1",
+        "drupal/core": "^11.0",
         "drupal/entity": "^1.0",
         "drupal/key": "^1.8",
         "php-http/guzzle7-adapter": "^1.0"
     },
     "require-dev": {
         "apigee/apigee-mock-client-php": "^1.1.2",
-        "drupal/drupal-extension": "^4.2.1 || ~5",
+        "drupal/drupal-extension": "~5",
         "cweagans/composer-patches": "^1.6",
-        "drupal/core-dev": "^11.1",
-        "drush/drush": "^12.4.3",
-        "mglaman/drupal-check": "1.3",
+        "drupal/core-dev": "^11.0",
+        "drush/drush": "^13.3",
+        "mglaman/drupal-check": "1.5",
         "phpmd/phpmd": "^2.8.2",
         "phpmetrics/phpmetrics": "^2.5",
-        "phpstan/phpstan": "^1.5"
+        "phpstan/phpstan": "^1.12"
     },
     "config": {
         "sort-packages": true
@@ -31,7 +31,7 @@
     "extra": {
         "drush": {
             "services": {
-                "drush.services.yml": "^12"
+                "drush.services.yml": "^13"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "~8.3.0",
         "ext-json": "*",
         "apigee/apigee-client-php": "4.x-dev",
-        "drupal/core": "^11.0",
+        "drupal/core": "^11.1",
         "drupal/entity": "^1.0",
         "drupal/key": "^1.8",
         "php-http/guzzle7-adapter": "^1.0"
@@ -16,7 +16,7 @@
         "apigee/apigee-mock-client-php": "^1.1.2",
         "drupal/drupal-extension": "~5",
         "cweagans/composer-patches": "^1.6",
-        "drupal/core-dev": "^11.0",
+        "drupal/core-dev": "^11.1",
         "drush/drush": "^13.3",
         "mglaman/drupal-check": "1.5",
         "phpmd/phpmd": "^2.8.2",


### PR DESCRIPTION
Fixes #1092
Version bump for Drush to v13.3, drupal-check to v1.5 & phpstan to 1.12
drupal-extension v4 is not required as v5 supports ^10