### PR TITLE
Fixed the "Remove" button logic in list_text field type | 4.x

### DIFF
--- a/apigee_edge.module
+++ b/apigee_edge.module
@@ -850,6 +850,81 @@ function apigee_edge_form_user_register_form_alter(&$form, FormStateInterface $f
 }
 
 /**
+ * Implements hook_form_FORM_ID_alter() for 'field_config_edit_form'.
+ */
+function apigee_edge_form_field_config_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+
+  $table = &$form['field_storage']['subform']['settings']['allowed_values']['table'] ?? null;
+
+  if (!$table) {
+    return;
+  }
+
+  $form_object = $form_state->getFormObject();
+
+  /** @var \Drupal\field\Entity\FieldConfig $field_config */
+  $field_config = $form_object->getEntity();
+  $target_entity_type = $field_config->getTargetEntityTypeId();
+  $field_name = $field_config->getName();
+
+  $used_values = _apigee_edge_get_used_values($target_entity_type, $field_name);
+
+  if (!empty($used_values)) {
+      _apigee_edge_disable_allowed_values($table, $used_values);
+  }
+}
+
+/**
+ * Helper function to calculate used allowed values.
+ */
+function _apigee_edge_get_used_values($target_entity_type, $field_name) {
+  $used_values = [];
+  
+  try {
+    $storage = \Drupal::entityTypeManager()->getStorage($target_entity_type);
+
+    $entities = $storage->loadMultiple();
+
+    foreach ($entities as $entity) {
+      /** @var \Drupal\apigee_edge\Entity\FieldableEdgeEntityInterface $entity */
+      if ($entity->hasField($field_name) && !$entity->get($field_name)->isEmpty()) {
+        $value = $entity->get($field_name)->value;
+        $used_values[$value] = TRUE;
+      }
+    }
+  }
+  catch (\Exception $e) {
+    return [];
+  }
+
+  return $used_values;
+}
+
+/**
+ * Helper function to disable buttons in the allowed values table.
+ */
+function _apigee_edge_disable_allowed_values(array &$table, array $used_values) {
+  foreach (Element::children($table) as $delta) {
+    $row = &$table[$delta];
+    $row_value = $row['item']['key']['#default_value'] ?? NULL;
+
+    if ($row_value && isset($used_values[$row_value])) {
+      // Disable Input Machine Name
+      $row['item']['key']['#attributes']['disabled'] = 'disabled';
+
+      // Disable Remove Button
+      $row['delete']['#attributes']['disabled'] = 'disabled';
+      $row['delete'] += [
+            'message' => [
+              '#type' => 'item',
+              '#markup' => t('Cannot be removed: option in use.'),
+            ],
+      ];
+    }
+  }
+}
+
+/**
  * After build function for user_registration_form.
  *
  * @param array $form


### PR DESCRIPTION
Fixes #1147  | 4.x

Fixed the "Remove" button logic in list_text field type: previously, the remove button remained active even if values were in uses in apigee entity. It is now correctly disabled (mimicking Core behavior) when the field value is present on an Apigee entity.