### PR TITLE
Eliminate repated sync of team memberships with no reason

### DIFF
--- a/modules/apigee_edge_teams/apigee_edge_teams.services.yml
+++ b/modules/apigee_edge_teams/apigee_edge_teams.services.yml
@@ -161,3 +161,8 @@ services:
   apigee_edge_teams.app_group_scope_manager:
     class: Drupal\apigee_edge_teams\Service\AppGroupScopeManager
     arguments: ['@apigee_edge.sdk_connector', '@apigee_edge.controller.organization']
+
+  apigee_edge_teams.team_sync.last_update_tracker:
+    class: Drupal\Core\KeyValueStore\KeyValueStoreInterface
+    factory: [ '@keyvalue', 'get' ]
+    arguments: [ 'apigee_edge_teams.team_sync.last_update_tracker' ]

--- a/modules/apigee_edge_teams/src/CliService.php
+++ b/modules/apigee_edge_teams/src/CliService.php
@@ -63,7 +63,9 @@ class CliService implements CliServiceInterface {
         if (isset($context['message']) && $context['message'] !== $last_message) {
           $io->text($t($context['message']));
         }
-        $last_message = $context['message'];
+        // Fallback to an empty string if the batch operation didn't set a new
+        // message.
+        $last_message = $context['message'] ?? '';
 
         gc_collect_cycles();
       }

--- a/modules/apigee_edge_teams/src/Job/TeamMemberCreateUpdate.php
+++ b/modules/apigee_edge_teams/src/Job/TeamMemberCreateUpdate.php
@@ -58,6 +58,10 @@ abstract class TeamMemberCreateUpdate extends EdgeJob {
     else {
       $team_members = $member_controller->getMembers($this->team_ids);
     }
+
+    // Record the sync attempt timestamp for the team, regardless of whether
+    // an entity update occurred, to prevent redundant sync operations.
+    \Drupal::service('apigee_edge_teams.team_sync.last_update_tracker')->set($this->team_ids, \Drupal::time()->getCurrentTime());
   }
 
 }

--- a/modules/apigee_edge_teams/src/Job/TeamMemberSync.php
+++ b/modules/apigee_edge_teams/src/Job/TeamMemberSync.php
@@ -58,12 +58,23 @@ class TeamMemberSync extends EdgeJob {
   public function execute(): bool {
     parent::execute();
 
-    $team_ids = array_keys(\Drupal::entityTypeManager()->getStorage('team')->loadMultiple());
+    /** @var \Drupal\apigee_edge_teams\Entity\TeamInterface[] $teams */
+    $teams = \Drupal::entityTypeManager()->getStorage('team')->loadMultiple();
+    $lastUpdateTracker = \Drupal::service('apigee_edge_teams.team_sync.last_update_tracker');
 
-    foreach ($team_ids as $team_name) {
-      $update_team_member_job = new TeamMemberUpdate($team_name);
-      $update_team_member_job->setTag($this->getTag());
-      $this->scheduleJob($update_team_member_job);
+    foreach ($teams as $team_name => $team) {
+      $last_synced = $lastUpdateTracker->get($team_name, 0);
+
+      // Get the last modified timestamp from Apigee.
+      $last_modified = $team->getLastModifiedAt() ? $team->getLastModifiedAt()->getTimestamp() : 0;
+
+      // Only schedule a sync if we have never synced this team BEFORE, OR if
+      // the team has been modified in Apigee AFTER our last sync.
+      if ($last_synced === 0 || $last_synced < $last_modified) {
+        $update_team_member_job = new TeamMemberUpdate($team_name);
+        $update_team_member_job->setTag($this->getTag());
+        $this->scheduleJob($update_team_member_job);
+      }
     }
 
     return FALSE;


### PR DESCRIPTION
Resolves #1160 

### Description
Currently, running `drush apigee-edge:teams-sync` schedules a `TeamMemberUpdate` job for every single team, regardless of whether their memberships have actually changed in Apigee. This results in unnecessary API calls and long sync times.

This PR introduces a memory mechanism (similar to the one implemented in #1153 for developers) to skip redundant syncs.

### What changed:
* **Added a Last Update Tracker:** Created the `apigee_edge_teams.team_sync.last_update_tracker` key-value service to store the timestamp of the last successful sync attempt per team.
* **Smart Scheduling:** Updated `TeamMemberSync.php` to compare the `last_synced` timestamp against the Team's `getLastModifiedAt()` timestamp from Apigee. The update job is now only scheduled if the Apigee entity is newer than our last sync.
* **Timestamp Recording:** `TeamMemberCreateUpdate.php` now records the current time into the tracker upon job execution.
* **CLI Warning Fix:** Handled a minor UI side-effect in `CliService.php`. When the sync skips all teams (queue is empty), `$context['message']` is not set. Added a null coalescing fallback to prevent an "Undefined array key" warning. Not sure if this was the right way to handle the CLI warning message.

### Testing Instructions
1. Run `drush apigee-edge:teams-sync`. The first run will process all teams and populate the tracker.
2. Run `drush apigee-edge:teams-sync` immediately again. The batch process should finish almost instantly without scheduling team updates.
3. Modify a team/AppGroup in Apigee.
4. Run `drush apigee-edge:teams-sync` again. It should only queue and process the team that was just modified.