### PR TITLE
Issue #1275: Fix Team App Analytics for Apigee X / Hybrid (AppGroups)

### DIFF
--- a/modules/apigee_edge_teams/src/Form/TeamAppAnalyticsForm.php
+++ b/modules/apigee_edge_teams/src/Form/TeamAppAnalyticsForm.php
@@ -21,12 +21,57 @@
 namespace Drupal\apigee_edge_teams\Form;
 
 use Drupal\apigee_edge\Entity\AppInterface;
+use Drupal\apigee_edge\Entity\Controller\OrganizationControllerInterface;
 use Drupal\apigee_edge\Form\AppAnalyticsFormBase;
+use Drupal\apigee_edge\SDKConnectorInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Routing\UrlGeneratorInterface;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Displays the analytics page of a team app on the UI.
  */
 class TeamAppAnalyticsForm extends AppAnalyticsFormBase {
+
+  /**
+   * The organization controller.
+   *
+   * @var \Drupal\apigee_edge\Entity\Controller\OrganizationControllerInterface
+   */
+  protected $organizationController;
+
+  /**
+   * Constructs a new TeamAppAnalyticsForm.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\apigee_edge\SDKConnectorInterface $sdk_connector
+   *   The SDK connector service.
+   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $tempstore_private
+   *   The private temp store factory.
+   * @param \Drupal\Core\Routing\UrlGeneratorInterface $url_generator
+   *   The URL generator.
+   * @param \Drupal\apigee_edge\Entity\Controller\OrganizationControllerInterface $organization_controller
+   *   The organization controller.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, SDKConnectorInterface $sdk_connector, PrivateTempStoreFactory $tempstore_private, UrlGeneratorInterface $url_generator, OrganizationControllerInterface $organization_controller) {
+    parent::__construct($entity_type_manager, $sdk_connector, $tempstore_private, $url_generator);
+    $this->organizationController = $organization_controller;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('apigee_edge.sdk_connector'),
+      $container->get('tempstore.private'),
+      $container->get('url_generator'),
+      $container->get('apigee_edge.controller.organization')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -40,6 +85,26 @@ class TeamAppAnalyticsForm extends AppAnalyticsFormBase {
    */
   protected function getAnalyticsFilterCriteriaByAppOwner(AppInterface $app): string {
     return "developer eq '{$this->connector->getOrganization()}@@@{$app->getAppOwner()}'";
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getAnalyticsDimensions(): array {
+    if ($this->organizationController->isOrganizationApigeeX()) {
+      return ['app_group_app'];
+    }
+    return parent::getAnalyticsDimensions();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getAnalyticsFilter(AppInterface $app): string {
+    if ($this->organizationController->isOrganizationApigeeX()) {
+      return "(app_group_name eq '{$app->getAppOwner()}' and app_group_app eq '{$app->getName()}')";
+    }
+    return parent::getAnalyticsFilter($app);
   }
 
 }

--- a/src/Form/AppAnalyticsFormBase.php
+++ b/src/Form/AppAnalyticsFormBase.php
@@ -504,9 +504,32 @@ abstract class AppAnalyticsFormBase extends FormBase {
     $stats_controller = new StatsController($environment, $this->connector->getOrganization(), $this->connector->getClient());
     $stats_query = new StatsQuery([$metric], Period::fromDate(new \DateTimeImmutable('@' . $since), new \DateTimeImmutable('@' . $until)));
     $stats_query
-      ->setFilter("({$this->getAnalyticsFilterCriteriaByAppOwner($app)} and developer_app eq '{$app->getName()}')")
+      ->setFilter($this->getAnalyticsFilter($app))
       ->setTimeUnit('hour');
-    return $stats_controller->getOptimizedMetricsByDimensions(['apps'], $stats_query);
+    return $stats_controller->getOptimizedMetricsByDimensions($this->getAnalyticsDimensions(), $stats_query);
+  }
+
+  /**
+   * Returns the analytics dimensions.
+   *
+   * @return array
+   *   The dimensions array.
+   */
+  protected function getAnalyticsDimensions(): array {
+    return ['apps'];
+  }
+
+  /**
+   * Returns the analytics filter.
+   *
+   * @param \Drupal\apigee_edge\Entity\AppInterface $app
+   *   The app entity.
+   *
+   * @return string
+   *   The analytics filter.
+   */
+  protected function getAnalyticsFilter(AppInterface $app): string {
+    return "({$this->getAnalyticsFilterCriteriaByAppOwner($app)} and developer_app eq '{$app->getName()}')";
   }
 
   /**


### PR DESCRIPTION
Fixes: #1275 

### Description of Changes
This Merge Request resolves the issue where analytics data fails to load for Team Apps on Apigee X / Hybrid instances due to incorrect dimensions and API endpoints. Apigee X uses AppGroups for teams, which require querying `/optimizedStats/app_group_app` instead of `/optimizedStats/apps`.

### Technical Details:
`AppAnalyticsFormBase.php`:
- Extracted the hardcoded analytics dimensions and filter string into `getAnalyticsDimensions()` and `getAnalyticsFilter()` to allow for child class overrides.

`TeamAppAnalyticsForm.php`:
- Added Dependency Injection for the `apigee_edge.controller.organization` service (OrganizationControllerInterface).
- Overrode `getAnalyticsDimensions()` and `getAnalyticsFilter()` to dynamically apply the correct AppGroup dimensions (`['app_group_app']`) and filter (`app_group_name eq '[app_group_name]' and app_group_app eq '[app_name]'`) when `isOrganizationApigeeX()` evaluates to `true`.
- Preserved backward compatibility for Apigee Edge by falling back to `parent::getAnalyticsDimensions()` and `parent::getAnalyticsFilter()` if the organization is not Apigee X.

Testing Instructions:
- Configure the module with an Apigee X/Hybrid organization.
- Create a Team and a Team App, then generate some traffic.
- Navigate to the Analytics tab for the Team App and verify that data is correctly displayed.
- Repeat the process on a legacy Apigee Edge organization to ensure backward compatibility is maintained.