### PR TITLE
Remove Drupal 10.4.x from workflow and bump to 10.5.x

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -37,7 +37,6 @@ jobs:
           - "8.3"
         drupal-core:
           # Should update the following as the minimum supported version from Drupal.org
-          - "10.4.x"
           - "10.5.x"
         instance-type:
           - "Edge"
@@ -145,13 +144,13 @@ jobs:
         sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 & # optional
 
     - name: "Run PHPUnit tests"
-      if: ${{ matrix.drupal-core != '10.4.x' || matrix.php-version != '8.3' }}
+      if: ${{ matrix.php-version != '8.3' }}
       run: |
         cd drupal
         vendor/bin/phpunit -c core --verbose --color --group apigee_edge --testsuite unit,kernel,functional,functional-javascript modules/contrib/apigee_edge
 
     - name: "Run PHPUnit tests with Code Coverage"
-      if: ${{ matrix.drupal-core == '10.4.x' && matrix.php-version == '8.3' }}
+      if: ${{ matrix.drupal-core == '10.5.x' && matrix.php-version == '8.3' }}
       run: |
         cd drupal
         cp modules/contrib/apigee_edge/phpunit.core.xml.dist core/phpunit.xml
@@ -165,7 +164,7 @@ jobs:
         path: drupal/sites/simpletest/browser_output/*
 
     - name: Upload coverage to Codecov
-      if: ${{ matrix.drupal-core == '10.4.x' && matrix.php-version == '8.3' }}
+      if: ${{ matrix.drupal-core == '10.5.x' && matrix.php-version == '8.3' }}
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Removed version 10.4.x from the build matrix as it is no longer required. Updated the conditional checks for Code Coverage and Codecov uploads to target Drupal 10.5.x (PHP 8.3) to ensure coverage reporting continues.