### PR TITLE
Fix TeamAppAccessHandler::checkCreateAccess() to respect $context array

### DIFF
--- a/modules/apigee_edge_teams/src/Entity/TeamAppAccessHandler.php
+++ b/modules/apigee_edge_teams/src/Entity/TeamAppAccessHandler.php
@@ -142,8 +142,13 @@ final class TeamAppAccessHandler extends EntityAccessControlHandler implements E
       $result = $this->checkAccessByPermissions($account);
 
       if ($result->isNeutral()) {
-        // Applies to "add-form-for-team" link template of Team App entity.
-        $team = $this->routeMatch->getParameter('team');
+        $team = $context['team'] ?? $this->routeMatch->getParameter('team');
+        // If the route parameter or context is just a string ID, upcast it to
+        // an entity.
+        if (is_string($team)) {
+          $team = $this->entityTypeManager->getStorage('team')->load($team);
+        }
+
         if ($team) {
           $result = $this->checkAccessByTeamMemberPermissions($team, 'create', $account);
         }


### PR DESCRIPTION
When checking Team App creation access programmatically via the entity access control handler (e.g., `$access_handler->createAccess('team_app', $user, ['team' => $team])`), the check was incorrectly returning neutral/false. This occurred because `checkCreateAccess()` ignored the provided `$context` array and strictly relied on the current URL route containing a `{team}` parameter.

This breaks access checks for headless architectures, custom REST/JSON:API endpoints, and any custom module that does not use standard Drupal UI routes.

This commit updates `TeamAppAccessHandler::checkCreateAccess()` to first attempt extracting the team from `$context['team']`, and only falls back to the route match parameter if the context is empty. It also includes logic to upcast string IDs to Team entities when passed via context.