### PR TITLE
Update guzzlehttp/guzzle version to ^7.15.1

### DIFF
--- a/modules/apigee_edge_debug/composer.json
+++ b/modules/apigee_edge_debug/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "~8.1",
         "drupal/apigee_edge": "*",
-        "guzzlehttp/guzzle": "^6.1.0"
+        "guzzlehttp/guzzle": "^7.15.1"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
Fix 
https://github.com/apigee/apigee-edge-drupal/security/dependabot/11
https://github.com/apigee/apigee-edge-drupal/security/dependabot/9
https://github.com/apigee/apigee-edge-drupal/security/dependabot/5
https://github.com/apigee/apigee-edge-drupal/security/dependabot/6
https://github.com/apigee/apigee-edge-drupal/security/dependabot/10
https://github.com/apigee/apigee-edge-drupal/security/dependabot/7
https://github.com/apigee/apigee-edge-drupal/security/dependabot/8
