### PR TITLE
Fixed the issue of Deprecated Function Error in Apigee Edge by adding AllowDynamicProperties attribute.

### DIFF
--- a/src/Entity/DeveloperApp.php
+++ b/src/Entity/DeveloperApp.php
@@ -91,6 +91,7 @@ use Drupal\user\UserInterface;
  *   field_ui_base_route = "apigee_edge.settings.developer_app",
  * )
  */
+#[\AllowDynamicProperties]
 class DeveloperApp extends App implements DeveloperAppInterface {
 
   /**


### PR DESCRIPTION
Fixes #1196 