### PR TITLE
Cache Apigee entity ids in memory during one page load

### DIFF
--- a/src/Entity/Storage/EdgeEntityStorageBase.php
+++ b/src/Entity/Storage/EdgeEntityStorageBase.php
@@ -75,6 +75,11 @@ abstract class EdgeEntityStorageBase extends DrupalEntityStorageBase implements 
   protected $systemTime;
 
   /**
+   * Indicates that all entities should be/have been loaded in this request.
+   */
+  private bool $allEntitiesHaveBeenLoaded = FALSE;
+
+  /**
    * Constructs an EdgeEntityStorageBase instance.
    *
    * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
@@ -468,10 +473,48 @@ abstract class EdgeEntityStorageBase extends DrupalEntityStorageBase implements 
         Cache::invalidateTags([$this->entityTypeId . ':values']);
       }
     }
+    // When resetting cache for ANY of the entities, cache entry for ALL
+    // entities MUST also be cleared to prevent cache poisoning eg. after a
+    // loadMultiple(); save(); loadMultiple(); cycle.
+    $this->memoryCache->delete($this->entityTypeId . '-all-entity-ids');
     // We do not clear the entity controller's cache here because our main goal
     // with the entity controller cache to reduce the API calls that we
     // send to Apigee Edge. Although we do delete the entity controller's cache
     // when it is necessary, like in loadUnchanged().
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadMultiple(?array $ids = NULL) {
+    // Without $ids the caller wants to load ALL entities. To speed things up,
+    // let's assume the storage does not change during a page load; IOW, load
+    // all the entities for the first time and store them in a memory cache.
+    // For all subsequent calls for the same page load, return entities from
+    // that memory cache instead (without making API calls to Apigee).
+    if ($ids === NULL) {
+      $all_known_entity_ids = $this->memoryCache->get($this->entityTypeId . '-all-entity-ids');
+      if ($all_known_entity_ids !== FALSE) {
+        return parent::loadMultiple($all_known_entity_ids->data);
+      }
+      $this->allEntitiesHaveBeenLoaded = TRUE;
+      $return = parent::loadMultiple($ids);
+      $this->allEntitiesHaveBeenLoaded = FALSE;
+      return $return;
+    }
+
+    return parent::loadMultiple($ids);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setStaticCache(array $entities) {
+    if ($this->allEntitiesHaveBeenLoaded) {
+      $ids = array_map(static fn(DrupalEdgeEntityInterface $entity) => $entity->id(), $entities);
+      $this->memoryCache->set($this->entityTypeId . '-all-entity-ids', $ids);
+    }
+    parent::setStaticCache($entities);
   }
 
 }

--- a/tests/src/Kernel/Entity/ListBuilder/AppListBuilderTest.php
+++ b/tests/src/Kernel/Entity/ListBuilder/AppListBuilderTest.php
@@ -327,6 +327,7 @@ class AppListBuilderTest extends ApigeeEdgeKernelTestBase {
           'apps' => [
             $this->approvedAppWithApprovedCredential,
             $this->approvedAppWithOneRevokedCredential,
+            $this->approvedAppWithAllRevokedCredential,
             $this->revokedAppWithRevokedCredential,
             $this->approvedAppWithExpiredCredential,
             $this->revokedAppWithExpiredCredential,


### PR DESCRIPTION
Addresses #1147

I can't say it *solves* that issue, because if there is a change in Apigee during a single page load, then this solution might be misleading. OTOH, I have no idea how to get around that *without* asking Apigee again and again.

So it seems to be a chicken-or-egg problem for me:
- we either want to be theoretically correct in all cases (therefore asking Apigee all the time), or
- we try to avoid timeouts and accept that this solution only works theoretically correctly in those cases when there's no change in Apigee during a single page load.

I, for one, am leaning towards the latter, for better UX.