### PR TITLE
Fix config schema error in the apigee_edge_teams submodule

### DIFF
--- a/modules/apigee_edge_teams/config/schema/apigee_edge_teams.schema.yml
+++ b/modules/apigee_edge_teams/config/schema/apigee_edge_teams.schema.yml
@@ -34,6 +34,9 @@ apigee_edge_teams.team_settings:
     team_invitation_email_new:
       type: 'mail'
       label: 'Team invitation email for new users'
+    team_invitation_auto_approve:
+      type: boolean
+      label: 'Automatically approve team invitations'
 
 apigee_edge_teams.team_app_settings:
   type: config_object


### PR DESCRIPTION
Fix #1273 
Added the missing property to the module's schema definition.
Original PR https://github.com/apigee/apigee-edge-drupal/pull/701