### PR TITLE
Fix dead code in apigee_edge_user_presave Function

### DIFF
--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -1405,8 +1405,7 @@ function apigee_edge_user_presave(UserInterface $account) {
           // that already belongs to a developer on Apigee Edge then override
           // its stored developer data there with the new one.
           if (isset($account->{APIGEE_EDGE_USER_REGISTRATION_SOURCE}) && $account->{APIGEE_EDGE_USER_REGISTRATION_SOURCE} === 'user_register_form') {
-            $developer = $user_developer->convertUser($account);
-            $developer->setDeveloperId($developer_id);
+            $developer = $user_developer->convertUser($account)->getDeveloper();
             $developer->enforceIsNew(FALSE);
             try {
               $developer->save();

--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -1400,7 +1400,6 @@ function apigee_edge_user_presave(UserInterface $account) {
         $logger->info($previous->getMessage());
         $developer = Developer::load($account->getEmail());
         if ($developer) {
-          $developer_id = $developer->getDeveloperId();
           // If a user could register on the portal with an email address
           // that already belongs to a developer on Apigee Edge then override
           // its stored developer data there with the new one.


### PR DESCRIPTION
The 'user presave' logic for syncing existing Apigee developers contained dead code that would throw a fatal error if executed. Methods were being called on the conversion Result object instead of the Developer entity. Fixed by calling the developer entity.