### PR TITLE
Suppressing the rederPlain() which is deprecated

### DIFF
--- a/src/Entity/ListBuilder/AppListBuilder.php
+++ b/src/Entity/ListBuilder/AppListBuilder.php
@@ -290,7 +290,8 @@ class AppListBuilder extends EdgeEntityListBuilder {
       $url = Url::fromUserInput($this->requestStack->getCurrentRequest()->getRequestUri(), $link_options);
       $link = Link::fromTextAndUrl($this->t('<span class="ui-icon-triangle-1-e ui-icon"></span><span class="text">Show details</span>'), $url);
       $build['warning-toggle'] = $link->toRenderable();
-      $rows[$info_row_css_id]['data']['status']['data'] = $this->renderer->renderPlain($build);
+      // @todo renderPlain() is deprecated for Drupal 10.3 & is removed from drupal:12.0. Use \Drupal\Core\Render\RendererInterface::renderInIsolation() instead. https://www.drupal.org/node/3407994
+      $rows[$info_row_css_id]['data']['status']['data'] = $this->renderer->renderPlain($build); // @phpstan-ignore argument.type
       $row['data']['info'] = [
         'colspan' => count($this->buildHeader()),
       ];


### PR DESCRIPTION
Fixes a part of https://github.com/apigee/apigee-edge-drupal/issues/1080
class RenderElement is deprecated - https://www.drupal.org/node/3436275