### PR TITLE
Remove entity save on config form

### DIFF
--- a/src/Form/AuthenticationForm.php
+++ b/src/Form/AuthenticationForm.php
@@ -183,6 +183,8 @@ class AuthenticationForm extends KeyEditForm {
     // @see https://www.drupal.org/project/key/issues/3048562
     $status = parent::save($form, $form_state);
 
+    // Save the authentication key entity id to module's configuration.
+    $this->configFactory->getEditable(static::CONFIG_NAME)->set('active_key', $this->entity->id());
     // Override the redirect destination.
     $form_state->setRedirect('apigee_edge.settings');
 

--- a/src/Form/AuthenticationForm.php
+++ b/src/Form/AuthenticationForm.php
@@ -183,8 +183,6 @@ class AuthenticationForm extends KeyEditForm {
     // @see https://www.drupal.org/project/key/issues/3048562
     $status = parent::save($form, $form_state);
 
-    // Save the authentication key entity id to module's configuration.
-    $this->configFactory->getEditable(static::CONFIG_NAME)->set('active_key', $this->entity->id())->save();
     // Override the redirect destination.
     $form_state->setRedirect('apigee_edge.settings');
 

--- a/tests/src/Kernel/UserAgentTest.php
+++ b/tests/src/Kernel/UserAgentTest.php
@@ -81,7 +81,7 @@ class UserAgentTest extends KernelTestBase {
     \Drupal::moduleHandler()->invokeAll('apigee_edge_user_agent_string_alter', [&$user_agent_parts]);
     $userAgentPrefix = implode('; ', $user_agent_parts);
 
-    $this->assertSame($userAgentPrefix, 'Apigee/3.x-dev;' . ' Drupal/' . \Drupal::VERSION);
+    $this->assertSame($userAgentPrefix, 'Apigee/3.x-dev; Drupal/' . \Drupal::VERSION);
   }
 
 }

--- a/tests/src/Unit/Command/Util/ApigeeEdgeManagementCliServiceTest.php
+++ b/tests/src/Unit/Command/Util/ApigeeEdgeManagementCliServiceTest.php
@@ -472,7 +472,7 @@ class ApigeeEdgeManagementCliServiceTest extends UnitTestCase {
     // User should see error message.
     $io = $this->prophet->prophesize(StyleInterface::class);
     $io->error(Argument::containingString('Error connecting to Apigee Edge'))->shouldBeCalledTimes(1);
-    $io->note(Argument::containingString('the url ' . $this->baseUrl . '/test' . ' does not seem to be a valid Apigee Edge endpoint.'))->shouldBeCalledTimes(1);
+    $io->note(Argument::containingString('the url ' . $this->baseUrl . '/test does not seem to be a valid Apigee Edge endpoint.'))->shouldBeCalledTimes(1);
 
     $apigee_edge_management_cli_service = new ApigeeEdgeManagementCliService($this->httpClient->reveal());
     $apigee_edge_management_cli_service->handleHttpClientExceptions($exception, $io->reveal(), [$this, 'mockDt'], $this->baseUrl . '/test', $this->org, $this->email);


### PR DESCRIPTION
Fixes https://github.com/apigee/apigee-devportal-kickstart-drupal/issues/733 issue.

Saving entity on Config form creates synthetic service call, which throws issue on Drupal 11 Devportal installation.

Storing key values & other required is done by Keys module save & submit() function.

Thanks!