### PR TITLE
Delete lock file to get the latest dependencies for github action - 4.x

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -80,6 +80,13 @@ jobs:
       with:
         path: drupal/modules/contrib/apigee_edge
 
+    - name: Delete lock file
+      # Deleting the composer.lock file forces Composer to re-evaluate all dependencies
+      # and ensure the latest, secure versions are resolved during the 'composer update' step.
+      run: |
+        echo "Removing composer.lock to force update latest dependencies."
+        rm -f drupal/composer.lock
+
     - name: "Allow plugins and dev dependencies"
       run: |
         cd drupal


### PR DESCRIPTION
Delete lock file to get the latest dependencies for github action