### PR TITLE
Suppressing the EXISTS_REPLACE  which is deprecated

### DIFF
--- a/src/OauthTokenFileStorage.php
+++ b/src/OauthTokenFileStorage.php
@@ -172,7 +172,8 @@ final class OauthTokenFileStorage implements OauthTokenStorageInterface {
     try {
       $this->checkRequirements();
       // Write the obfuscated token data to a private file.
-      $this->fileSystem->saveData(base64_encode(Json::encode($data)), $this->tokenFilePath, FileSystemInterface::EXISTS_REPLACE);
+      // @todo class constant EXISTS_REPLACE is deprecated for Drupal 10.3 & is removed from drupal:12.0. Use \Drupal\Core\File\FileExists::Replace instead. https://www.drupal.org/node/3426517
+      $this->fileSystem->saveData(base64_encode(Json::encode($data)), $this->tokenFilePath, FileSystemInterface::EXISTS_REPLACE); // @phpstan-ignore argument.type
     }
     catch (FileException $e) {
       $this->logger->critical('Error saving OAuth token file.');

--- a/src/Plugin/KeyProvider/PrivateFileKeyProvider.php
+++ b/src/Plugin/KeyProvider/PrivateFileKeyProvider.php
@@ -142,8 +142,8 @@ class PrivateFileKeyProvider extends KeyProviderRequirementsBase implements KeyP
 
     try {
       // Save the token data.
-      return $this->getFileSystem()
-        ->saveData($key_value, $file_uri, FileSystemInterface::EXISTS_REPLACE);
+      // @todo class constant EXISTS_REPLACE is deprecated for Drupal 10.3 & is removed from drupal:12.0. Use \Drupal\Core\File\FileExists::Replace instead. https://www.drupal.org/node/3426517
+      return $this->getFileSystem()->saveData($key_value, $file_uri, FileSystemInterface::EXISTS_REPLACE); // @phpstan-ignore argument.type
     }
     catch (FileException $e) {
       return FALSE;

--- a/tests/src/Kernel/OauthTokenFileStorageTest.php
+++ b/tests/src/Kernel/OauthTokenFileStorageTest.php
@@ -183,7 +183,8 @@ class OauthTokenFileStorageTest extends KernelTestBase {
     $stored_token['access_token'] = mb_strtolower($this->randomMachineName(32));
     \Drupal::service('file_system')->saveData(
       base64_encode(Json::encode($stored_token)),
-      $this->tokenFileUri(), FileSystemInterface::EXISTS_REPLACE);
+      // @todo class constant EXISTS_REPLACE is deprecated for Drupal 10.3 & is removed from drupal:12.0. Use \Drupal\Core\File\FileExists::Replace instead. https://www.drupal.org/node/3426517
+      $this->tokenFileUri(), FileSystemInterface::EXISTS_REPLACE); // @phpstan-ignore argument.type
 
     // Make sure the cached version is still returned.
     $this->assertSame($access_token, $storage->getAccessToken());


### PR DESCRIPTION
Fixes a part of #1080 

class constant EXISTS_REPLACE is deprecated - https://www.drupal.org/node/3426517